### PR TITLE
feat(report): file a GitHub bug report from inside the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,17 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   `Partial` on purpose), and the text is `pre-wrap` so git's multi-line advice
   survives. `test/appErrors.test.ts` + `error-banner.test.tsx` fail the build
   for a new surface that spells the enum. (`docs/dev/frontend.md`)
+- **One issue reporter — `features/report/`.** `report.ts` stays PURE and
+  `fileReport.ts` owns the side effects, because `PGErrorBoundary` mounts ABOVE
+  `PGDialogHost` and therefore CANNOT open the dialog — it takes an `onReport`
+  callback wired in `main.tsx`, and `PGErrorBanner` takes one for the same
+  reason (`src/design/` imports no `@/lib/tauri`). The log travels by
+  CLIPBOARD, never in the URL (`issues/new?body=` 414s far below
+  `TAIL_CAP_BYTES`, so `issueUrl` caps at `MAX_URL_LEN` by trimming the
+  summary), copy happens strictly BEFORE open, and the preview shows the exact
+  string that will be copied — the opt-out checkboxes filter the clipboard, not
+  just the display. Nothing is ever sent: the app writes the clipboard and
+  hands a URL to the user's browser. (`docs/dev/frontend.md`)
 - **Never `Command::new` outside `src-tauri/src/proc.rs`** — a guard test
   fails the build. Use the `proc::git*`/`proc::program*` constructors.
   (`docs/dev/backend.md`)

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -688,6 +688,21 @@ features/            Components + Zustand store colocated per feature:
 │                    docs/dev/distribution.md), semver.ts (§11 precedence,
 │                    tested), UpdateChip, UpdatePanel (Escape via
 │                    app.closeOverlay)
+├── report/          In-app bug reporting. report.ts is PURE (buildReport +
+│                    issueUrl, bounded by MAX_URL_LEN — a GitHub
+│                    issues/new?body= URL answers 414 well below the size of a
+│                    log tail, so the URL carries only the small facts plus a
+│                    paste marker and the report itself travels on the
+│                    CLIPBOARD); fileReport.ts owns every side effect
+│                    (gatherReport → copyReport → openUrl, copy strictly
+│                    BEFORE open, plus fileBugReport for a caller with no UI);
+│                    ReportIssueDialog (mounted ONCE by AppShell, so the
+│                    titlebar button, the error banner and the Settings row
+│                    all share it); useReportStore. PGErrorBoundary cannot use
+│                    the dialog — it mounts ABOVE PGDialogHost — so it takes an
+│                    onReport callback that main.tsx wires to fileBugReport.
+│                    Reads diagnostics_report + read_log_tail; makes no network
+│                    call of any kind
 ├── auth/            useAuthStore (ONE pending challenge + retry closure — never
 │                    the secret) + CredentialDialog. withAuthRetry LIVES IN
 │                    useRepoStore.ts, exported — never grow a second retry path.

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -2043,6 +2043,16 @@ every side effect, which is what makes the boundary's path possible at all. One
 report format: Settings' *Copy last 500 lines* button assembles its text with
 the same `buildReport`, so the two surfaces cannot drift.
 
+**Escape lives in the default runner, not in the component.** The dialog joins
+`app.closeOverlay`'s ordered chain in `features/keymap/actions.ts`, beside the
+other `PGModal` base-layer dialogs — *not* via a `useAction` registration.
+`useKeymapStore`'s dispatch tries registered handlers **before** the default
+runner, so a component registration would take Escape ahead of the credential
+prompt stacked above it and close the report dialog out from under a prompt
+some other op is still waiting on. That is the precise failure the runner's
+auth branch is ordered to prevent, so a new overlay belongs in the chain at its
+stacking position. `actions.test.ts` pins the ordering with both dialogs open.
+
 **A test note.** These specs use `fireEvent`, not `userEvent`.
 `userEvent.setup()` **replaces `navigator.clipboard`** with its own stub in
 order to implement copy/paste, which detaches any `writeText` spy installed

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1962,6 +1962,93 @@ commit` typed into the pane moves the graph already. A user who turned the
 watcher off gets no automatic refresh from the terminal either — documented,
 not worked around: a second mechanism for the same job would also fire on `ls`.
 
+## Reporting an issue from inside the app
+
+`features/report/` turns "something is broken" into a diagnosable GitHub issue.
+The log was already reachable (#274 put its path, and a *Copy last 500 lines*
+button, in Settings); what was missing was everything around it — knowing that
+Settings held the log at all, knowing the project is on GitHub, and filling in
+an Environment section by hand from facts the app had already printed.
+
+**Four entry points, one dialog.**
+
+| Where | Seeded with |
+|---|---|
+| the titlebar's `bug` button (`AppShell`'s `AppTitlebar`) | nothing |
+| `PGErrorBanner`'s `report` action | `errorBannerText(error)` |
+| Settings → Backup & diagnostics → *Report an issue* | nothing |
+| `PGErrorBoundary`'s *Report this bug* | the throw's `message` |
+
+`<ReportIssueDialog />` is mounted **once**, by `AppShell`, beside
+`PGDialogHost`. Settings is a screen below that point, so one mount serves the
+first three; a second mount anywhere is a second dialog that can open over the
+first.
+
+**The log travels by clipboard, never in the URL.** A GitHub
+`issues/new?body=…` URL answers **HTTP 414** somewhere around 8 KB, and
+`read_log_tail` returns up to `TAIL_CAP_BYTES`. So the split is by size:
+
+- *in the URL* — title, `labels=bug`, the body skeleton mirroring
+  `.github/ISSUE_TEMPLATE/bug_report.md`, and Environment prefilled with
+  version / os / arch / git version. `issueUrl` enforces `MAX_URL_LEN` (6000)
+  by trimming the **summary**, the only unbounded part, so no amount of pasted
+  prose can produce a 414.
+- *on the clipboard* — the whole report, log tail included, with a
+  `<!-- Paste … -->` marker in the body saying so.
+
+`copyAndOpenIssue` therefore copies **strictly before** it opens: a failed copy
+does not open the browser, because sending someone to a form that says "paste
+your report" with an empty clipboard is worse than saying nothing.
+
+Passing `body` and **not** `template=` is deliberate — given both, the two
+contend for the same field and which wins is GitHub's business. The body is
+written in `report.ts` instead, mirroring the template's headings.
+
+**Privacy.** No network call exists here: the app writes the clipboard and
+hands a URL to `openUrl`. The report is nonetheless the most revealing text the
+app assembles in one place — a log tail carries repository paths, branch names,
+remote URLs and hook output — so two rules hold, and they are why this is a
+dialog rather than a one-click button:
+
+- the preview renders the **exact string** that will be copied, in full, not a
+  summary of it;
+- environment and log tail are independently opt-out, and the checkbox filters
+  the **clipboard**, not just the display (there is a test for precisely that —
+  an opt-out that only filtered the preview would be worse than none, because
+  the user would believe they had removed the paths).
+
+The version line survives every opt-out: a report whose build is unknown cannot
+be acted on. An excluded section is *absent*, never present-and-empty — a
+`── log tail ──` rule with nothing under it reads like an empty log rather than
+an unread one, which is also what a failed `read_log_tail` must not look like.
+
+**The error boundary is the exception, and it is load-bearing.**
+`PGDialogHost` and `ReportIssueDialog` are both mounted by `AppShell`, which is
+mounted inside `PGErrorBoundary` (`main.tsx`). After a render throw React has
+unmounted that whole subtree, so from the boundary there is no dialog host, no
+dialog, and nothing subscribed to `useReportStore` — `openReport()` would set a
+flag nobody reads and the button would silently do nothing.
+
+So the boundary takes an `onReport?: (error: Error) => void`, on the same terms
+as the `onReload` it already had, and `main.tsx` wires it to `fileBugReport`,
+which gathers, copies and opens with no React tree involved. The callback also
+keeps IPC out of `src/design/`: nothing there imports `@/lib/tauri`, and the
+same reasoning is why `PGErrorBanner` takes `onReport` instead of reaching for
+the store itself. `error-boundary.test.tsx` renders the boundary with **no**
+host mounted at all — that absence is the boundary's real world, not a
+simplification of it.
+
+`report.ts` is pure (no React, no IPC, no clipboard) and `fileReport.ts` owns
+every side effect, which is what makes the boundary's path possible at all. One
+report format: Settings' *Copy last 500 lines* button assembles its text with
+the same `buildReport`, so the two surfaces cannot drift.
+
+**A test note.** These specs use `fireEvent`, not `userEvent`.
+`userEvent.setup()` **replaces `navigator.clipboard`** with its own stub in
+order to implement copy/paste, which detaches any `writeText` spy installed
+before it — every clipboard assertion then passes against userEvent's internal
+clipboard while asserting nothing about the app.
+
 ## Dialogs
 
 - **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt` from

--- a/docs/superpowers/plans/2026-09-07-issue-report.md
+++ b/docs/superpowers/plans/2026-09-07-issue-report.md
@@ -1,0 +1,1812 @@
+# In-app issue reporter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user file a diagnosable GitHub bug report from inside the app — the report assembled for them, shown in full, copied to the clipboard, with a prefilled issue open in their browser.
+
+**Architecture:** A new `src/features/report/` directory splits pure text assembly (`report.ts`) from side effects (`fileReport.ts`) from surface (`ReportIssueDialog.tsx` + `useReportStore.ts`). The log travels by clipboard because a GitHub `issues/new?body=` URL 414s far below the size of a log tail. Four entry points; three drive one dialog mounted in `AppShell`, and the error boundary — which sits *above* the dialog host and so cannot use it — calls `fileBugReport` through a new optional prop.
+
+**Tech Stack:** React 19 + TypeScript, Zustand, vitest (`unit` jsdom project + `docs` node project), the existing `commands/diagnostics.rs` Tauri commands. No new backend code, no new dependency.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-issue-report-spec.md`
+
+## Global Constraints
+
+- **Toolchain.** Node 22 + pnpm at `~/Library/pnpm`, Rust at `~/.cargo/bin`. This session is worktree-isolated, so `export PATH=…` is refused — invoke `~/Library/pnpm/pnpm` by absolute path.
+- **No new backend work.** `diagnostics_report`, `read_log_tail` and `open_url` already exist and are already wrapped in `src/lib/tauri.ts`. Do not add a Tauri command.
+- **Repository slug is `jonassaa/platypusgit`.** Issues URL base: `https://github.com/jonassaa/platypusgit/issues/new`.
+- **`MAX_URL_LEN = 6000`.** The finished URL must never exceed it (GitHub answers a long query string with HTTP 414).
+- **Icons:** `src/design/icons.tsx` is the ONLY file that may import `lucide-react`, and every call-site string literal must be a declared `IconName` member (`test/iconSet.test.ts` fails the build for either).
+- **No native `<select>`/`<option>`**, no `window.confirm`/`window.prompt`, no `Command::new` outside `proc.rs`. Guard tests enforce all three.
+- **No hardcoded accent hue** — CSS vars / theme tokens only (`var(--fg-2)`, `var(--bg-1)`, …).
+- **Escape** is the keymap's job: `useAction("app.closeOverlay", …)`, never a local capture-phase listener.
+- **`src/design/` performs no IPC.** No file under `src/design/` may import `@/lib/tauri`. Check before committing: `grep -rn 'lib/tauri' src/design/` must stay empty.
+- **Errors** surface via `pgFlash(appErrorMessage(e))`, matching the diagnostics buttons this feature sits beside.
+- **Commit style:** `feat(report): …` / `test: …` / `docs: …`, imperative subject under 72 chars, optional `**Why:**` body, trailing `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+- **Test commands:** `~/Library/pnpm/pnpm test` (whole suite), `~/Library/pnpm/pnpm vitest run <path>` (one file), `~/Library/pnpm/pnpm tsc --noEmit` (typecheck).
+
+---
+
+### Task 1: The pure report module
+
+**Files:**
+- Create: `src/features/report/report.ts`
+- Test: `src/features/report/report.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface ReportParts { version: string; environment: string; logPath: string; logTail: string | null; includeEnvironment: boolean; includeLog: boolean }`
+  - `function buildReport(parts: ReportParts): string`
+  - `function issueUrl(opts: { summary: string; version: string; environment: string }): string`
+  - `const MAX_URL_LEN = 6000`
+  - `const PASTE_MARKER: string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/report/report.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReport,
+  issueUrl,
+  MAX_URL_LEN,
+  PASTE_MARKER,
+  type ReportParts,
+} from "./report";
+
+const PARTS: ReportParts = {
+  version: "0.8.0",
+  environment: "host os=macos arch=aarch64 git=2.49.0",
+  logPath: "/Users/x/Library/Logs/com.platypusgit.app/platypusgit.log",
+  logTail: "11:02 INFO open_repo /tmp/r\n11:02 WARN invoke fetch slow: 1400ms",
+  includeEnvironment: true,
+  includeLog: true,
+};
+
+describe("buildReport", () => {
+  it("always names the build, whatever else is excluded", () => {
+    const text = buildReport({
+      ...PARTS,
+      includeEnvironment: false,
+      includeLog: false,
+    });
+    expect(text).toContain("platypusgit 0.8.0");
+    // A report whose build is unknown cannot be acted on, so the version line
+    // is not one of the opt-outs.
+    expect(text).not.toContain("host os=macos");
+    expect(text).not.toContain("invoke fetch");
+  });
+
+  it("includes the environment line only when asked", () => {
+    expect(buildReport(PARTS)).toContain("host os=macos arch=aarch64 git=2.49.0");
+    expect(
+      buildReport({ ...PARTS, includeEnvironment: false }),
+    ).not.toContain("host os=macos");
+  });
+
+  it("includes the log tail and its path only when asked", () => {
+    const withLog = buildReport(PARTS);
+    expect(withLog).toContain("invoke fetch slow: 1400ms");
+    expect(withLog).toContain(PARTS.logPath);
+
+    const without = buildReport({ ...PARTS, includeLog: false });
+    expect(without).not.toContain("invoke fetch slow");
+    expect(without).not.toContain(PARTS.logPath);
+  });
+
+  it("omits the log section entirely when the tail could not be read", () => {
+    // A failed `read_log_tail` must not produce a section header with nothing
+    // under it — that reads like an empty log rather than an unread one.
+    const text = buildReport({ ...PARTS, logTail: null });
+    expect(text).not.toContain(PARTS.logPath);
+    expect(text).toContain("platypusgit 0.8.0");
+    expect(text).toContain("host os=macos");
+  });
+
+  it("does not hardcode the backend's tail line count", () => {
+    // TAIL_LINES lives in commands/diagnostics.rs. Repeating "500" here is a
+    // second copy of a constant this side cannot see change.
+    expect(buildReport(PARTS)).not.toContain("500");
+  });
+});
+
+describe("issueUrl", () => {
+  const BASE = { version: "0.8.0", environment: "host os=linux arch=x86_64 git=2.43.0" };
+
+  it("targets the project's issue tracker with the bug label", () => {
+    const u = new URL(issueUrl({ ...BASE, summary: "Fetch hangs" }));
+    expect(u.origin + u.pathname).toBe(
+      "https://github.com/jonassaa/platypusgit/issues/new",
+    );
+    expect(u.searchParams.get("labels")).toBe("bug");
+  });
+
+  it("titles the issue from the summary's first line, template-style", () => {
+    const u = new URL(
+      issueUrl({ ...BASE, summary: "Fetch hangs forever\nand then crashes" }),
+    );
+    expect(u.searchParams.get("title")).toBe("[bug] Fetch hangs forever");
+  });
+
+  it("still produces a usable title for an empty summary", () => {
+    const u = new URL(issueUrl({ ...BASE, summary: "" }));
+    expect(u.searchParams.get("title")).toBe("[bug]");
+  });
+
+  it("mirrors the bug_report.md headings and carries the paste marker", () => {
+    const body = new URL(
+      issueUrl({ ...BASE, summary: "Fetch hangs" }),
+    ).searchParams.get("body")!;
+    for (const heading of [
+      "## Describe the bug",
+      "## Steps to reproduce",
+      "## Expected behavior",
+      "## Actual behavior",
+      "## Environment",
+      "## Additional context",
+    ]) {
+      expect(body).toContain(heading);
+    }
+    expect(body).toContain("Fetch hangs");
+    expect(body).toContain(PASTE_MARKER);
+  });
+
+  it("prefills Environment with the small, bounded facts", () => {
+    const body = new URL(
+      issueUrl({ ...BASE, summary: "x" }),
+    ).searchParams.get("body")!;
+    expect(body).toContain("0.8.0");
+    expect(body).toContain("host os=linux arch=x86_64 git=2.43.0");
+  });
+
+  it("never carries a log tail — that is what the clipboard is for", () => {
+    const url = issueUrl({ ...BASE, summary: "x" });
+    expect(url).not.toContain("invoke");
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+  });
+
+  it("stays inside the URL budget however long the summary is", () => {
+    // GitHub answers a long enough query string with 414, so the button must
+    // not be able to produce one. 40k of prose is a plausible paste.
+    const url = issueUrl({ ...BASE, summary: "wall of text ".repeat(4000) });
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+    expect(new URL(url).searchParams.get("body")).toContain("…");
+  });
+
+  it("stays inside the budget when the summary is all multi-byte escapes", () => {
+    // A newline costs three URL bytes and appears in both title and body, so
+    // shrinking by character count alone can undershoot.
+    const url = issueUrl({ ...BASE, summary: "\n".repeat(9000) });
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+  });
+
+  it("fits the skeleton even with no summary at all", () => {
+    // The truncation loop's floor. If this ever exceeds the budget, no amount
+    // of trimming the summary can save it.
+    expect(issueUrl({ ...BASE, summary: "" }).length).toBeLessThanOrEqual(
+      MAX_URL_LEN,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/report.test.ts`
+Expected: FAIL — `Failed to resolve import "./report"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/report/report.ts`:
+
+```ts
+/**
+ * Assembling a bug report, and the URL that files it.
+ *
+ * Pure on purpose: no React, no IPC, no clipboard. Every branch here is
+ * reachable from a unit test with no jsdom and no mocks, which matters because
+ * one of the callers is the error boundary — a surface that runs when the React
+ * tree below it has already been unmounted, and that therefore cannot be
+ * exercised through the dialog at all.
+ *
+ * The one non-obvious rule is the SPLIT. A GitHub `issues/new?body=…` URL is
+ * the obvious place to put the whole report, and it does not fit: GitHub
+ * answers a long enough query string with HTTP 414, and the practical ceiling
+ * is around 8 KB of URL, while `read_log_tail` returns up to `TAIL_CAP_BYTES`.
+ * Putting the log in the URL therefore works in testing, where the log is
+ * short, and fails on exactly the machine that has been running long enough to
+ * have a bug worth reporting. So the small bounded facts go in the URL and the
+ * unbounded report goes on the clipboard, with a marker in the body saying so.
+ */
+
+/** Where this app's own issues live. */
+const ISSUES_URL = "https://github.com/jonassaa/platypusgit/issues/new";
+
+/**
+ * The one unbounded input, and so the only thing ever trimmed.
+ *
+ * 6000 rather than the ~8 KB ceiling: the margin covers a long environment
+ * line and GitHub moving the limit without this app finding out from a 414 in
+ * someone else's browser.
+ */
+export const MAX_URL_LEN = 6000;
+
+/** What the body asks the reporter to do with their clipboard. */
+export const PASTE_MARKER =
+  "<!-- Paste the diagnostics report from your clipboard here (Cmd/Ctrl+V) -->";
+
+/**
+ * The log section's rule.
+ *
+ * Deliberately does NOT say "last 500 lines": that count is `TAIL_LINES` in
+ * `commands/diagnostics.rs`, and a second copy on this side is a constant that
+ * silently stops being true.
+ */
+const LOG_RULE = "── log tail ──";
+
+/** How long a title may get before GitHub's own field does the trimming. */
+const MAX_TITLE_LEN = 120;
+
+export interface ReportParts {
+  /** The running build. */
+  version: string;
+  /** The startup `host os=… arch=… git=…` line. */
+  environment: string;
+  /** Absolute path the tail was read from — provenance for a pasted excerpt. */
+  logPath: string;
+  /** The tail itself, or `null` when it could not be read. */
+  logTail: string | null;
+  includeEnvironment: boolean;
+  includeLog: boolean;
+}
+
+/**
+ * The pasteable block, in the order a reader wants it.
+ *
+ * The version line is not one of the opt-outs: a report whose build is unknown
+ * cannot be acted on. Everything else is the user's choice, and an excluded
+ * section is ABSENT rather than present-and-empty — a `── log tail ──` rule
+ * with nothing under it reads like an empty log rather than an unread one.
+ */
+export function buildReport(parts: ReportParts): string {
+  const lines: string[] = [`platypusgit ${parts.version}`];
+  if (parts.includeEnvironment) lines.push(parts.environment);
+  if (parts.includeLog && parts.logTail) {
+    lines.push(parts.logPath, "", LOG_RULE, parts.logTail);
+  }
+  return lines.join("\n");
+}
+
+/** `[bug] ` + the summary's first line, matching `bug_report.md`'s front matter. */
+function issueTitle(summary: string): string {
+  const first = summary.split("\n")[0]?.trim() ?? "";
+  return first ? `[bug] ${first.slice(0, MAX_TITLE_LEN)}` : "[bug]";
+}
+
+/**
+ * The body, mirroring `.github/ISSUE_TEMPLATE/bug_report.md`.
+ *
+ * Written here rather than fetched by passing `template=`: given both
+ * `template` and `body`, the two contend for the same field, and which one
+ * wins is GitHub's business rather than something this app should depend on.
+ */
+function issueBody(summary: string, version: string, environment: string): string {
+  return [
+    "## Describe the bug",
+    "",
+    summary || "<!-- What went wrong? -->",
+    "",
+    "## Steps to reproduce",
+    "",
+    "1. …",
+    "2. …",
+    "3. …",
+    "",
+    "## Expected behavior",
+    "",
+    "## Actual behavior",
+    "",
+    "## Environment",
+    "",
+    `- platypusgit version: ${version}`,
+    `- ${environment}`,
+    "",
+    "## Additional context",
+    "",
+    PASTE_MARKER,
+    "",
+  ].join("\n");
+}
+
+function build(
+  summary: string,
+  opts: { version: string; environment: string },
+): string {
+  const u = new URL(ISSUES_URL);
+  u.searchParams.set("labels", "bug");
+  u.searchParams.set("title", issueTitle(summary));
+  u.searchParams.set("body", issueBody(summary, opts.version, opts.environment));
+  return u.toString();
+}
+
+/**
+ * The prefilled issue URL, guaranteed to fit inside [`MAX_URL_LEN`].
+ *
+ * The summary is the only unbounded part, so it is the only part trimmed. The
+ * loop shrinks rather than computing a length: percent-encoding makes a
+ * character's cost variable — a newline is three bytes and appears in BOTH the
+ * title and the body — so arithmetic alone cannot land it in one pass.
+ */
+export function issueUrl(opts: {
+  summary: string;
+  version: string;
+  environment: string;
+}): string {
+  const summary = opts.summary.trim();
+  const full = build(summary, opts);
+  if (full.length <= MAX_URL_LEN) return full;
+
+  let keep = summary.length;
+  while (keep > 0) {
+    const candidate = build(`${summary.slice(0, keep)}…`, opts);
+    if (candidate.length <= MAX_URL_LEN) return candidate;
+    const over = candidate.length - MAX_URL_LEN;
+    // Nine is the worst case for one character of UTF-8 in a query string
+    // (three bytes, percent-encoded, in two fields), so this never overshoots
+    // past the answer — it only ever needs another pass.
+    keep = Math.max(0, keep - Math.max(1, Math.ceil(over / 9)));
+  }
+  return build("", opts);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/report.test.ts`
+Expected: PASS, 14 tests.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+git add src/features/report/report.ts src/features/report/report.test.ts
+git commit -m "$(cat <<'EOF'
+feat(report): assemble a bug report and the URL that files it
+
+**Why:** a GitHub issues/new?body= URL answers 414 well below the size of
+a log tail, so the report splits by size — bounded facts in the URL, the
+log on the clipboard. Pure and IPC-free because the error boundary needs
+these builders on a surface that cannot mount a dialog.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: The `bug` icon
+
+**Files:**
+- Modify: `src/design/icons.tsx` (the `lucide-react` import block, the `IconName` union, the `ICONS` record)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `"bug"` as a member of `IconName`, renderable as `<PGIcon name="bug" />`.
+
+- [ ] **Step 1: Run the existing guard to see it pass first**
+
+Run: `~/Library/pnpm/pnpm vitest run test/iconSet.test.ts`
+Expected: PASS. This is the baseline — the guard must still pass after the edit, and it is what will fail later if a call site names `"bug"` before the union declares it.
+
+- [ ] **Step 2: Add the import**
+
+In `src/design/icons.tsx`, add `Bug,` to the alphabetised `lucide-react` import block, between `BookMarked,` and `Check,`.
+
+- [ ] **Step 3: Add the union member**
+
+In the `IconName` union, extend the line that reads:
+
+```ts
+  | "dot" | "circle" | "warn" | "error" | "info" | "clock"
+```
+
+to:
+
+```ts
+  | "dot" | "circle" | "warn" | "error" | "info" | "clock" | "bug"
+```
+
+- [ ] **Step 4: Add the record entry**
+
+In the `ICONS` record, add `bug: Bug,` beside the other status glyphs (`warn`, `error`, `info`).
+
+- [ ] **Step 5: Verify the guard and the typecheck**
+
+Run: `~/Library/pnpm/pnpm vitest run test/iconSet.test.ts && ~/Library/pnpm/pnpm tsc --noEmit`
+Expected: PASS. The `Record<IconName, LucideIcon>` type makes a missing record entry a compile error, so the typecheck is the real assertion here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/design/icons.tsx
+git commit -m "$(cat <<'EOF'
+feat(design): add the bug icon
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: The store and the side effects
+
+**Files:**
+- Create: `src/features/report/useReportStore.ts`
+- Create: `src/features/report/fileReport.ts`
+- Test: `src/features/report/fileReport.test.ts`
+
+**Interfaces:**
+- Consumes: `buildReport`, `issueUrl`, `ReportParts` from Task 1.
+- Produces:
+  - `useReportStore` — `{ open: boolean; seed: string; openReport(seed?: string): void; closeReport(): void }`
+  - `interface ReportSources { version: string; environment: string; logPath: string; logTail: string | null }`
+  - `function gatherReport(includeLog: boolean): Promise<ReportSources>`
+  - `function copyAndOpenIssue(parts: ReportParts & { summary: string }): Promise<void>`
+  - `function copyReport(parts: ReportParts): Promise<void>`
+  - `function fileBugReport(summary: string): Promise<void>`
+
+- [ ] **Step 1: Write the store**
+
+Create `src/features/report/useReportStore.ts`:
+
+```ts
+import { create } from "zustand";
+
+/**
+ * Whether the report dialog is open, and what the summary box starts with.
+ *
+ * App-level rather than per-repo, so it stays out of `RepoSlice`/`emptySlice`:
+ * those exist for state that must be DROPPED on a tab switch, and "is the
+ * report dialog open" is not about a repository at all.
+ *
+ * `seed` exists because two of the four entry points know something the user
+ * would otherwise retype — the error banner has the error text, and the error
+ * boundary has the render throw's message.
+ */
+interface ReportState {
+  open: boolean;
+  seed: string;
+  openReport: (seed?: string) => void;
+  closeReport: () => void;
+}
+
+export const useReportStore = create<ReportState>((set) => ({
+  open: false,
+  seed: "",
+  openReport: (seed = "") => set({ open: true, seed }),
+  closeReport: () => set({ open: false }),
+}));
+```
+
+- [ ] **Step 2: Write the failing test for the side effects**
+
+Create `src/features/report/fileReport.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+
+import { copyAndOpenIssue, fileBugReport, gatherReport } from "./fileReport";
+
+const DIAG = {
+  logPath: "/tmp/platypusgit.log",
+  logExists: true,
+  logSizeBytes: 4096,
+  environment: "host os=linux arch=x86_64 git=2.43.0",
+  version: "0.8.0",
+};
+
+let written: string[] = [];
+
+beforeEach(() => {
+  written = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn(async (t: string) => {
+        written.push(t);
+      }),
+    },
+  });
+  mockInvoke("diagnostics_report", () => DIAG);
+  mockInvoke("read_log_tail", () => "11:02 WARN invoke fetch slow: 1400ms");
+  mockInvoke("open_url", () => undefined);
+});
+
+describe("gatherReport", () => {
+  it("reads the log tail when asked", async () => {
+    const src = await gatherReport(true);
+    expect(src.version).toBe("0.8.0");
+    expect(src.environment).toBe(DIAG.environment);
+    expect(src.logPath).toBe(DIAG.logPath);
+    expect(src.logTail).toContain("invoke fetch slow");
+  });
+
+  it("does not read the log tail when not asked", async () => {
+    const src = await gatherReport(false);
+    expect(src.logTail).toBeNull();
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("read_log_tail");
+  });
+
+  it("survives a log that cannot be read", async () => {
+    // An unreadable log must not lose the environment: an environment-only
+    // report is worth more than no report at all.
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "no log file yet" };
+    });
+    const src = await gatherReport(true);
+    expect(src.logTail).toBeNull();
+    expect(src.environment).toBe(DIAG.environment);
+  });
+});
+
+describe("copyAndOpenIssue", () => {
+  const PARTS = {
+    summary: "Fetch hangs",
+    version: "0.8.0",
+    environment: DIAG.environment,
+    logPath: DIAG.logPath,
+    logTail: "11:02 WARN invoke fetch slow",
+    includeEnvironment: true,
+    includeLog: true,
+  };
+
+  it("copies the report before opening the browser", async () => {
+    await copyAndOpenIssue(PARTS);
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("invoke fetch slow");
+    // Order matters: by the time GitHub has loaded, the clipboard must already
+    // hold what the body's paste marker asks for.
+    const opened = getInvokeCalls().find((c) => c.cmd === "open_url");
+    expect(opened).toBeTruthy();
+    expect(written.length).toBe(1);
+  });
+
+  it("opens a URL inside the budget with no log in it", async () => {
+    await copyAndOpenIssue(PARTS);
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args.url as string;
+    expect(url).toContain("github.com/jonassaa/platypusgit/issues/new");
+    expect(url).not.toContain("invoke+fetch+slow");
+    expect(url.length).toBeLessThanOrEqual(6000);
+  });
+
+  it("does not open the browser when the clipboard write fails", async () => {
+    // Opening GitHub with nothing on the clipboard sends the user to a form
+    // whose instructions they cannot follow.
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => {
+          throw new Error("denied");
+        }),
+      },
+    });
+    await expect(copyAndOpenIssue(PARTS)).rejects.toThrow();
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+  });
+
+  it("reports a webview with no clipboard rather than pretending to copy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    await expect(copyAndOpenIssue(PARTS)).rejects.toThrow(/clipboard/i);
+  });
+});
+
+describe("fileBugReport", () => {
+  it("gathers, copies and opens in one call", async () => {
+    // This is the error boundary's whole path: it has no dialog to mount and
+    // no store subscriber, so one call has to do everything.
+    await fileBugReport("Render error: x is not a function");
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("invoke fetch slow");
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args.url as string;
+    expect(decodeURIComponent(url)).toContain("Render error: x is not a function");
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/fileReport.test.ts`
+Expected: FAIL — `Failed to resolve import "./fileReport"`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/features/report/fileReport.ts`:
+
+```ts
+/**
+ * The side effects: reading the diagnostics, writing the clipboard, opening
+ * the browser.
+ *
+ * Split from `report.ts` so that the text assembly stays pure, and split from
+ * `ReportIssueDialog` so that a caller with no React tree can still file a
+ * report. That caller is `PGErrorBoundary`, which runs precisely when the tree
+ * below it has been unmounted — see `fileBugReport`.
+ */
+import { diagnosticsReport, openUrl, readLogTail } from "@/lib/tauri";
+
+import { buildReport, issueUrl, type ReportParts } from "./report";
+
+/** Everything a report is assembled from, as read off this machine. */
+export interface ReportSources {
+  version: string;
+  environment: string;
+  logPath: string;
+  /** `null` when the log could not be read — see `gatherReport`. */
+  logTail: string | null;
+}
+
+/**
+ * Read the facts a report is built from.
+ *
+ * A failing `read_log_tail` is NOT an error here. A fresh install has no log
+ * file at all, and an environment-only report is worth more than no report, so
+ * the tail degrades to `null` and `buildReport` drops the section.
+ */
+export async function gatherReport(includeLog: boolean): Promise<ReportSources> {
+  const diag = await diagnosticsReport();
+  let logTail: string | null = null;
+  if (includeLog) {
+    try {
+      logTail = await readLogTail();
+    } catch {
+      logTail = null;
+    }
+  }
+  return {
+    version: diag.version,
+    environment: diag.environment,
+    logPath: diag.logPath,
+    logTail,
+  };
+}
+
+/** Put the assembled report on the clipboard. Throws if it cannot. */
+export async function copyReport(parts: ReportParts): Promise<void> {
+  const clip = navigator.clipboard;
+  if (!clip) throw new Error("This webview has no clipboard access");
+  await clip.writeText(buildReport(parts));
+}
+
+/**
+ * Copy the report, then open the prefilled issue. In that order.
+ *
+ * The order is the feature: the body carries a marker asking the reporter to
+ * paste, so the clipboard has to be loaded before GitHub is on screen. A
+ * failed copy therefore does NOT open the browser — that would send someone to
+ * a form whose instructions they cannot follow.
+ */
+export async function copyAndOpenIssue(
+  parts: ReportParts & { summary: string },
+): Promise<void> {
+  await copyReport(parts);
+  await openUrl(
+    issueUrl({
+      summary: parts.summary,
+      version: parts.version,
+      environment: parts.environment,
+    }),
+  );
+}
+
+/**
+ * Gather, copy and open — the whole flow in one call, with everything included.
+ *
+ * For a caller that cannot render the dialog. `PGDialogHost` and
+ * `ReportIssueDialog` both mount inside `AppShell`, which mounts inside
+ * `PGErrorBoundary`; after a render throw React has unmounted that whole
+ * subtree, so there is no dialog to open and nothing subscribed to
+ * `useReportStore`. Calling `openReport()` from the boundary would set a flag
+ * nobody reads.
+ */
+export async function fileBugReport(summary: string): Promise<void> {
+  const src = await gatherReport(true);
+  await copyAndOpenIssue({
+    ...src,
+    summary,
+    includeEnvironment: true,
+    includeLog: src.logTail !== null,
+  });
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/fileReport.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Typecheck and commit**
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+git add src/features/report/useReportStore.ts src/features/report/fileReport.ts src/features/report/fileReport.test.ts
+git commit -m "$(cat <<'EOF'
+feat(report): gather the diagnostics, copy, then open the issue
+
+**Why:** copy strictly before open — the issue body carries a paste
+marker, so opening GitHub with an empty clipboard sends the reporter to
+a form whose instructions they cannot follow. A failed read_log_tail
+degrades to an environment-only report rather than an error.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: The dialog
+
+**Files:**
+- Create: `src/features/report/ReportIssueDialog.tsx`
+- Test: `src/features/report/ReportIssueDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `useReportStore` and `gatherReport`/`copyReport`/`copyAndOpenIssue` from Task 3, `buildReport`/`ReportParts` from Task 1, `"bug"` from Task 2.
+- Produces: `function ReportIssueDialog(): JSX.Element | null` — a self-contained overlay driven entirely by `useReportStore`, taking no props, mounted once by `AppShell` in Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/report/ReportIssueDialog.test.tsx`:
+
+```tsx
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+
+import { ReportIssueDialog } from "./ReportIssueDialog";
+import { useReportStore } from "./useReportStore";
+
+const DIAG = {
+  logPath: "/tmp/platypusgit.log",
+  logExists: true,
+  logSizeBytes: 4096,
+  environment: "host os=linux arch=x86_64 git=2.43.0",
+  version: "0.8.0",
+};
+
+let written: string[] = [];
+
+beforeEach(() => {
+  written = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(async (t: string) => void written.push(t)) },
+  });
+  mockInvoke("diagnostics_report", () => DIAG);
+  mockInvoke("read_log_tail", () => "11:02 WARN invoke fetch slow: 1400ms");
+  mockInvoke("open_url", () => undefined);
+  useReportStore.setState({ open: false, seed: "" });
+});
+
+function openDialog(seed = "") {
+  useReportStore.getState().openReport(seed);
+}
+
+describe("ReportIssueDialog", () => {
+  it("renders nothing while closed", () => {
+    render(<ReportIssueDialog />);
+    expect(screen.queryByTestId("report-dialog")).toBeNull();
+  });
+
+  it("shows the exact text that will be copied", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    // Nothing leaves this app without being shown first — the preview is the
+    // report itself, not a summary of it.
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).toHaveTextContent(
+        "platypusgit 0.8.0",
+      ),
+    );
+    expect(screen.getByTestId("report-preview")).toHaveTextContent(
+      "invoke fetch slow: 1400ms",
+    );
+    expect(screen.getByTestId("report-preview")).toHaveTextContent(
+      "host os=linux arch=x86_64 git=2.43.0",
+    );
+  });
+
+  it("seeds the summary from the caller", async () => {
+    render(<ReportIssueDialog />);
+    openDialog("Network: could not resolve host");
+    await waitFor(() =>
+      expect(screen.getByTestId("report-summary")).toHaveValue(
+        "Network: could not resolve host",
+      ),
+    );
+  });
+
+  it("drops the log from the preview when the box is unchecked", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueDialog />);
+    openDialog();
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).toHaveTextContent(
+        "invoke fetch slow",
+      ),
+    );
+    await user.click(screen.getByTestId("report-include-log"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+        "invoke fetch slow",
+      ),
+    );
+    // Unchecking the log is the privacy control: it is what removes the paths.
+    expect(screen.getByTestId("report-preview")).not.toHaveTextContent("/tmp/");
+  });
+
+  it("drops the environment from the preview when unchecked", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueDialog />);
+    openDialog();
+    await waitFor(() => screen.getByTestId("report-preview"));
+    await user.click(screen.getByTestId("report-include-env"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+        "host os=linux",
+      ),
+    );
+  });
+
+  it("copies without opening the browser on Copy report", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueDialog />);
+    openDialog();
+    await waitFor(() => screen.getByTestId("report-copy"));
+    await user.click(screen.getByTestId("report-copy"));
+    await waitFor(() => expect(written.length).toBe(1));
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+    // Copy-only leaves the dialog open: the user is mid-flow, filing by hand.
+    expect(screen.getByTestId("report-dialog")).toBeTruthy();
+  });
+
+  it("copies and opens the prefilled issue on Copy & open", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueDialog />);
+    openDialog();
+    await waitFor(() => screen.getByTestId("report-open"));
+    await user.type(screen.getByTestId("report-summary"), "Fetch hangs");
+    await user.click(screen.getByTestId("report-open"));
+    await waitFor(() =>
+      expect(getInvokeCalls().map((c) => c.cmd)).toContain("open_url"),
+    );
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args
+      .url as string;
+    expect(decodeURIComponent(url)).toContain("Fetch hangs");
+    expect(url).toContain("labels=bug");
+  });
+
+  it("still offers an environment report when the log cannot be read", async () => {
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "no log file at /tmp/x yet" };
+    });
+    render(<ReportIssueDialog />);
+    openDialog();
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).toHaveTextContent(
+        "platypusgit 0.8.0",
+      ),
+    );
+    expect(screen.getByTestId("report-preview")).toHaveTextContent(
+      "host os=linux",
+    );
+    expect(screen.getByTestId("report-copy")).toBeEnabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/ReportIssueDialog.test.tsx`
+Expected: FAIL — `Failed to resolve import "./ReportIssueDialog"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/report/ReportIssueDialog.tsx`:
+
+```tsx
+/**
+ * The Report an issue dialog.
+ *
+ * Mounted ONCE, by `AppShell`, beside `PGDialogHost`. Settings is a screen
+ * inside `AppShell`, so that single mount serves three of the four entry points
+ * (titlebar, error banner, Settings). The fourth — `PGErrorBoundary` — sits
+ * ABOVE this mount and cannot use it at all; see `fileReport.ts::fileBugReport`.
+ *
+ * The preview is the point. This is the most revealing text the app ever
+ * assembles in one place — a log tail carries repository paths, branch names,
+ * remote URLs and hook output — so the dialog renders the exact string that
+ * will be copied, in full, and each part is independently opt-out. Nothing is
+ * ever sent anywhere: the clipboard is written and a URL is handed to the
+ * user's own browser.
+ */
+import React from "react";
+
+import {
+  PGButton,
+  PGCheckbox,
+  PGModal,
+  appErrorMessage,
+  pgFlash,
+} from "@/design";
+import { useAction } from "@/features/keymap/useAction";
+
+import { buildReport } from "./report";
+import { copyAndOpenIssue, copyReport, gatherReport, type ReportSources } from "./fileReport";
+import { useReportStore } from "./useReportStore";
+
+export function ReportIssueDialog() {
+  const open = useReportStore((s) => s.open);
+  const seed = useReportStore((s) => s.seed);
+  const close = useReportStore((s) => s.closeReport);
+
+  const [summary, setSummary] = React.useState("");
+  const [withEnv, setWithEnv] = React.useState(true);
+  const [withLog, setWithLog] = React.useState(true);
+  const [sources, setSources] = React.useState<ReportSources | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  // Escape goes through the keymap so it stays in the cheat sheet and honours
+  // rebinding — never a local capture-phase listener (issue #47's rule).
+  useAction(
+    "app.closeOverlay",
+    () => {
+      if (!open) return false;
+      close();
+      return true;
+    },
+    [open, close],
+  );
+
+  // A fresh open is a fresh report: whatever the entry point knows goes in the
+  // box, and last time's text does not linger.
+  React.useEffect(() => {
+    if (open) {
+      setSummary(seed);
+      setSources(null);
+    }
+  }, [open, seed]);
+
+  // Always read the log, whatever the checkbox says. It is what the PREVIEW
+  // needs in order to show the user what they are about to include, and
+  // re-reading it on every toggle would make the box feel slow for no gain.
+  React.useEffect(() => {
+    if (!open || sources) return;
+    let live = true;
+    gatherReport(true)
+      .then((s) => {
+        if (live) setSources(s);
+      })
+      .catch((e) => {
+        if (live) pgFlash(appErrorMessage(e));
+      });
+    return () => {
+      live = false;
+    };
+  }, [open, sources]);
+
+  if (!open) return null;
+
+  const parts = {
+    version: sources?.version ?? "",
+    environment: sources?.environment ?? "",
+    logPath: sources?.logPath ?? "",
+    logTail: sources?.logTail ?? null,
+    includeEnvironment: withEnv,
+    includeLog: withLog,
+  };
+  const preview = sources ? buildReport(parts) : "Reading diagnostics…";
+
+  const onCopy = async () => {
+    setBusy(true);
+    try {
+      await copyReport(parts);
+      pgFlash("Report copied");
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopyAndOpen = async () => {
+    setBusy(true);
+    try {
+      await copyAndOpenIssue({ ...parts, summary });
+      close();
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <PGModal onCancel={close} width={620} dismissable={!busy}>
+      <div data-testid="report-dialog" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>
+          Report an issue
+        </div>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: "var(--fs-12)", color: "var(--fg-2)" }}>
+            What went wrong?
+          </span>
+          <textarea
+            data-testid="report-summary"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            rows={4}
+            style={{
+              resize: "vertical",
+              background: "var(--bg-1)",
+              color: "var(--fg-0)",
+              border: "1px solid var(--border-1)",
+              borderRadius: "var(--r-2)",
+              padding: 8,
+              fontSize: "var(--fs-12)",
+              fontFamily: "inherit",
+            }}
+          />
+        </label>
+
+        <div style={{ display: "flex", gap: 16 }}>
+          <PGCheckbox
+            checked={withEnv}
+            onChange={setWithEnv}
+            label="Include environment"
+            testId="report-include-env"
+          />
+          <PGCheckbox
+            checked={withLog}
+            onChange={setWithLog}
+            label="Include log tail"
+            testId="report-include-log"
+          />
+        </div>
+
+        <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-2)" }}>
+          This is copied to your clipboard — nothing is sent anywhere. Paste it
+          into the issue GitHub opens.
+        </div>
+        <pre
+          data-testid="report-preview"
+          style={{
+            margin: 0,
+            maxHeight: 220,
+            overflow: "auto",
+            background: "var(--bg-1)",
+            border: "1px solid var(--border-0)",
+            borderRadius: "var(--r-2)",
+            padding: 8,
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-1)",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {preview}
+        </pre>
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 6 }}>
+          <PGButton size="sm" variant="ghost" onClick={close} disabled={busy}>
+            Cancel
+          </PGButton>
+          <PGButton
+            size="sm"
+            icon="copy"
+            onClick={onCopy}
+            disabled={busy || !sources}
+            data-testid="report-copy"
+          >
+            Copy report
+          </PGButton>
+          <PGButton
+            size="sm"
+            variant="primary"
+            icon="external"
+            onClick={onCopyAndOpen}
+            disabled={busy || !sources}
+            data-testid="report-open"
+          >
+            Copy &amp; open GitHub
+          </PGButton>
+        </div>
+      </div>
+    </PGModal>
+  );
+}
+```
+
+> **Note on `PGCheckbox`:** confirm its prop names against
+> `src/design/primitives.tsx` (`checked`, `onChange`, `label`, `testId`) and
+> whether `onChange` receives the next boolean or an event; adapt the two call
+> sites if it differs. Same for `PGButton` accepting `data-testid` through its
+> `...rest` spread — it does, but verify rather than assume.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/report/ReportIssueDialog.test.tsx`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+git add src/features/report/ReportIssueDialog.tsx src/features/report/ReportIssueDialog.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(report): the Report an issue dialog
+
+**Why:** the preview is the privacy story — this is the most revealing
+text the app assembles in one place, so it renders the exact string that
+will be copied and makes each part independently opt-out.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: The three in-tree entry points
+
+**Files:**
+- Modify: `src/AppShell.tsx` (mount the dialog beside `PGDialogHost` ~line 479; the `PGErrorBanner` call ~line 495; `AppTitlebar`'s `rightSlot` ~line 737)
+- Modify: `src/design/error-banner.tsx` (new optional `onReport` prop)
+- Modify: `src/screens/Reflog.tsx:182` (pass `onReport`)
+- Modify: `src/features/settings/pages/backup.tsx` (a Diagnostics row + move `copyLog` onto `buildReport`)
+- Test: `src/design/error-banner.test.tsx` (extend), `src/screens/settings.index.test.tsx` (existing gate — no edit expected)
+
+**Interfaces:**
+- Consumes: `ReportIssueDialog` and `useReportStore` from Tasks 3–4, `buildReport` from Task 1, `"bug"` from Task 2.
+- Produces: `PGErrorBanner` gains `onReport?: () => void`; `<ReportIssueDialog />` is mounted exactly once in the app.
+
+- [ ] **Step 1: Write the failing test for the banner's report action**
+
+Add to `src/design/error-banner.test.tsx`:
+
+```tsx
+it("offers a report action only when a handler is given", async () => {
+  const user = userEvent.setup();
+  const onReport = vi.fn();
+  const { rerender } = render(
+    <PGErrorBanner
+      error={{ kind: "Network", message: "could not resolve host" }}
+      onDismiss={() => {}}
+    />,
+  );
+  // Optional on the same terms as `compact`: a surface with no report flow
+  // must not grow a dead button.
+  expect(screen.queryByTestId("banner-report")).toBeNull();
+
+  rerender(
+    <PGErrorBanner
+      error={{ kind: "Network", message: "could not resolve host" }}
+      onDismiss={() => {}}
+      onReport={onReport}
+    />,
+  );
+  await user.click(screen.getByTestId("banner-report"));
+  expect(onReport).toHaveBeenCalledTimes(1);
+});
+```
+
+> Match the existing file's imports and its `AppError` fixture shape — read it
+> before adding this, and reuse whatever error object the neighbouring tests
+> use rather than inventing one.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/error-banner.test.tsx`
+Expected: FAIL — no element with testid `banner-report`.
+
+- [ ] **Step 3: Add the prop to the banner**
+
+In `src/design/error-banner.tsx`, extend the props:
+
+```tsx
+  /** Offers "report" beside "dismiss". Optional on the same terms as
+   *  `compact`: a surface with no report flow must not grow a dead button.
+   *  A callback rather than the banner reaching for `useReportStore` —
+   *  `src/design/` is the design system and performs no IPC. */
+  onReport?: () => void;
+```
+
+and render it before the dismiss button, sharing its styling:
+
+```tsx
+      {onReport && (
+        <button
+          onClick={onReport}
+          data-testid="banner-report"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "inherit",
+            cursor: "pointer",
+            fontSize: "var(--fs-11)",
+            textDecoration: "underline",
+          }}
+        >
+          report
+        </button>
+      )}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/error-banner.test.tsx`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 5: Wire AppShell — mount, banner, titlebar**
+
+In `src/AppShell.tsx`:
+
+1. Import: `import { ReportIssueDialog } from "@/features/report/ReportIssueDialog";` and `import { useReportStore } from "@/features/report/useReportStore";`
+2. Beside `<PGDialogHost />` (~line 479), add `<ReportIssueDialog />`.
+3. At the `PGErrorBanner` call (~line 495), pass the seed:
+
+```tsx
+      {error && (
+        <PGErrorBanner
+          error={error}
+          onDismiss={clearError}
+          onReport={() =>
+            useReportStore.getState().openReport(errorBannerText(error))
+          }
+        />
+      )}
+```
+
+   Import `errorBannerText` from `@/lib/errors` if it is not already imported.
+4. In `AppTitlebar`'s `rightSlot` (~line 737), before `<UpdateChip />`:
+
+```tsx
+            <PGButton
+              size="sm"
+              variant="ghost"
+              icon="bug"
+              title="Report an issue"
+              onClick={() => useReportStore.getState().openReport()}
+              data-testid="titlebar-report"
+            />
+```
+
+   `getState()` rather than a hook subscription, for the reason the comment
+   above `onFetch` already gives: this titlebar re-rendered on every store
+   write once, and it is not doing that again.
+
+- [ ] **Step 6: Add the Settings row and unify the report format**
+
+In `src/features/settings/pages/backup.tsx`:
+
+1. Add to `meta.cards`' diagnostics `rows` (the array that already holds
+   `diagnostics.environment` and `diagnostics.log`):
+
+```ts
+        { id: "diagnostics.report", label: "Report an issue", keywords: "bug github issue report file feedback" },
+```
+
+   `settings.index.test.tsx` fails the build for a row rendered but not
+   declared, and a word that lives only in a `hint` is not indexed — hence
+   `keywords`.
+
+2. Replace the hand-built header in `copyLog` with `buildReport`, so the two
+   surfaces cannot drift:
+
+```ts
+  const copyLog = async () => {
+    setDiagBusy(true);
+    try {
+      const tail = await readLogTail();
+      // One report format, shared with the Report an issue dialog
+      // (features/report/report.ts). This used to assemble its own header.
+      await navigator.clipboard?.writeText(
+        buildReport({
+          version: diagReport?.version ?? "",
+          environment: diagReport?.environment ?? "",
+          logPath: diagReport?.logPath ?? "",
+          logTail: tail,
+          includeEnvironment: true,
+          includeLog: true,
+        }),
+      );
+      pgFlash("Log tail copied");
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setDiagBusy(false);
+    }
+  };
+```
+
+3. Add the row inside the Diagnostics `SettingsCard`, after `diagnostics.log`:
+
+```tsx
+        <SettingsRow
+          id="diagnostics.report"
+          label="Report an issue"
+          hint="Assembles the environment and the log tail, copies them, and opens a prefilled GitHub issue. Nothing is sent — you paste it."
+          control={
+            <PGButton
+              size="sm"
+              icon="bug"
+              onClick={() => useReportStore.getState().openReport()}
+            >
+              Report an issue
+            </PGButton>
+          }
+        />
+```
+
+- [ ] **Step 7: Pass the prop from Reflog**
+
+In `src/screens/Reflog.tsx:182`, add `onReport` to the `PGErrorBanner` call, mirroring AppShell's:
+
+```tsx
+        <PGErrorBanner
+          error={error}
+          onDismiss={clearError}
+          onReport={() =>
+            useReportStore.getState().openReport(errorBannerText(error))
+          }
+          compact
+        />
+```
+
+- [ ] **Step 8: Verify the whole unit suite and the guards**
+
+Run: `~/Library/pnpm/pnpm test`
+Expected: PASS. Watch specifically for `settings.index.test.tsx` (the row must be declared), `iconSet.test.ts` (`"bug"` must be in the union — it is, from Task 2), `AppShell.navroutes.test.tsx` and the startup-paint guard.
+
+Also run: `grep -rn 'lib/tauri' src/design/` — expected: no output. The banner takes a callback precisely so this stays empty.
+
+- [ ] **Step 9: Typecheck and commit**
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+git add src/AppShell.tsx src/design/error-banner.tsx src/design/error-banner.test.tsx src/screens/Reflog.tsx src/features/settings/pages/backup.tsx
+git commit -m "$(cat <<'EOF'
+feat(report): reach the reporter from the titlebar, banner and Settings
+
+**Why:** the banner takes an onReport callback rather than importing
+useReportStore, because src/design/ is the design system and does not
+reach into features/. Settings' Copy last 500 lines moves onto
+buildReport so there is one report format rather than two.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: The error boundary — the entry point that cannot use the dialog
+
+**Files:**
+- Modify: `src/design/error-boundary.tsx` (new optional `onReport` prop + button)
+- Modify: `src/main.tsx` (wire it to `fileBugReport`)
+- Test: `src/design/error-boundary.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `fileBugReport` from Task 3.
+- Produces: `PGErrorBoundary` gains `onReport?: (error: Error) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/design/error-boundary.test.tsx`:
+
+```tsx
+it("offers to report the throw, with no dialog host mounted", async () => {
+  const user = userEvent.setup();
+  const onReport = vi.fn();
+  const Boom = () => {
+    throw new Error("x is not a function");
+  };
+  // Deliberately NO <PGDialogHost /> and no <ReportIssueDialog />. This is the
+  // real shape of the boundary's world: both mount inside AppShell, which
+  // mounts inside this boundary, so a render throw has already unmounted them.
+  // A report path that needs either of them does nothing at all here.
+  render(
+    <PGErrorBoundary onReport={onReport}>
+      <Boom />
+    </PGErrorBoundary>,
+  );
+  expect(screen.getByTestId("app-error-boundary")).toBeTruthy();
+  await user.click(screen.getByTestId("boundary-report"));
+  expect(onReport).toHaveBeenCalledTimes(1);
+  // Seeded with the throw, so the reporter does not retype it.
+  expect(onReport.mock.calls[0][0]).toBeInstanceOf(Error);
+  expect((onReport.mock.calls[0][0] as Error).message).toBe(
+    "x is not a function",
+  );
+});
+
+it("shows no report button when no handler is given", () => {
+  const Boom = () => {
+    throw new Error("boom");
+  };
+  render(
+    <PGErrorBoundary>
+      <Boom />
+    </PGErrorBoundary>,
+  );
+  expect(screen.getByTestId("app-error-boundary")).toBeTruthy();
+  expect(screen.queryByTestId("boundary-report")).toBeNull();
+});
+```
+
+> The existing file already renders a throwing child and silences
+> `console.error`; follow its setup exactly rather than adding a second
+> mechanism.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/error-boundary.test.tsx`
+Expected: FAIL — no element with testid `boundary-report`.
+
+- [ ] **Step 3: Add the prop and the button**
+
+In `src/design/error-boundary.tsx`, extend `Props`:
+
+```tsx
+  /**
+   * Files a bug report for the throw. Optional, and a CALLBACK rather than
+   * work done here, for two reasons:
+   *
+   *   - Nothing in `src/design/` performs IPC, and this is not the place to
+   *     start: a design-system component that reaches for `@/lib/tauri` cannot
+   *     be tested without a bridge.
+   *   - The boundary cannot use the report DIALOG under any circumstances.
+   *     `PGDialogHost` and `ReportIssueDialog` both mount inside `AppShell`,
+   *     which mounts inside this boundary, so by the time this renders React
+   *     has unmounted them — `openReport()` would set a flag nobody reads.
+   *
+   * `main.tsx` wires it to `features/report/fileReport.ts::fileBugReport`,
+   * which gathers, copies and opens in one call with no React tree involved.
+   */
+  onReport?: (error: Error) => void;
+```
+
+and render the button beside `Reload`, wrapping both in a flex row:
+
+```tsx
+        <div style={{ display: "flex", gap: 8 }}>
+          {this.props.onReport && (
+            <button
+              data-testid="boundary-report"
+              onClick={() => this.props.onReport?.(error)}
+              style={{
+                background: "var(--bg-2)",
+                color: "var(--fg-0)",
+                border: "1px solid var(--border-1)",
+                borderRadius: 4,
+                padding: "6px 14px",
+                cursor: "pointer",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              Report this bug
+            </button>
+          )}
+          <button
+            onClick={() => {
+              if (this.props.onReload) this.props.onReload();
+              else window.location.reload();
+            }}
+            style={{
+              background: "var(--accent)",
+              color: "var(--bg-0)",
+              border: "none",
+              borderRadius: 4,
+              padding: "6px 14px",
+              cursor: "pointer",
+              fontSize: "var(--fs-12)",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+```
+
+Keep the existing `Reload` button's markup and styling byte-for-byte — only its
+wrapper is new.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/error-boundary.test.tsx`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 5: Wire it in main.tsx**
+
+In `src/main.tsx`, import `fileBugReport` and pass it:
+
+```tsx
+import { fileBugReport } from "./features/report/fileReport";
+```
+
+```tsx
+    <PGErrorBoundary
+      onReport={(err) => {
+        // Fire and forget: the boundary has no place to render a failure, and
+        // `fileBugReport` already degrades a missing log to an
+        // environment-only report.
+        void fileBugReport(`Render error: ${err.message}`).catch((e) =>
+          console.error("could not file a bug report", e),
+        );
+      }}
+    >
+      {isMergeWindow ? <MergeWindow /> : <App />}
+    </PGErrorBoundary>
+```
+
+- [ ] **Step 6: Verify the startup-paint guard still holds**
+
+Run: `~/Library/pnpm/pnpm vitest run test/startupPaint.test.ts src/design/error-boundary.test.tsx`
+Expected: PASS. `main.tsx` is what `startupPaint.test.ts` reads — the reveal must
+still be a sibling of the boundary, not a child, and this edit must not move it.
+
+- [ ] **Step 7: Typecheck and commit**
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+git add src/design/error-boundary.tsx src/design/error-boundary.test.tsx src/main.tsx
+git commit -m "$(cat <<'EOF'
+feat(report): report a render throw from the error boundary
+
+**Why:** the boundary is the one entry point that cannot use the dialog —
+PGDialogHost and ReportIssueDialog both mount inside AppShell, which
+mounts inside the boundary, so a render throw has already unmounted them.
+It takes an onReport callback (like onReload) and main.tsx wires it to
+fileBugReport, which needs no React tree. Test asserts the no-host case.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Docs, the privacy allow-list, and the e2e assertion
+
+**Files:**
+- Modify: `docs/dev/architecture.md` (the `src/features/` tree)
+- Modify: `docs/dev/frontend.md` (a section on the reporter)
+- Modify: `CLAUDE.md` (one convention line)
+- Modify: `test/privacy.test.ts` (extend the `github.com` reason)
+- Modify: `e2e/specs/settings.e2e.ts` (one assertion)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a green `pnpm test` including `docs.test.ts` and `privacy.test.ts`.
+
+- [ ] **Step 1: Prove the docs gate is live before satisfying it**
+
+Run: `~/Library/pnpm/pnpm vitest run test/docs.test.ts`
+Expected: **FAIL** — "Feature directories absent from the features/ tree in
+docs/dev/architecture.md: report". Seeing this red first is the point: it proves
+the gate covers the new directory rather than being assumed to.
+
+- [ ] **Step 2: Add the features-tree entry**
+
+In `docs/dev/architecture.md`'s `src/features/` tree, add an entry in the
+app-level chrome neighbourhood (near `update/` / `windows/`), matching the
+surrounding `├── name/` + aligned-prose format:
+
+```
+├── report/          In-app bug reporting. report.ts is PURE (buildReport +
+│                    issueUrl, with a MAX_URL_LEN budget — a GitHub
+│                    issues/new?body= URL 414s well below the size of a log
+│                    tail, which is why the log travels by CLIPBOARD and the
+│                    URL carries only the bounded facts plus a paste marker);
+│                    fileReport.ts owns the side effects (gather → copy →
+│                    open, in that order); ReportIssueDialog (mounted once by
+│                    AppShell, so Settings and the error banner share it);
+│                    useReportStore. PGErrorBoundary cannot use the dialog —
+│                    it mounts ABOVE PGDialogHost — so it takes an onReport
+│                    callback wired in main.tsx to fileBugReport
+```
+
+- [ ] **Step 3: Re-run the gate**
+
+Run: `~/Library/pnpm/pnpm vitest run test/docs.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Extend the privacy allow-list's reason**
+
+In `test/privacy.test.ts`, replace the `github.com` entry's reason so the new
+literal is argued for in public — the list exists to force exactly this review
+checkpoint:
+
+```ts
+  [
+    "github.com",
+    "Two rendered strings, no request. (1) Placeholder text in the clone " +
+      "dialog's URL field (`https://github.com/org/repo.git`), so the input " +
+      "shows the shape it wants. (2) The base of the prefilled bug-report URL " +
+      "(`features/report/report.ts`): the app builds an `issues/new?…` link " +
+      "and hands it to `openUrl`, which is the USER'S OWN BROWSER. Nothing " +
+      "here fetches anything, and the report itself never travels in the URL " +
+      "— it goes on the clipboard, and only the user's paste puts it on " +
+      "GitHub.",
+  ],
+```
+
+- [ ] **Step 5: Add the frontend.md section**
+
+In `docs/dev/frontend.md`, add a section covering: the four entry points; the
+clipboard/URL split and why (414 vs `TAIL_CAP_BYTES`); the privacy rules
+(preview shows the exact string, each part opt-out, no network call); and the
+boundary trap (`PGDialogHost` mounts inside `AppShell` mounts inside
+`PGErrorBoundary`, so the boundary takes `onReport` and calls `fileBugReport`).
+Match the file's existing heading depth and prose register.
+
+- [ ] **Step 6: Add the CLAUDE.md convention line**
+
+In `CLAUDE.md`'s "Conventions — the load-bearing rules" list, after the error
+banner bullet:
+
+```markdown
+- **One issue reporter — `features/report/`.** `report.ts` is PURE and
+  `fileReport.ts` owns the side effects, because `PGErrorBoundary` mounts ABOVE
+  `PGDialogHost` and so cannot open the dialog: it takes an `onReport` callback
+  wired in `main.tsx`. The log travels by CLIPBOARD, never in the URL (a
+  GitHub `issues/new?body=` URL 414s far below `TAIL_CAP_BYTES`), the preview
+  shows the exact string that will be copied, and nothing is ever sent — the
+  app writes the clipboard and hands a URL to the user's browser.
+  (`docs/dev/frontend.md`)
+```
+
+- [ ] **Step 7: Read the e2e skill, then add one assertion**
+
+**Read `.claude/skills/e2e-testing/SKILL.md` first** — this is mandatory before
+writing or debugging any e2e spec.
+
+Then, in `e2e/specs/settings.e2e.ts`, add an assertion that navigating to the
+Diagnostics page and clicking the report button opens the dialog and renders a
+non-empty preview. It must **not** click `report-open`: a spec that opens a
+browser is a spec that hangs CI.
+
+- [ ] **Step 8: Typecheck e2e and run the full unit suite**
+
+```bash
+~/Library/pnpm/pnpm exec tsc -p e2e/tsconfig.json --noEmit
+~/Library/pnpm/pnpm tsc --noEmit
+~/Library/pnpm/pnpm test
+```
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/ CLAUDE.md test/privacy.test.ts e2e/specs/settings.e2e.ts
+git commit -m "$(cat <<'EOF'
+docs(report): document the reporter and argue its github.com literal
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Final verification and PR
+
+- [ ] **Step 1: Rebuild the e2e snapshot and run the touched specs**
+
+`src/` changed, so the snapshot is stale and must be rebuilt first. One cold
+container build at a time across ALL worktrees.
+
+```bash
+~/Library/pnpm/pnpm test:e2e:docker build
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/settings.e2e.ts
+```
+
+- [ ] **Step 2: Re-run the full unit suite AFTER the last edit**
+
+```bash
+~/Library/pnpm/pnpm test
+~/Library/pnpm/pnpm tsc --noEmit
+```
+
+A green number only counts for the tree it ran on, so this comes after every
+other change is in. Note the total test count in the PR body.
+
+- [ ] **Step 3: Squash to one Conventional Commit**
+
+The PR squash-merges anyway, so squash locally first for a clean message. Pin
+`main`'s SHA rather than using the moving ref — a concurrent PR landing between
+the fetch and the reset would otherwise be reverted:
+
+```bash
+git fetch origin
+git rev-parse origin/main          # note the SHA
+git reset --soft <that-sha>
+git commit -m "$(cat <<'EOF'
+feat(report): file a GitHub bug report from inside the app
+
+Assembles the environment line and the log tail into one report, shows
+the user every byte of it, copies it and opens a prefilled issue.
+Reachable from the titlebar, the error banner, the error boundary and
+Settings → Diagnostics.
+
+**Why the clipboard:** a GitHub `issues/new?body=` URL answers HTTP 414
+well below the size of a log tail, so the split is by size — bounded
+facts (version, os, arch, git) in the URL, the report on the clipboard,
+with a paste marker in the body. Copy happens strictly before open.
+
+**Why the boundary is different:** PGDialogHost and ReportIssueDialog
+both mount inside AppShell, which mounts inside PGErrorBoundary, so a
+render throw has already unmounted them. The boundary takes an onReport
+callback (like the onReload it already had) and main.tsx wires it to
+fileBugReport, which needs no React tree.
+
+No network call and no new backend command: this reuses
+diagnostics_report and read_log_tail, writes the clipboard, and hands a
+URL to the user's own browser.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/issue-report
+```
+
+Then `gh pr create --title "feat(report): file a GitHub bug report from inside the app" --body-file <path>` — a `--body-file`, never `--body "<prose>"`, which the worktree guard refuses. Before merging, check `gh pr view <N> --json closingIssuesReferences` — a body that merely mentions an issue number still closes it.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: *Why the clipboard* →
+Task 1 (`MAX_URL_LEN`, the budget tests); *Privacy* → Task 4 (preview,
+checkboxes) + Task 7 (allow-list prose); `report.ts` → Task 1; `fileReport.ts` +
+`useReportStore.ts` → Task 3; `ReportIssueDialog.tsx` → Task 4; the four entry
+points → Tasks 5–6; *The error boundary cannot use the dialog* → Task 6;
+*The icon* → Task 2; *Testing* table → the test in each task; *Documentation* →
+Task 7. *Not in scope* needs no task by construction.
+
+**Placeholders.** None: every code step carries the actual code. Two steps
+delegate prose to the implementer (Task 7's frontend.md section, Task 7's e2e
+assertion) with the required content enumerated; both are documentation and
+test-copy rather than logic, and the e2e one is gated behind reading the
+project's e2e skill, which is the house rule.
+
+**Type consistency.** `ReportParts` (Task 1) is consumed by `copyReport` /
+`copyAndOpenIssue` (Task 3) and spread in Task 4's `parts` — same six fields
+throughout. `ReportSources` (Task 3) has four fields and is spread into
+`copyAndOpenIssue` alongside `summary` + the two `include*` flags, which is
+exactly `ReportParts & { summary }`. `openReport(seed?)` is called with no
+argument (titlebar, Settings) and with one (banner, boundary) — the default
+`""` covers both. `onReport` is `() => void` on the banner and
+`(error: Error) => void` on the boundary; the difference is deliberate and
+noted in both places.

--- a/docs/superpowers/specs/2026-09-07-issue-report-spec.md
+++ b/docs/superpowers/specs/2026-09-07-issue-report-spec.md
@@ -1,0 +1,304 @@
+# Reporting a bug from inside the app
+
+Status: approved, ready for an implementation plan.
+Date: 2026-09-07.
+
+## The problem
+
+The app writes a good log and, since #274, can even tell you where it is. What it
+cannot do is help you *report* anything. Filing a bug today means:
+
+1. Notice something broke.
+2. Know that Settings → Backup & diagnostics exists, and go there.
+3. Press *Copy last 500 lines*.
+4. Know the project lives on GitHub, find the repository, find *New issue*.
+5. Fill in the Environment section by hand — OS, version, git version — from
+   facts the app already printed into the log you just copied.
+
+Steps 2 and 4 are the ones that lose reports. A user who hits a render throw
+sees the error boundary's *"This is a bug in platypusgit"* — a screen that names
+the problem correctly and then offers nothing but *Reload*. The evidence is one
+click away and the issue tracker is unmentioned.
+
+The log itself is the other half of the problem. It is the only artifact that
+makes a report diagnosable — #146 was diagnosed *and mis-diagnosed* from one —
+and it is exactly the thing a reporter is least likely to attach unprompted.
+
+## What we are building
+
+A **Report an issue** dialog that assembles the report for you, shows you every
+byte of it, puts it on your clipboard and opens a prefilled GitHub issue.
+
+Reachable from four places. Two of them are where you already are when
+something breaks:
+
+- the titlebar (a `bug` icon, always there),
+- the error banner (`PGErrorBanner`) — "report this", seeded with the error,
+- the error boundary, after a render throw,
+- Settings → Backup & diagnostics, beside the log rows it belongs with.
+
+Three decisions were made up front and are not open in the plan:
+
+1. **The log travels by clipboard, not in the URL.** See *Why the clipboard*.
+2. **Bug reports only.** Feature requests get no diagnostics and no log, so they
+   share nothing with this flow but a hostname. `feature_request.md` stays a
+   thing you open in a browser.
+3. **No command-palette entry.** Four entry points is already the ceiling; the
+   titlebar button covers "reachable from anywhere".
+
+## Why the clipboard
+
+A GitHub `issues/new?body=…` URL is the obvious place to put the report, and it
+does not fit. GitHub answers a long enough query string with **HTTP 414**, and
+the practical ceiling is around 8 KB of URL. `read_log_tail` returns up to 500
+lines capped at `TAIL_CAP_BYTES` — orders of magnitude past that. A design that
+puts the log in the URL works in testing, where the log is short, and fails on
+exactly the machine that has been running long enough to have a bug worth
+reporting.
+
+So the split is by size:
+
+- **In the URL** (small, bounded): the title, the `bug` label, the body skeleton,
+  and the Environment section prefilled with version / OS / arch / git version.
+- **On the clipboard** (unbounded): the full report, including the log tail.
+
+The body carries a paste marker under *Additional context* so the last step is
+obvious:
+
+```
+<!-- Paste the diagnostics report from your clipboard here (Cmd/Ctrl+V) -->
+```
+
+The dialog copies *before* it opens the browser, so by the time GitHub has
+loaded, the clipboard already holds what the marker asks for.
+
+## Privacy
+
+This feature makes **no network request**. It writes text to the clipboard and
+hands a URL to `openUrl`, which is the user's own browser. Nothing is uploaded,
+nothing is phoned home, and the "no telemetry, no account" promise is untouched
+— `test/privacy.test.ts` and `src-tauri/tests/no_telemetry.rs` both still hold.
+
+The report is nonetheless the most revealing text this app has ever assembled in
+one place: a log tail carries repository paths, branch names, remote URLs and
+hook output. Two rules follow, and they are the reason the dialog exists at all
+rather than a one-click "report" button:
+
+- **Nothing leaves without being shown first.** The dialog renders the exact
+  string that will be copied, scrollable, in full. Not a summary of it.
+- **Each part is opt-out.** Environment and log tail are independent checkboxes.
+  Unchecking the log gives a report with no paths in it.
+
+`github.com` is already on `test/privacy.test.ts`'s `ALLOWED_HOSTS` for the
+clone dialog's placeholder. Its stated reason gains the issue URL: that prose is
+the review checkpoint the list exists to force, so it gets updated even though
+the assertion would pass regardless.
+
+## Architecture
+
+A new feature directory, `src/features/report/`, with the logic separated from
+the surface so that the one entry point that *cannot* use the surface still gets
+the logic.
+
+```
+src/features/report/
+├── report.ts               PURE — assembles the text and the URL
+├── fileReport.ts           the side effects: gather → copy → open
+├── ReportIssueDialog.tsx   the PGModal
+└── useReportStore.ts       open/close, plus the seed
+```
+
+`report.ts` is pure and `fileReport.ts` owns every side effect, because the
+error boundary needs the second without being able to mount the third.
+
+### `report.ts` — pure
+
+No React, no IPC, no clipboard. Every branch of it is reachable from a unit test
+with no jsdom and no mocks.
+
+```ts
+export interface ReportParts {
+  version: string;
+  environment: string;
+  logPath: string;
+  logTail: string | null;
+  includeEnvironment: boolean;
+  includeLog: boolean;
+}
+
+/** The pasteable block. */
+export function buildReport(parts: ReportParts): string;
+
+/** The prefilled `issues/new` URL. */
+export function issueUrl(opts: {
+  summary: string;
+  version: string;
+  environment: string;
+}): string;
+```
+
+`buildReport` produces, in order: the `platypusgit <version>` line, the
+`host os=… arch=… git=…` line, the log path, then the log tail under a
+`── log (last 500 lines) ──` rule. Sections the caller excluded are absent
+entirely rather than present-and-empty.
+
+**This becomes the single report format.** `features/settings/pages/backup.tsx`
+already assembles a header by hand for its *Copy last 500 lines* button; that
+call site moves onto `buildReport`, so the two surfaces cannot drift. This is
+the same "one composition surface" rule the commit message box follows.
+
+`issueUrl` derives the title from the summary's first line, prefixed `[bug] ` to
+match `bug_report.md`'s front matter. It passes `title`, `labels=bug` and `body`
+and **deliberately not `template=`**: given both, `template` and `body` contend
+for the same field, and which one wins is GitHub's business rather than
+something this app should depend on. The body is written here instead, mirroring
+the template's headings.
+
+It also enforces a **URL budget**. `MAX_URL_LEN` (6000, comfortably under the
+8 KB ceiling) bounds the finished URL; if the user's summary pushes past it, the
+summary is truncated with an ellipsis and the skeleton survives. A user pasting
+a wall of text into the summary box must not produce a 414.
+
+### `useReportStore.ts`
+
+A three-field Zustand store — `open: boolean`, `seed: string`, plus `openReport(seed?)`
+and `closeReport()`. App-level rather than per-repo, so it stays out of
+`RepoSlice`/`emptySlice`: those exist for state that must be dropped on a tab
+switch, and "is the report dialog open" is not about a repository at all. The
+summary text the user types is the dialog's own component state, which survives
+a tab switch for the same reason — the dialog is mounted by `AppShell`, above
+the per-repo screens.
+
+### `ReportIssueDialog.tsx`
+
+A `PGModal`. Mounted **once**, in `AppShell`, beside `PGDialogHost` — Settings
+is a screen inside `AppShell`, so one mount serves three of the four entry
+points. Escape is wired through `app.closeOverlay` in the keymap, never a local
+capture-phase listener (issue #47's rule).
+
+On open it calls `diagnosticsReport()`, and `readLogTail()` only while the log
+checkbox is checked. Layout:
+
+```
+┌ Report an issue ──────────────────────────┐
+│ What went wrong?                          │
+│ ┌───────────────────────────────────────┐ │
+│ │ Clicking Fetch hangs forever…         │ │
+│ └───────────────────────────────────────┘ │
+│ ☑ Include environment   ☑ Include log tail│
+│ This will be copied to your clipboard:    │
+│ ┌───────────────────────────────────────┐ │
+│ │ platypusgit 0.8.0                     │ │
+│ │ host os=macos arch=aarch64 git=2.49.0 │ │
+│ │ ── log (last 500 lines) ──            │ │
+│ │ 2026-09-07 11:02 INFO  open_repo …    │ │
+│ └───────────────────────────────────────┘ │
+│      [Copy report only]  [Copy & open GH] │
+└───────────────────────────────────────────┘
+```
+
+The preview is the report, `pre-wrap`, in the mono font, scrolling in its own
+box. `[Copy report only]` exists for someone who would rather file the issue by
+hand, or paste it into a chat — and it is the honest fallback if the browser
+never opens.
+
+Failures use `pgFlash` with `appErrorMessage`, matching the diagnostics buttons
+this dialog sits beside. A log that cannot be read is not fatal: the dialog
+reports it and still assembles the rest, because an environment-only report is
+worth more than no report.
+
+### Entry points
+
+| Where | What it looks like | Seed |
+|---|---|---|
+| `AppTitlebar` (`AppShell.tsx`) | `PGButton` `icon="bug"`, in `rightSlot` next to `UpdateChip` | none |
+| `PGErrorBanner` | a `report` action beside `dismiss` | `errorBannerText(error)` |
+| `PGErrorBoundary` | a `Report this bug` button beside `Reload`, via a new optional `onReport` prop wired in `main.tsx` | `error.message` |
+| Settings → Diagnostics | a `diagnostics.report` row | none |
+
+**`PGErrorBanner` gets an optional `onReport` prop**, passed at both call sites
+(`AppShell` and `screens/Reflog.tsx`). A prop rather than the banner importing
+`useReportStore` directly: `src/design/` is the design system and does not reach
+into `features/`. The prop being optional keeps the banner usable by a future
+surface with no report flow, exactly as `compact` is.
+
+### The error boundary cannot use the dialog
+
+`PGDialogHost` is mounted inside `AppShell` (`AppShell.tsx:479`), and `AppShell`
+is inside `PGErrorBoundary` (`main.tsx`). After a render throw, React has
+unmounted the whole tree below the boundary: there is no dialog host, no
+`ReportIssueDialog`, and no subscriber to `useReportStore`. Calling
+`openReport()` from the boundary would set a flag nothing reads and appear to do
+nothing at all.
+
+So the boundary does the terminal action itself, with no React tree involved
+beyond its own fallback. It must not, however, *import* the machinery: nothing
+in `src/design/` imports `@/lib/tauri` today, and the boundary is not the place
+to start — a design-system component that performs IPC is a design system that
+cannot be tested without a bridge.
+
+The boundary already solves this problem once. It takes an optional
+`onReload?: () => void` so its owner can override the reload; it gains an
+optional `onReport?: (error: Error) => void` on exactly the same terms, and
+renders the report button only when given one. `main.tsx` — which already
+imports from `features/` — wires it to `fileBugReport(err.message)`.
+
+`fileReport.ts` therefore holds two exported functions, and the dialog and the
+boundary share the second:
+
+```ts
+/** Read the version, the environment line and (optionally) the log tail. */
+export async function gatherReport(includeLog: boolean): Promise<ReportSources>;
+
+/** Copy the report, then open the issue. In that order — see Why the clipboard. */
+export async function copyAndOpenIssue(
+  parts: ReportParts & { summary: string },
+): Promise<void>;
+
+/** gatherReport + copyAndOpenIssue, for a caller with no UI to offer. */
+export async function fileBugReport(summary: string): Promise<void>;
+```
+
+This is a real regression risk, not a theoretical one, so it gets its own test
+that mounts the boundary with **no** `PGDialogHost` present.
+
+### The icon
+
+`Bug` joins `src/design/icons.tsx` as `"bug"`, in both the lucide import and the
+`IconName` union. That file is the only one allowed to import `lucide-react`, and
+`test/iconSet.test.ts` fails the build both for a stray import and for a call-site
+literal the union does not declare.
+
+## Not in scope
+
+- **No attachment upload.** GitHub's API can attach files; doing so needs a token
+  and turns a rendered URL into a network call. The clipboard is the whole point.
+- **No Store gating.** `UpdateCapability` gates *update* surfaces, because Store
+  policy 10.2.5 makes notifying about an update the violation. A link to an issue
+  tracker is not an update surface and ships in every channel.
+- **No crash auto-reporting.** Nothing is ever sent without the user pressing a
+  button; that is the privacy story, and an automatic report would be telemetry
+  under a friendlier name.
+- **No feature-request path.** Decision 2 above.
+
+## Testing
+
+| Layer | File | What it pins |
+|---|---|---|
+| unit (pure) | `src/features/report/report.test.ts` | body mirrors the template's headings; the paste marker is present; `title` is `[bug] ` + first line; percent-encoding; each `include*` flag adds/removes exactly its section; the URL budget truncates the summary and never exceeds `MAX_URL_LEN` |
+| component | `src/features/report/ReportIssueDialog.test.tsx` | preview tracks the checkboxes; `[Copy report only]` writes the clipboard and does not open a URL; `[Copy & open GitHub]` does both, in that order; a failing `readLogTail` still yields an environment report |
+| component | `src/design/error-boundary.test.tsx` (extended) | the report button copies and opens **with no `PGDialogHost` mounted** |
+| component | `src/screens/settings.index.test.tsx` (existing gate) | the new Diagnostics row is in `meta.cards[].rows` |
+| guard | `test/iconSet.test.ts` (existing gate) | `"bug"` is declared, and lucide is still imported from one file |
+| guard | `test/docs.test.ts` (existing gate) | `features/report` is named in `docs/dev/architecture.md` |
+| e2e | `e2e/specs/settings.e2e.ts` (extended) | the dialog opens from Settings and renders a preview. It does **not** click through to GitHub — a spec must never open a browser. |
+
+## Documentation
+
+- `docs/dev/architecture.md` — `features/report/` in the frontend tree. Required:
+  `test/docs.test.ts` fails the build without it.
+- `docs/dev/frontend.md` — the dialog, the four entry points, the clipboard split
+  and the reason the error boundary bypasses the store.
+- `CLAUDE.md` — one convention line, because the boundary trap is the kind of
+  thing that gets "simplified" back into a bug: the report logic stays pure and
+  the boundary calls it directly.

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -319,4 +319,61 @@ describe("settings", () => {
     // …and a non-matching row on the page we WERE on is filtered out.
     await expect($('[data-setting-id="diff.context"]')).not.toBeExisting();
   });
+
+  /**
+   * The report dialog against the real webview.
+   *
+   * What only a real run proves: the diagnostics commands actually answer on
+   * a real build (`diagnostics_report` resolves the per-platform log dir, and
+   * `read_log_tail` reads a file that the LOGGER, not the test, created), and
+   * the preview therefore renders something rather than sitting on "Reading
+   * diagnostics…" forever. The unit tests mock both.
+   *
+   * It deliberately stops before `report-open`: that hands a URL to the OS
+   * browser, which under xvfb means either a hung `xdg-open` or a browser
+   * nobody closes. Copy-and-open is covered by the component test.
+   */
+  it("assembles a bug report from the real diagnostics", async () => {
+    await openSettings("advanced.backup");
+    await $('[data-testid="settings-report-issue"]').click();
+
+    const preview = $('[data-testid="report-preview"]');
+    await preview.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "report dialog never rendered a preview",
+    });
+    // The version line is the one part no opt-out removes, so it is the
+    // signal that the report was ASSEMBLED rather than merely mounted —
+    // "Reading diagnostics…" is what an unresolved `diagnostics_report`
+    // leaves on screen, and it satisfies "displayed" just as well.
+    await browser.waitUntil(
+      async () => (await preview.getText()).includes("platypusgit "),
+      {
+        timeout: 10_000,
+        timeoutMsg: "preview never carried the version line",
+      },
+    );
+    const text = await preview.getText();
+    // The startup environment line, written by the real backend.
+    expect(text).toContain("host os=");
+    expect(text).toContain("arch=");
+
+    // Both opt-outs are wired to the real preview, and the version survives.
+    await $('[data-testid="report-include-env"]').click();
+    await browser.waitUntil(
+      async () => !(await preview.getText()).includes("host os="),
+      {
+        timeout: 10_000,
+        timeoutMsg: "unchecking the environment never changed the preview",
+      },
+    );
+    expect(await preview.getText()).toContain("platypusgit ");
+
+    await $('[data-testid="report-cancel"]').click();
+    await $('[data-testid="report-dialog"]').waitForExist({
+      reverse: true,
+      timeout: 10_000,
+      timeoutMsg: "report dialog never closed",
+    });
+  });
 });

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -358,15 +358,43 @@ describe("settings", () => {
     expect(text).toContain("host os=");
     expect(text).toContain("arch=");
 
-    // Both opt-outs are wired to the real preview, and the version survives.
+    // The log tail is present, and it is the real file: the logger's own
+    // startup lines are in it, which no mock produces.
+    expect(text).toContain("── log tail ──");
+    expect(text).toContain("platypusgit.log");
+
+    /*
+     * Now both opt-outs, and the ORDER matters for a reason worth writing
+     * down: the log tail CONTAINS the environment line. `environment_line`
+     * writes `host os=… arch=… git=…` into the log at startup — that is the
+     * whole reason `read_log_tail` and the report header coexist (#274) — so
+     * "the environment is excluded" cannot be checked by the absence of
+     * `host os=` while the log is still included. Measured: unchecking the
+     * environment took the preview from 2762 to 2700 characters and left a
+     * `host os=` line from the log behind.
+     *
+     * So the log comes off first, and only then is `host os=` a signal.
+     */
+    await $('[data-testid="report-include-log"]').click();
+    await browser.waitUntil(
+      async () => !(await preview.getText()).includes("── log tail ──"),
+      {
+        timeout: 10_000,
+        timeoutMsg: "unchecking the log never removed it from the preview",
+      },
+    );
+    // The path goes with it — that is what makes this the privacy control.
+    expect(await preview.getText()).not.toContain("platypusgit.log");
+
     await $('[data-testid="report-include-env"]').click();
     await browser.waitUntil(
       async () => !(await preview.getText()).includes("host os="),
       {
         timeout: 10_000,
-        timeoutMsg: "unchecking the environment never changed the preview",
+        timeoutMsg: "unchecking the environment never removed it",
       },
     );
+    // Down to the one line no opt-out removes.
     expect(await preview.getText()).toContain("platypusgit ");
 
     await $('[data-testid="report-cancel"]').click();

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -45,6 +45,7 @@ import { ActivityStatus } from "@/features/repo/ActivityStatus";
 import { LoadingStatus } from "@/features/repo/LoadingStatus";
 import { primaryActivity } from "@/features/repo/repoActivity";
 import type { NetProgress, RebaseProgress } from "@/lib/types";
+import { errorBannerText } from "@/lib/errors";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
@@ -61,6 +62,8 @@ import {
   CheatSheet,
   type ActionId,
 } from "@/features/keymap";
+import { ReportIssueDialog } from "@/features/report/ReportIssueDialog";
+import { useReportStore } from "@/features/report/useReportStore";
 import { CommandPalette } from "@/features/palette/CommandPalette";
 import { TerminalPanel } from "@/features/terminal";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -488,11 +491,27 @@ export function AppShell() {
           its three call sites — a context-menu item builder and a palette step —
           are not React components. Renders nothing until one opens it. */}
       <CreateTagDialog />
+      {/* Report an issue (features/report). Mounted HERE, once: Settings is a
+          screen below this point, so this single mount serves the titlebar
+          button, the error banner and the Settings row alike. The one entry
+          point it cannot serve is PGErrorBoundary, which is ABOVE it — that
+          one calls fileBugReport directly, from main.tsx. */}
+      <ReportIssueDialog />
       {/* One banner, shared with Reflog (#212). It leads with written prose or
           with nothing — never with the enum's own spelling — and preserves the
           newlines in git's multi-line advice. The remediation the two terse
           variants need travels with the text, in `errorBannerText`. */}
-      {error && <PGErrorBanner error={error} onDismiss={clearError} />}
+      {error && (
+        <PGErrorBanner
+          error={error}
+          onDismiss={clearError}
+          // Seeded with the text the user is already reading, so the report
+          // starts from the error rather than from a blank box.
+          onReport={() =>
+            useReportStore.getState().openReport(errorBannerText(error))
+          }
+        />
+      )}
       {/* Below the banner (which is transient) and above the screens (which
           all need to know): the standing "a merge/rebase is open" signal, and
           the only route to the resolver now that the Conflicts tab is gone. */}
@@ -736,6 +755,20 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
         dirty={dirty}
         rightSlot={
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            {/* Report an issue (features/report). Outside the `repo &&` guard
+                on purpose: "the app is broken" does not require a repository
+                to be open, and the Welcome screen is a place bugs happen too.
+                `getState()` rather than a hook, for the reason `onFetch`
+                below gives — this titlebar is not re-subscribing. */}
+            <PGButton
+              size="sm"
+              variant="ghost"
+              icon="bug"
+              title="Report an issue"
+              aria-label="Report an issue"
+              onClick={() => useReportStore.getState().openReport()}
+              data-testid="titlebar-report"
+            />
             <UpdateChip />
             {repo && (
               <>

--- a/src/design/error-banner.test.tsx
+++ b/src/design/error-banner.test.tsx
@@ -135,4 +135,29 @@ describe("PGErrorBanner", () => {
     await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(onDismiss).toHaveBeenCalledOnce();
   });
+
+  it("offers no report action without a handler", () => {
+    // Optional on the same terms as `compact`: a surface with no report flow
+    // must not grow a button that does nothing.
+    render(
+      <PGErrorBanner
+        error={{ kind: "Network", message: "could not resolve host" }}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("banner-report")).toBeNull();
+  });
+
+  it("reports, when given somewhere to report to", async () => {
+    const onReport = vi.fn();
+    render(
+      <PGErrorBanner
+        error={{ kind: "Network", message: "could not resolve host" }}
+        onDismiss={vi.fn()}
+        onReport={onReport}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("banner-report"));
+    expect(onReport).toHaveBeenCalledOnce();
+  });
 });

--- a/src/design/error-banner.tsx
+++ b/src/design/error-banner.tsx
@@ -26,10 +26,22 @@ import {
 export function PGErrorBanner({
   error,
   onDismiss,
+  onReport,
   compact = false,
 }: {
   error: AppError;
   onDismiss: () => void;
+  /**
+   * Offers "report" beside "dismiss" — the entry point that catches someone at
+   * the moment they hit the bug (`features/report`).
+   *
+   * A CALLBACK rather than this component reaching for `useReportStore`:
+   * `src/design/` is the design system and performs no IPC — nothing here
+   * imports `@/lib/tauri`, and the report flow does. Optional on the same
+   * terms as `compact`, so a surface with no report flow does not grow a
+   * button that does nothing.
+   */
+  onReport?: () => void;
   /** Tighter padding for a banner inside a screen rather than under the tab
    *  bar. The only thing the two call sites ever disagreed about. */
   compact?: boolean;
@@ -76,6 +88,23 @@ export function PGErrorBanner({
       >
         {errorBannerText(error)}
       </span>
+      {onReport && (
+        <button
+          onClick={onReport}
+          data-testid="banner-report"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "inherit",
+            cursor: "pointer",
+            fontSize: "var(--fs-11)",
+            textDecoration: "underline",
+            whiteSpace: "nowrap",
+          }}
+        >
+          report
+        </button>
+      )}
       <button
         onClick={onDismiss}
         style={{

--- a/src/design/error-boundary.test.tsx
+++ b/src/design/error-boundary.test.tsx
@@ -77,4 +77,52 @@ describe("PGErrorBoundary", () => {
 
     expect(onReload).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * The report path here CANNOT go through the dialog, and this is the test
+   * that keeps it that way.
+   *
+   * `PGDialogHost` and `ReportIssueDialog` are both mounted by `AppShell`,
+   * which is mounted inside this boundary (`main.tsx`). By the time this
+   * fallback renders, React has unmounted that entire subtree — so there is no
+   * dialog host, no dialog, and nothing subscribed to `useReportStore`.
+   * `openReport()` from here would set a flag nobody reads and the button
+   * would appear to do nothing at all.
+   *
+   * Hence a callback, and hence a render with NO host of any kind mounted:
+   * that absence is the boundary's real world, not a simplification of it.
+   */
+  it("reports the throw with no dialog host mounted anywhere", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onReport = vi.fn();
+
+    render(
+      <PGErrorBoundary onReport={onReport}>
+        <Boom />
+      </PGErrorBoundary>,
+    );
+    screen.getByTestId("boundary-report").click();
+
+    expect(onReport).toHaveBeenCalledTimes(1);
+    // Handed the error itself, so the report is seeded with the throw rather
+    // than starting from a blank box.
+    const seen = onReport.mock.calls[0]![0] as Error;
+    expect(seen).toBeInstanceOf(Error);
+    expect(seen.message).toContain("Rendered more hooks");
+  });
+
+  it("offers no report button when no handler is given", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <PGErrorBoundary>
+        <Boom />
+      </PGErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("app-error-boundary")).toBeInTheDocument();
+    expect(screen.queryByTestId("boundary-report")).toBeNull();
+    // Reload is unconditional and must survive the new sibling.
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
 });

--- a/src/design/error-boundary.tsx
+++ b/src/design/error-boundary.tsx
@@ -19,6 +19,23 @@ interface Props {
   children: React.ReactNode;
   /** Overrides the reload action — the merge window closes instead. */
   onReload?: () => void;
+  /**
+   * Files a bug report for the throw (`features/report`). Optional, and a
+   * CALLBACK rather than work done here, for two independent reasons:
+   *
+   *   - Nothing in `src/design/` performs IPC, and this is not the place to
+   *     start: a design-system component that reaches for `@/lib/tauri` cannot
+   *     be rendered in a test without a bridge.
+   *   - This boundary cannot use the report DIALOG under any circumstances.
+   *     `PGDialogHost` and `ReportIssueDialog` are both mounted by `AppShell`,
+   *     which is mounted inside this boundary (`main.tsx`), so by the time
+   *     this fallback renders React has unmounted them. Calling `openReport()`
+   *     from here would set a flag nobody reads.
+   *
+   * `main.tsx` wires it to `features/report/fileReport.ts::fileBugReport`,
+   * which gathers, copies and opens in one call with no React tree involved.
+   */
+  onReport?: (error: Error) => void;
 }
 
 interface State {
@@ -88,23 +105,42 @@ export class PGErrorBoundary extends React.Component<Props, State> {
         >
           {error.message}
         </pre>
-        <button
-          onClick={() => {
-            if (this.props.onReload) this.props.onReload();
-            else window.location.reload();
-          }}
-          style={{
-            background: "var(--accent)",
-            color: "var(--bg-0)",
-            border: "none",
-            borderRadius: 4,
-            padding: "6px 14px",
-            cursor: "pointer",
-            fontSize: "var(--fs-12)",
-          }}
-        >
-          Reload
-        </button>
+        <div style={{ display: "flex", gap: 8 }}>
+          {this.props.onReport && (
+            <button
+              data-testid="boundary-report"
+              onClick={() => this.props.onReport?.(error)}
+              style={{
+                background: "var(--bg-2)",
+                color: "var(--fg-0)",
+                border: "1px solid var(--border-1)",
+                borderRadius: 4,
+                padding: "6px 14px",
+                cursor: "pointer",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              Report this bug
+            </button>
+          )}
+          <button
+            onClick={() => {
+              if (this.props.onReload) this.props.onReload();
+              else window.location.reload();
+            }}
+            style={{
+              background: "var(--accent)",
+              color: "var(--bg-0)",
+              border: "none",
+              borderRadius: 4,
+              padding: "6px 14px",
+              cursor: "pointer",
+              fontSize: "var(--fs-12)",
+            }}
+          >
+            Reload
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -28,6 +28,7 @@ import {
   ArrowUpFromLine,
   Bell,
   BookMarked,
+  Bug,
   Check,
   ChevronDown,
   ChevronLeft,
@@ -115,7 +116,7 @@ export type IconName =
   | "chevronRight" | "chevronDown" | "chevronUp" | "chevronLeft"
   | "search" | "settings" | "filter" | "sort" | "more"
   | "pull" | "push" | "fetch" | "sync" | "refresh" | "stash" | "rebase"
-  | "dot" | "circle" | "warn" | "error" | "info" | "clock"
+  | "dot" | "circle" | "warn" | "error" | "info" | "clock" | "bug"
   | "user" | "eye" | "terminal" | "history" | "kbd"
   | "download" | "upload" | "link" | "lock"
   | "play" | "pause" | "star" | "copy" | "external" | "pin"
@@ -192,6 +193,7 @@ const ICONS: Record<IconName, LucideIcon> = {
   error: CircleX,
   info: Info,
   clock: Clock,
+  bug: Bug,
 
   // ── Chrome ──────────────────────────────────────────────────────────────
   user: User,

--- a/src/features/keymap/actions.test.ts
+++ b/src/features/keymap/actions.test.ts
@@ -5,6 +5,7 @@ import { useCreateStore } from "@/features/create/useCreateStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
 import { useOverlayStore } from "./useOverlayStore";
+import { useReportStore } from "@/features/report/useReportStore";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { newTab } from "@/features/repo/tabs";
@@ -93,6 +94,35 @@ describe("default runners", () => {
     expect(useOverlayStore.getState().cheatSheetOpen).toBe(false);
     // Nothing left to close — the runner must decline so Escape falls through.
     expect(ACTIONS["app.closeOverlay"].run?.()).toBe(false);
+  });
+
+  it("app.closeOverlay closes the report dialog, but not before the credential prompt", () => {
+    useOverlayStore.setState({ cheatSheetOpen: false });
+    useReportStore.setState({ open: true, seed: "" });
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+    expect(useReportStore.getState().open).toBe(false);
+    // ...and declines once there is nothing left to close.
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(false);
+
+    // The precedence is the point of putting this in the runner's chain rather
+    // than registering a handler from the component: a registered handler runs
+    // BEFORE the default runner, so it would close the report dialog out from
+    // under a credential prompt stacked above it — the failure the auth branch
+    // is ordered to prevent. With both open, the prompt goes first and the
+    // report dialog is still there.
+    useReportStore.setState({ open: true, seed: "" });
+    // A real `AuthChallengeRequest` through `raise`, not a cast: the runner
+    // calls `dismiss()`, which fires `onDismiss`, so a half-built object would
+    // pass this test by throwing somewhere else.
+    useAuthStore.getState().raise({
+      host: "github.com",
+      kind: "Https",
+      retry: async () => {},
+      onDismiss: () => {},
+    });
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+    expect(useReportStore.getState().open).toBe(true);
+    useReportStore.setState({ open: false, seed: "" });
   });
 
   it("app.closeOverlay also closes an open create dialog (clone or init)", () => {

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -12,6 +12,7 @@
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useCreateTagStore } from "@/features/tags/useCreateTagStore";
+import { useReportStore } from "@/features/report/useReportStore";
 import { useForgeStore } from "@/features/forge/useForgeStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
@@ -333,6 +334,17 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
       // Same stacking layer (PGModal), same rule (#132).
       if (useCreateTagStore.getState().target) {
         useCreateTagStore.getState().close();
+        return true;
+      }
+      // Same again, for the report dialog (features/report). It belongs in
+      // THIS chain rather than registering its own `app.closeOverlay` handler
+      // from the component: a registered handler runs BEFORE this default
+      // runner (see useKeymapStore's dispatch), so it would take Escape ahead
+      // of the credential prompt above — closing the report dialog out from
+      // under a prompt some other op is still waiting on, which is the exact
+      // failure the auth branch above is ordered to prevent.
+      if (useReportStore.getState().open) {
+        useReportStore.getState().closeReport();
         return true;
       }
       if (useUpdateStore.getState().panelOpen) {

--- a/src/features/report/ReportIssueDialog.test.tsx
+++ b/src/features/report/ReportIssueDialog.test.tsx
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+import { ReportIssueDialog } from "./ReportIssueDialog";
+import { useReportStore } from "./useReportStore";
+
+/**
+ * `fireEvent`, not `userEvent`, and deliberately so.
+ *
+ * `userEvent.setup()` REPLACES `navigator.clipboard` with its own stub in
+ * order to implement copy/paste, which silently detaches any spy installed
+ * before it — the writes land in userEvent's internal clipboard and a
+ * `writeText` assertion sees nothing at all. Every clipboard assertion in this
+ * file would be vacuous. `fireEvent` is also what `design/dialog.test.tsx`
+ * uses, so this is the house pattern either way.
+ */
+
+const DIAG = {
+  logPath: "/tmp/platypusgit.log",
+  logExists: true,
+  logSizeBytes: 4096,
+  environment: "host os=linux arch=x86_64 git=2.43.0",
+  version: "0.8.0",
+};
+
+let written: string[] = [];
+
+beforeEach(() => {
+  written = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn(async (t: string) => {
+        written.push(t);
+      }),
+    },
+  });
+  mockInvoke("diagnostics_report", () => DIAG);
+  mockInvoke("read_log_tail", () => "11:02 WARN invoke fetch slow: 1400ms");
+  mockInvoke("open_url", () => undefined);
+  useReportStore.setState({ open: false, seed: "" });
+});
+
+function openDialog(seed = "") {
+  useReportStore.getState().openReport(seed);
+}
+
+/** The preview only exists once `diagnostics_report` has resolved. */
+async function readyPreview() {
+  await waitFor(() =>
+    expect(screen.getByTestId("report-preview")).toHaveTextContent(
+      "platypusgit 0.8.0",
+    ),
+  );
+  return screen.getByTestId("report-preview");
+}
+
+describe("ReportIssueDialog", () => {
+  it("renders nothing while closed", () => {
+    render(<ReportIssueDialog />);
+    expect(screen.queryByTestId("report-dialog")).toBeNull();
+  });
+
+  it("shows the exact text that will be copied", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    // Nothing leaves this app without being shown first — the preview is the
+    // report itself, not a summary of it.
+    const preview = await readyPreview();
+    expect(preview).toHaveTextContent("invoke fetch slow: 1400ms");
+    expect(preview).toHaveTextContent("host os=linux arch=x86_64 git=2.43.0");
+    expect(preview).toHaveTextContent("/tmp/platypusgit.log");
+  });
+
+  it("seeds the summary from the caller", async () => {
+    render(<ReportIssueDialog />);
+    openDialog("Network: could not resolve host");
+    await waitFor(() =>
+      expect(screen.getByTestId("report-summary")).toHaveValue(
+        "Network: could not resolve host",
+      ),
+    );
+  });
+
+  it("drops the log from the preview when the box is unchecked", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.click(screen.getByTestId("report-include-log"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+        "invoke fetch slow",
+      ),
+    );
+    // Unchecking the log is the privacy control: it is what removes the paths.
+    expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+      "/tmp/platypusgit.log",
+    );
+  });
+
+  it("drops the environment from the preview when unchecked", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.click(screen.getByTestId("report-include-env"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+        "host os=linux",
+      ),
+    );
+    // The build survives every opt-out.
+    expect(screen.getByTestId("report-preview")).toHaveTextContent(
+      "platypusgit 0.8.0",
+    );
+  });
+
+  it("copies what the preview shows, not the unfiltered report", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.click(screen.getByTestId("report-include-log"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-preview")).not.toHaveTextContent(
+        "invoke fetch slow",
+      ),
+    );
+    fireEvent.click(screen.getByTestId("report-copy"));
+    await waitFor(() => expect(written.length).toBe(1));
+    // An opt-out that filters only the preview would be worse than no opt-out
+    // at all: the user would believe they had removed the paths.
+    expect(written[0]).not.toContain("invoke fetch slow");
+    expect(written[0]).not.toContain("/tmp/platypusgit.log");
+    expect(written[0]).toContain("platypusgit 0.8.0");
+  });
+
+  it("copies without opening the browser on Copy report", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.click(screen.getByTestId("report-copy"));
+    await waitFor(() => expect(written.length).toBe(1));
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("invoke fetch slow");
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+    // Copy-only leaves the dialog open: the user is mid-flow, filing by hand.
+    expect(screen.getByTestId("report-dialog")).toBeTruthy();
+  });
+
+  it("copies and opens the prefilled issue on Copy & open", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.change(screen.getByTestId("report-summary"), {
+      target: { value: "Fetch hangs" },
+    });
+    fireEvent.click(screen.getByTestId("report-open"));
+    await waitFor(() =>
+      expect(getInvokeCalls().map((c) => c.cmd)).toContain("open_url"),
+    );
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args
+      .url as string;
+    const params = new URL(url).searchParams;
+    expect(params.get("labels")).toBe("bug");
+    expect(params.get("title")).toBe("[bug] Fetch hangs");
+    expect(params.get("body")).toContain("Fetch hangs");
+    // The log rode the clipboard, not the URL.
+    expect(params.get("body")).not.toContain("invoke fetch slow");
+  });
+
+  it("closes after handing the issue to the browser", async () => {
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.click(screen.getByTestId("report-open"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("report-dialog")).toBeNull(),
+    );
+  });
+
+  it("stays open when the copy fails, so nothing typed is lost", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => {
+          throw new Error("denied");
+        }),
+      },
+    });
+    render(<ReportIssueDialog />);
+    openDialog();
+    await readyPreview();
+    fireEvent.change(screen.getByTestId("report-summary"), {
+      target: { value: "typed this" },
+    });
+    fireEvent.click(screen.getByTestId("report-open"));
+    await waitFor(() =>
+      expect(screen.getByTestId("report-open")).toBeEnabled(),
+    );
+    expect(screen.getByTestId("report-dialog")).toBeTruthy();
+    expect(screen.getByTestId("report-summary")).toHaveValue("typed this");
+    // And it did not send the user to a form they cannot fill in.
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+  });
+
+  it("still offers an environment report when the log cannot be read", async () => {
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "no log file at /tmp/x yet" };
+    });
+    render(<ReportIssueDialog />);
+    openDialog();
+    const preview = await readyPreview();
+    expect(preview).toHaveTextContent("host os=linux");
+    // No dangling section header for a log that was never read.
+    expect(preview).not.toHaveTextContent("log tail");
+    expect(screen.getByTestId("report-copy")).toBeEnabled();
+  });
+
+  it("starts a fresh report on each open rather than keeping the last one", async () => {
+    render(<ReportIssueDialog />);
+    openDialog("first error");
+    await waitFor(() =>
+      expect(screen.getByTestId("report-summary")).toHaveValue("first error"),
+    );
+    fireEvent.click(screen.getByTestId("report-cancel"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("report-dialog")).toBeNull(),
+    );
+
+    openDialog("second error");
+    await waitFor(() =>
+      expect(screen.getByTestId("report-summary")).toHaveValue("second error"),
+    );
+  });
+});

--- a/src/features/report/ReportIssueDialog.tsx
+++ b/src/features/report/ReportIssueDialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * The Report an issue dialog.
+ *
+ * Mounted ONCE, by `AppShell`, beside `PGDialogHost`. Settings is a screen
+ * inside `AppShell`, so that single mount serves three of the four entry points
+ * (titlebar, error banner, Settings). The fourth — `PGErrorBoundary` — sits
+ * ABOVE this mount and cannot use it at all; see `fileReport.ts::fileBugReport`.
+ *
+ * The preview is the point. This is the most revealing text the app ever
+ * assembles in one place — a log tail carries repository paths, branch names,
+ * remote URLs and hook output — so the dialog renders the exact string that
+ * will be copied, in full, and each part is independently opt-out. Nothing is
+ * ever sent anywhere: the clipboard is written and a URL is handed to the
+ * user's own browser.
+ */
+import React from "react";
+
+import { PGButton, PGCheckbox, PGModal, pgFlash } from "@/design";
+import { appErrorMessage } from "@/lib/errors";
+import { useAction } from "@/features/keymap/useAction";
+
+import { buildReport } from "./report";
+import {
+  copyAndOpenIssue,
+  copyReport,
+  gatherReport,
+  type ReportSources,
+} from "./fileReport";
+import { useReportStore } from "./useReportStore";
+
+export function ReportIssueDialog() {
+  const open = useReportStore((s) => s.open);
+  const seed = useReportStore((s) => s.seed);
+  const close = useReportStore((s) => s.closeReport);
+
+  const [summary, setSummary] = React.useState("");
+  const [withEnv, setWithEnv] = React.useState(true);
+  const [withLog, setWithLog] = React.useState(true);
+  const [sources, setSources] = React.useState<ReportSources | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  // Escape goes through the keymap so it stays in the cheat sheet and honours
+  // rebinding — never a local capture-phase listener (issue #47's rule).
+  useAction(
+    "app.closeOverlay",
+    () => {
+      if (!open) return false;
+      close();
+      return true;
+    },
+    [open, close],
+  );
+
+  // A fresh open is a fresh report: whatever the entry point knows goes in the
+  // box, last time's text does not linger, and the diagnostics are re-read
+  // rather than served from a snapshot of an earlier session.
+  React.useEffect(() => {
+    if (open) {
+      setSummary(seed);
+      setSources(null);
+      setWithEnv(true);
+      setWithLog(true);
+    }
+  }, [open, seed]);
+
+  // The log is read whatever the checkbox says, because the PREVIEW is what
+  // the checkbox filters: the user has to be able to see what they are about
+  // to include before deciding. Re-reading on every toggle would make the box
+  // feel slow for no gain.
+  React.useEffect(() => {
+    if (!open || sources) return;
+    let live = true;
+    gatherReport(true)
+      .then((s) => {
+        if (live) setSources(s);
+      })
+      .catch((e) => {
+        if (live) pgFlash(appErrorMessage(e));
+      });
+    return () => {
+      live = false;
+    };
+  }, [open, sources]);
+
+  if (!open) return null;
+
+  const parts = {
+    version: sources?.version ?? "",
+    environment: sources?.environment ?? "",
+    logPath: sources?.logPath ?? "",
+    logTail: sources?.logTail ?? null,
+    includeEnvironment: withEnv,
+    includeLog: withLog,
+  };
+  const preview = sources ? buildReport(parts) : "Reading diagnostics…";
+
+  const onCopy = async () => {
+    setBusy(true);
+    try {
+      await copyReport(parts);
+      pgFlash("Report copied");
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopyAndOpen = async () => {
+    setBusy(true);
+    try {
+      await copyAndOpenIssue({ ...parts, summary });
+      close();
+    } catch (e) {
+      // Deliberately stays open on failure: the report is still assembled and
+      // still copyable by hand, and closing would throw away what was typed.
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <PGModal onCancel={close} width={620} dismissable={!busy}>
+      <div
+        data-testid="report-dialog"
+        style={{ display: "flex", flexDirection: "column", gap: 12 }}
+      >
+        <div style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>
+          Report an issue
+        </div>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: "var(--fs-12)", color: "var(--fg-2)" }}>
+            What went wrong?
+          </span>
+          <textarea
+            data-testid="report-summary"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            rows={4}
+            style={{
+              resize: "vertical",
+              background: "var(--bg-1)",
+              color: "var(--fg-0)",
+              border: "1px solid var(--border-1)",
+              borderRadius: "var(--r-2)",
+              padding: 8,
+              fontSize: "var(--fs-12)",
+              fontFamily: "inherit",
+            }}
+          />
+        </label>
+
+        <div style={{ display: "flex", gap: 16 }}>
+          <PGCheckbox
+            checked={withEnv}
+            onChange={setWithEnv}
+            label="Include environment"
+            testId="report-include-env"
+          />
+          <PGCheckbox
+            checked={withLog}
+            onChange={setWithLog}
+            label="Include log tail"
+            testId="report-include-log"
+          />
+        </div>
+
+        <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-2)" }}>
+          This goes on your clipboard — nothing is sent anywhere. Paste it into
+          the issue GitHub opens.
+        </div>
+        <pre
+          data-testid="report-preview"
+          style={{
+            margin: 0,
+            maxHeight: 220,
+            overflow: "auto",
+            background: "var(--bg-1)",
+            border: "1px solid var(--border-0)",
+            borderRadius: "var(--r-2)",
+            padding: 8,
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-1)",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {preview}
+        </pre>
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 6 }}>
+          <PGButton
+            size="sm"
+            variant="ghost"
+            onClick={close}
+            disabled={busy}
+            data-testid="report-cancel"
+          >
+            Cancel
+          </PGButton>
+          <PGButton
+            size="sm"
+            icon="copy"
+            onClick={onCopy}
+            disabled={busy || !sources}
+            data-testid="report-copy"
+          >
+            Copy report
+          </PGButton>
+          <PGButton
+            size="sm"
+            variant="primary"
+            icon="external"
+            onClick={onCopyAndOpen}
+            disabled={busy || !sources}
+            data-testid="report-open"
+          >
+            Copy &amp; open GitHub
+          </PGButton>
+        </div>
+      </div>
+    </PGModal>
+  );
+}

--- a/src/features/report/ReportIssueDialog.tsx
+++ b/src/features/report/ReportIssueDialog.tsx
@@ -17,7 +17,6 @@ import React from "react";
 
 import { PGButton, PGCheckbox, PGModal, pgFlash } from "@/design";
 import { appErrorMessage } from "@/lib/errors";
-import { useAction } from "@/features/keymap/useAction";
 
 import { buildReport } from "./report";
 import {
@@ -39,17 +38,12 @@ export function ReportIssueDialog() {
   const [sources, setSources] = React.useState<ReportSources | null>(null);
   const [busy, setBusy] = React.useState(false);
 
-  // Escape goes through the keymap so it stays in the cheat sheet and honours
-  // rebinding — never a local capture-phase listener (issue #47's rule).
-  useAction(
-    "app.closeOverlay",
-    () => {
-      if (!open) return false;
-      close();
-      return true;
-    },
-    [open, close],
-  );
+  // Escape is NOT handled here. It arrives through the keymap's
+  // `app.closeOverlay` DEFAULT RUNNER (`features/keymap/actions.ts`), which is
+  // an ordered chain over the overlay stores — a `useAction` registration from
+  // this component would run BEFORE that runner and so take Escape ahead of
+  // the credential prompt stacked above it. Never a local capture-phase
+  // listener either (issue #47's rule).
 
   // A fresh open is a fresh report: whatever the entry point knows goes in the
   // box, last time's text does not linger, and the diagnostics are re-read

--- a/src/features/report/fileReport.test.ts
+++ b/src/features/report/fileReport.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+import { copyAndOpenIssue, fileBugReport, gatherReport } from "./fileReport";
+
+const DIAG = {
+  logPath: "/tmp/platypusgit.log",
+  logExists: true,
+  logSizeBytes: 4096,
+  environment: "host os=linux arch=x86_64 git=2.43.0",
+  version: "0.8.0",
+};
+
+let written: string[] = [];
+
+beforeEach(() => {
+  written = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn(async (t: string) => {
+        written.push(t);
+      }),
+    },
+  });
+  mockInvoke("diagnostics_report", () => DIAG);
+  mockInvoke("read_log_tail", () => "11:02 WARN invoke fetch slow: 1400ms");
+  mockInvoke("open_url", () => undefined);
+});
+
+describe("gatherReport", () => {
+  it("reads the log tail when asked", async () => {
+    const src = await gatherReport(true);
+    expect(src.version).toBe("0.8.0");
+    expect(src.environment).toBe(DIAG.environment);
+    expect(src.logPath).toBe(DIAG.logPath);
+    expect(src.logTail).toContain("invoke fetch slow");
+  });
+
+  it("does not read the log tail when not asked", async () => {
+    const src = await gatherReport(false);
+    expect(src.logTail).toBeNull();
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("read_log_tail");
+  });
+
+  it("survives a log that cannot be read", async () => {
+    // An unreadable log must not lose the environment: an environment-only
+    // report is worth more than no report at all.
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "no log file yet" };
+    });
+    const src = await gatherReport(true);
+    expect(src.logTail).toBeNull();
+    expect(src.environment).toBe(DIAG.environment);
+  });
+});
+
+describe("copyAndOpenIssue", () => {
+  const PARTS = {
+    summary: "Fetch hangs",
+    version: "0.8.0",
+    environment: DIAG.environment,
+    logPath: DIAG.logPath,
+    logTail: "11:02 WARN invoke fetch slow",
+    includeEnvironment: true,
+    includeLog: true,
+  };
+
+  it("copies the report before opening the browser", async () => {
+    await copyAndOpenIssue(PARTS);
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("invoke fetch slow");
+    // Order matters: by the time GitHub has loaded, the clipboard must already
+    // hold what the body's paste marker asks for.
+    expect(getInvokeCalls().find((c) => c.cmd === "open_url")).toBeTruthy();
+    expect(written.length).toBe(1);
+  });
+
+  it("opens a URL inside the budget with no log in it", async () => {
+    await copyAndOpenIssue(PARTS);
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args
+      .url as string;
+    expect(url).toContain("github.com/jonassaa/platypusgit/issues/new");
+    // Read through searchParams, not decodeURIComponent: URLSearchParams
+    // encodes a space as `+`, which decodeURIComponent leaves alone — so a
+    // raw-string assertion about prose in the query is accidentally true.
+    const body = new URL(url).searchParams.get("body")!;
+    expect(body).not.toContain("invoke fetch slow");
+    expect(body).toContain("Fetch hangs");
+    expect(url.length).toBeLessThanOrEqual(6000);
+  });
+
+  it("does not open the browser when the clipboard write fails", async () => {
+    // Opening GitHub with nothing on the clipboard sends the user to a form
+    // whose instructions they cannot follow.
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => {
+          throw new Error("denied");
+        }),
+      },
+    });
+    await expect(copyAndOpenIssue(PARTS)).rejects.toThrow();
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+  });
+
+  it("reports a webview with no clipboard rather than pretending to copy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    await expect(copyAndOpenIssue(PARTS)).rejects.toThrow(/clipboard/i);
+    expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("open_url");
+  });
+});
+
+describe("fileBugReport", () => {
+  it("gathers, copies and opens in one call", async () => {
+    // This is the error boundary's whole path: it has no dialog to mount and
+    // no store subscriber, so one call has to do everything.
+    await fileBugReport("Render error: x is not a function");
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("invoke fetch slow");
+    const url = getInvokeCalls().find((c) => c.cmd === "open_url")!.args
+      .url as string;
+    const params = new URL(url).searchParams;
+    expect(params.get("title")).toBe("[bug] Render error: x is not a function");
+    expect(params.get("body")).toContain("Render error: x is not a function");
+  });
+
+  it("still files a report when there is no log to read", async () => {
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "no log file yet" };
+    });
+    await fileBugReport("Render error: boom");
+    expect(written[0]).toContain("platypusgit 0.8.0");
+    expect(written[0]).toContain("host os=linux");
+    // No dangling log section for a log that was never read.
+    expect(written[0]).not.toContain("log tail");
+    expect(getInvokeCalls().map((c) => c.cmd)).toContain("open_url");
+  });
+});

--- a/src/features/report/fileReport.ts
+++ b/src/features/report/fileReport.ts
@@ -1,0 +1,100 @@
+/**
+ * The side effects: reading the diagnostics, writing the clipboard, opening
+ * the browser.
+ *
+ * Split from `report.ts` so that the text assembly stays pure, and split from
+ * `ReportIssueDialog` so that a caller with no React tree can still file a
+ * report. That caller is `PGErrorBoundary`, which runs precisely when the tree
+ * below it has been unmounted — see {@link fileBugReport}.
+ *
+ * Nothing here makes a network request. The clipboard is written and a URL is
+ * handed to `openUrl`, which is the user's own browser.
+ */
+import { diagnosticsReport, openUrl, readLogTail } from "@/lib/tauri";
+
+import { buildReport, issueUrl, type ReportParts } from "./report";
+
+/** Everything a report is assembled from, as read off this machine. */
+export interface ReportSources {
+  version: string;
+  environment: string;
+  logPath: string;
+  /** `null` when the log could not be read — see {@link gatherReport}. */
+  logTail: string | null;
+}
+
+/**
+ * Read the facts a report is built from.
+ *
+ * A failing `read_log_tail` is NOT an error here. A fresh install has no log
+ * file at all, and an environment-only report is worth more than no report, so
+ * the tail degrades to `null` and `buildReport` drops the section rather than
+ * emitting a header with nothing under it.
+ */
+export async function gatherReport(includeLog: boolean): Promise<ReportSources> {
+  const diag = await diagnosticsReport();
+  let logTail: string | null = null;
+  if (includeLog) {
+    try {
+      logTail = await readLogTail();
+    } catch {
+      logTail = null;
+    }
+  }
+  return {
+    version: diag.version,
+    environment: diag.environment,
+    logPath: diag.logPath,
+    logTail,
+  };
+}
+
+/** Put the assembled report on the clipboard. Throws if it cannot. */
+export async function copyReport(parts: ReportParts): Promise<void> {
+  const clip = navigator.clipboard;
+  // Not optional-chained into silence: a caller that is told the copy
+  // succeeded will send the user to a form asking them to paste.
+  if (!clip) throw new Error("This webview has no clipboard access");
+  await clip.writeText(buildReport(parts));
+}
+
+/**
+ * Copy the report, then open the prefilled issue. In that order.
+ *
+ * The order is the feature: the body carries a marker asking the reporter to
+ * paste, so the clipboard has to be loaded before GitHub is on screen. A
+ * failed copy therefore does NOT open the browser — that would send someone to
+ * a form whose instructions they cannot follow.
+ */
+export async function copyAndOpenIssue(
+  parts: ReportParts & { summary: string },
+): Promise<void> {
+  await copyReport(parts);
+  await openUrl(
+    issueUrl({
+      summary: parts.summary,
+      version: parts.version,
+      environment: parts.environment,
+    }),
+  );
+}
+
+/**
+ * Gather, copy and open — the whole flow in one call, with everything included.
+ *
+ * For a caller that cannot render the dialog. `PGDialogHost` and
+ * `ReportIssueDialog` both mount inside `AppShell`, which mounts inside
+ * `PGErrorBoundary`; after a render throw React has unmounted that whole
+ * subtree, so there is no dialog to open and nothing subscribed to
+ * `useReportStore`. Calling `openReport()` from the boundary would set a flag
+ * nobody reads.
+ */
+export async function fileBugReport(summary: string): Promise<void> {
+  const src = await gatherReport(true);
+  await copyAndOpenIssue({
+    ...src,
+    summary,
+    includeEnvironment: true,
+    includeLog: src.logTail !== null,
+  });
+}

--- a/src/features/report/report.test.ts
+++ b/src/features/report/report.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReport,
+  issueUrl,
+  MAX_URL_LEN,
+  PASTE_MARKER,
+  type ReportParts,
+} from "./report";
+
+const PARTS: ReportParts = {
+  version: "0.8.0",
+  environment: "host os=macos arch=aarch64 git=2.49.0",
+  logPath: "/Users/x/Library/Logs/com.platypusgit.app/platypusgit.log",
+  logTail: "11:02 INFO open_repo /tmp/r\n11:02 WARN invoke fetch slow: 1400ms",
+  includeEnvironment: true,
+  includeLog: true,
+};
+
+describe("buildReport", () => {
+  it("always names the build, whatever else is excluded", () => {
+    const text = buildReport({
+      ...PARTS,
+      includeEnvironment: false,
+      includeLog: false,
+    });
+    expect(text).toContain("platypusgit 0.8.0");
+    // A report whose build is unknown cannot be acted on, so the version line
+    // is not one of the opt-outs.
+    expect(text).not.toContain("host os=macos");
+    expect(text).not.toContain("invoke fetch");
+  });
+
+  it("includes the environment line only when asked", () => {
+    expect(buildReport(PARTS)).toContain(
+      "host os=macos arch=aarch64 git=2.49.0",
+    );
+    expect(buildReport({ ...PARTS, includeEnvironment: false })).not.toContain(
+      "host os=macos",
+    );
+  });
+
+  it("includes the log tail and its path only when asked", () => {
+    const withLog = buildReport(PARTS);
+    expect(withLog).toContain("invoke fetch slow: 1400ms");
+    expect(withLog).toContain(PARTS.logPath);
+
+    const without = buildReport({ ...PARTS, includeLog: false });
+    expect(without).not.toContain("invoke fetch slow");
+    expect(without).not.toContain(PARTS.logPath);
+  });
+
+  it("omits the log section entirely when the tail could not be read", () => {
+    // A failed `read_log_tail` must not produce a section header with nothing
+    // under it — that reads like an empty log rather than an unread one.
+    const text = buildReport({ ...PARTS, logTail: null });
+    expect(text).not.toContain(PARTS.logPath);
+    expect(text).toContain("platypusgit 0.8.0");
+    expect(text).toContain("host os=macos");
+  });
+
+  it("does not hardcode the backend's tail line count", () => {
+    // TAIL_LINES lives in commands/diagnostics.rs. Repeating "500" here is a
+    // second copy of a constant this side cannot see change.
+    expect(buildReport(PARTS)).not.toContain("500");
+  });
+});
+
+describe("issueUrl", () => {
+  const BASE = {
+    version: "0.8.0",
+    environment: "host os=linux arch=x86_64 git=2.43.0",
+  };
+
+  it("targets the project's issue tracker with the bug label", () => {
+    const u = new URL(issueUrl({ ...BASE, summary: "Fetch hangs" }));
+    expect(u.origin + u.pathname).toBe(
+      "https://github.com/jonassaa/platypusgit/issues/new",
+    );
+    expect(u.searchParams.get("labels")).toBe("bug");
+  });
+
+  it("titles the issue from the summary's first line, template-style", () => {
+    const u = new URL(
+      issueUrl({ ...BASE, summary: "Fetch hangs forever\nand then crashes" }),
+    );
+    expect(u.searchParams.get("title")).toBe("[bug] Fetch hangs forever");
+  });
+
+  it("still produces a usable title for an empty summary", () => {
+    const u = new URL(issueUrl({ ...BASE, summary: "" }));
+    expect(u.searchParams.get("title")).toBe("[bug]");
+  });
+
+  it("mirrors the bug_report.md headings and carries the paste marker", () => {
+    const body = new URL(
+      issueUrl({ ...BASE, summary: "Fetch hangs" }),
+    ).searchParams.get("body")!;
+    for (const heading of [
+      "## Describe the bug",
+      "## Steps to reproduce",
+      "## Expected behavior",
+      "## Actual behavior",
+      "## Environment",
+      "## Additional context",
+    ]) {
+      expect(body).toContain(heading);
+    }
+    expect(body).toContain("Fetch hangs");
+    expect(body).toContain(PASTE_MARKER);
+  });
+
+  it("prefills Environment with the small, bounded facts", () => {
+    const body = new URL(issueUrl({ ...BASE, summary: "x" })).searchParams.get(
+      "body",
+    )!;
+    expect(body).toContain("0.8.0");
+    expect(body).toContain("host os=linux arch=x86_64 git=2.43.0");
+  });
+
+  it("never carries a log tail — that is what the clipboard is for", () => {
+    const url = issueUrl({ ...BASE, summary: "x" });
+    expect(url).not.toContain("invoke");
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+  });
+
+  it("stays inside the URL budget however long the summary is", () => {
+    // GitHub answers a long enough query string with 414, so the button must
+    // not be able to produce one. 40k of prose is a plausible paste.
+    const url = issueUrl({ ...BASE, summary: "wall of text ".repeat(4000) });
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+    expect(new URL(url).searchParams.get("body")).toContain("…");
+  });
+
+  it("stays inside the budget when the summary is mostly escapes", () => {
+    // A newline costs three URL bytes and appears in both title and body, so
+    // shrinking by character count alone can undershoot. `a\n` rather than a
+    // bare `\n`: a summary of pure whitespace trims to empty and never reaches
+    // the truncation loop at all, which would make this assertion vacuous.
+    const summary = "a\n".repeat(9000);
+    expect(summary.trim().length).toBeGreaterThan(MAX_URL_LEN);
+    const url = issueUrl({ ...BASE, summary });
+    expect(url.length).toBeLessThanOrEqual(MAX_URL_LEN);
+    expect(new URL(url).searchParams.get("body")).toContain("…");
+  });
+
+  it("truncates rather than dropping the summary wholesale", () => {
+    // The loop must land on a real prefix. Shrinking straight to "" would also
+    // satisfy the budget, and would silently throw away what the user wrote.
+    const url = issueUrl({
+      ...BASE,
+      summary: `Fetch hangs forever. ${"detail ".repeat(3000)}`,
+    });
+    const body = new URL(url).searchParams.get("body")!;
+    expect(body).toContain("Fetch hangs forever.");
+    expect(body).toContain("detail");
+    expect(url.length).toBeGreaterThan(MAX_URL_LEN - 500);
+  });
+
+  it("fits the skeleton even with no summary at all", () => {
+    // The truncation loop's floor. If this ever exceeds the budget, no amount
+    // of trimming the summary can save it.
+    expect(issueUrl({ ...BASE, summary: "" }).length).toBeLessThanOrEqual(
+      MAX_URL_LEN,
+    );
+  });
+});

--- a/src/features/report/report.ts
+++ b/src/features/report/report.ts
@@ -1,0 +1,162 @@
+/**
+ * Assembling a bug report, and the URL that files it.
+ *
+ * Pure on purpose: no React, no IPC, no clipboard. Every branch here is
+ * reachable from a unit test with no jsdom and no mocks, which matters because
+ * one of the callers is the error boundary — a surface that runs when the React
+ * tree below it has already been unmounted, and that therefore cannot be
+ * exercised through the dialog at all.
+ *
+ * The one non-obvious rule is the SPLIT. A GitHub `issues/new?body=…` URL is
+ * the obvious place to put the whole report, and it does not fit: GitHub
+ * answers a long enough query string with HTTP 414, and the practical ceiling
+ * is around 8 KB of URL, while `read_log_tail` returns up to `TAIL_CAP_BYTES`.
+ * Putting the log in the URL therefore works in testing, where the log is
+ * short, and fails on exactly the machine that has been running long enough to
+ * have a bug worth reporting. So the small bounded facts go in the URL and the
+ * unbounded report goes on the clipboard, with a marker in the body saying so.
+ */
+
+/** Where this app's own issues live. */
+const ISSUES_URL = "https://github.com/jonassaa/platypusgit/issues/new";
+
+/**
+ * The ceiling the finished URL must stay under.
+ *
+ * 6000 rather than the ~8 KB where GitHub actually answers 414: the margin
+ * covers a long environment line, and it covers GitHub moving the limit
+ * without this app finding out from a 414 in someone else's browser.
+ */
+export const MAX_URL_LEN = 6000;
+
+/** What the body asks the reporter to do with their clipboard. */
+export const PASTE_MARKER =
+  "<!-- Paste the diagnostics report from your clipboard here (Cmd/Ctrl+V) -->";
+
+/**
+ * The log section's rule.
+ *
+ * Deliberately does NOT say "last 500 lines": that count is `TAIL_LINES` in
+ * `commands/diagnostics.rs`, and a second copy on this side is a constant that
+ * silently stops being true.
+ */
+const LOG_RULE = "── log tail ──";
+
+/** How long a title may get before GitHub's own field does the trimming. */
+const MAX_TITLE_LEN = 120;
+
+export interface ReportParts {
+  /** The running build. */
+  version: string;
+  /** The startup `host os=… arch=… git=…` line. */
+  environment: string;
+  /** Absolute path the tail was read from — provenance for a pasted excerpt. */
+  logPath: string;
+  /** The tail itself, or `null` when it could not be read. */
+  logTail: string | null;
+  includeEnvironment: boolean;
+  includeLog: boolean;
+}
+
+/**
+ * The pasteable block, in the order a reader wants it.
+ *
+ * The version line is not one of the opt-outs: a report whose build is unknown
+ * cannot be acted on. Everything else is the user's choice, and an excluded
+ * section is ABSENT rather than present-and-empty — a `── log tail ──` rule
+ * with nothing under it reads like an empty log rather than an unread one.
+ */
+export function buildReport(parts: ReportParts): string {
+  const lines: string[] = [`platypusgit ${parts.version}`];
+  if (parts.includeEnvironment) lines.push(parts.environment);
+  if (parts.includeLog && parts.logTail) {
+    lines.push(parts.logPath, "", LOG_RULE, parts.logTail);
+  }
+  return lines.join("\n");
+}
+
+/** `[bug] ` + the summary's first line, matching `bug_report.md`'s front matter. */
+function issueTitle(summary: string): string {
+  const first = summary.split("\n")[0]?.trim() ?? "";
+  return first ? `[bug] ${first.slice(0, MAX_TITLE_LEN)}` : "[bug]";
+}
+
+/**
+ * The body, mirroring `.github/ISSUE_TEMPLATE/bug_report.md`.
+ *
+ * Written here rather than fetched by passing `template=`: given both
+ * `template` and `body`, the two contend for the same field, and which one
+ * wins is GitHub's business rather than something this app should depend on.
+ */
+function issueBody(
+  summary: string,
+  version: string,
+  environment: string,
+): string {
+  return [
+    "## Describe the bug",
+    "",
+    summary || "<!-- What went wrong? -->",
+    "",
+    "## Steps to reproduce",
+    "",
+    "1. …",
+    "2. …",
+    "3. …",
+    "",
+    "## Expected behavior",
+    "",
+    "## Actual behavior",
+    "",
+    "## Environment",
+    "",
+    `- platypusgit version: ${version}`,
+    `- ${environment}`,
+    "",
+    "## Additional context",
+    "",
+    PASTE_MARKER,
+    "",
+  ].join("\n");
+}
+
+function build(
+  summary: string,
+  opts: { version: string; environment: string },
+): string {
+  const u = new URL(ISSUES_URL);
+  u.searchParams.set("labels", "bug");
+  u.searchParams.set("title", issueTitle(summary));
+  u.searchParams.set("body", issueBody(summary, opts.version, opts.environment));
+  return u.toString();
+}
+
+/**
+ * The prefilled issue URL, guaranteed to fit inside {@link MAX_URL_LEN}.
+ *
+ * The summary is the only unbounded part, so it is the only part trimmed. The
+ * loop shrinks rather than computing a length: percent-encoding makes a
+ * character's cost variable — a newline is three bytes and appears in BOTH the
+ * title and the body — so arithmetic alone cannot land it in one pass.
+ */
+export function issueUrl(opts: {
+  summary: string;
+  version: string;
+  environment: string;
+}): string {
+  const summary = opts.summary.trim();
+  const full = build(summary, opts);
+  if (full.length <= MAX_URL_LEN) return full;
+
+  let keep = summary.length;
+  while (keep > 0) {
+    const candidate = build(`${summary.slice(0, keep)}…`, opts);
+    if (candidate.length <= MAX_URL_LEN) return candidate;
+    const over = candidate.length - MAX_URL_LEN;
+    // Nine is the worst case for one character of UTF-8 in a query string
+    // (three bytes, percent-encoded, in two fields), so this never overshoots
+    // past the answer — it only ever needs another pass.
+    keep = Math.max(0, keep - Math.max(1, Math.ceil(over / 9)));
+  }
+  return build("", opts);
+}

--- a/src/features/report/useReportStore.ts
+++ b/src/features/report/useReportStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+/**
+ * Whether the report dialog is open, and what the summary box starts with.
+ *
+ * App-level rather than per-repo, so it stays out of `RepoSlice`/`emptySlice`:
+ * those exist for state that must be DROPPED on a tab switch, and "is the
+ * report dialog open" is not about a repository at all.
+ *
+ * `seed` exists because two of the four entry points already know something
+ * the user would otherwise retype — the error banner has the error text, and
+ * the error boundary has the render throw's message. The two that do not
+ * (the titlebar, Settings) call `openReport()` with no argument.
+ */
+interface ReportState {
+  open: boolean;
+  seed: string;
+  openReport: (seed?: string) => void;
+  closeReport: () => void;
+}
+
+export const useReportStore = create<ReportState>((set) => ({
+  open: false,
+  seed: "",
+  openReport: (seed = "") => set({ open: true, seed }),
+  closeReport: () => set({ open: false }),
+}));

--- a/src/features/settings/pages/backup.tsx
+++ b/src/features/settings/pages/backup.tsx
@@ -9,6 +9,8 @@ import {
   type SettingsImportReport,
 } from "@/features/settings/useSettingsStore";
 import { appErrorMessage } from "@/lib/errors";
+import { buildReport } from "@/features/report/report";
+import { useReportStore } from "@/features/report/useReportStore";
 import { diagnosticsReport, readLogTail, revealLogFile } from "@/lib/tauri";
 import type { DiagnosticsReport } from "@/lib/types";
 
@@ -34,6 +36,7 @@ export const meta: SettingsPageMeta = {
       rows: [
         { id: "diagnostics.environment", label: "Environment", keywords: "version os arch git bug report" },
         { id: "diagnostics.log", label: "Log file", keywords: "tail reveal path debug troubleshoot" },
+        { id: "diagnostics.report", label: "Report an issue", keywords: "bug github issue file feedback broken crash complain" },
       ],
     },
   ],
@@ -151,10 +154,20 @@ export function BackupPage() {
       // not reach back far enough to include the startup `host …` line, and a
       // log whose platform is unknown is what made #274 hard to read in the
       // first place — so the copy carries its own provenance.
-      const header = diagReport
-        ? `platypusgit ${diagReport.version}\n${diagReport.environment}\n${diagReport.logPath}\n\n`
-        : "";
-      await navigator.clipboard?.writeText(`${header}${tail}`);
+      //
+      // Assembled by `features/report/report.ts`, not by hand here: this
+      // button and the Report an issue dialog produce the SAME text, and two
+      // copies of the format are two things to keep in step.
+      await navigator.clipboard?.writeText(
+        buildReport({
+          version: diagReport?.version ?? "",
+          environment: diagReport?.environment ?? "",
+          logPath: diagReport?.logPath ?? "",
+          logTail: tail,
+          includeEnvironment: true,
+          includeLog: true,
+        }),
+      );
       pgFlash("Log tail copied");
     } catch (e) {
       pgFlash(appErrorMessage(e));
@@ -287,6 +300,21 @@ export function BackupPage() {
                 Show file
               </PGButton>
             </div>
+          }
+        />
+        <SettingsRow
+          id="diagnostics.report"
+          label="Report an issue"
+          hint="Assembles the environment and the log tail, shows you all of it, and opens a prefilled GitHub issue. Nothing is sent — the report goes on your clipboard and you paste it."
+          control={
+            <PGButton
+              size="sm"
+              icon="bug"
+              onClick={() => useReportStore.getState().openReport()}
+              data-testid="settings-report-issue"
+            >
+              Report an issue
+            </PGButton>
           }
         />
       </SettingsCard>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App";
 import { PGErrorBoundary } from "./design/error-boundary";
+import { fileBugReport } from "./features/report/fileReport";
 import { MergeWindow } from "./features/merge/MergeWindow";
 import { RevealOnFirstPaint } from "./lib/revealWindow";
 import { startSystemAppearanceWatch } from "./features/settings/useSettingsStore";
@@ -36,7 +37,20 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <RevealOnFirstPaint />
     {/* Outermost, so a throw anywhere still leaves a window that says what
         happened instead of an empty one. */}
-    <PGErrorBoundary>
+    <PGErrorBoundary
+      // The one report entry point that cannot go through the dialog: the
+      // dialog and PGDialogHost are both mounted by AppShell, BELOW this, and
+      // a render throw has already unmounted them. fileBugReport needs no
+      // React tree — it gathers, copies and opens on its own.
+      onReport={(err) => {
+        // Fire and forget: the boundary has nowhere to render a failure, and
+        // fileBugReport already degrades an unreadable log to an
+        // environment-only report rather than throwing.
+        void fileBugReport(`Render error: ${err.message}`).catch((e) =>
+          console.error("could not file a bug report", e),
+        );
+      }}
+    >
       {isMergeWindow ? <MergeWindow /> : <App />}
     </PGErrorBoundary>
   </React.StrictMode>,

--- a/src/screens/Reflog.tsx
+++ b/src/screens/Reflog.tsx
@@ -8,6 +8,8 @@ import {
   PGToolbar,
   PGSpinner,
 } from "@/design";
+import { errorBannerText } from "@/lib/errors";
+import { useReportStore } from "@/features/report/useReportStore";
 import {
   useReflogStore,
   type ReflogActionChoice,
@@ -179,7 +181,14 @@ export function ReflogScreen() {
       }}
     >
       {error && (
-        <PGErrorBanner error={error} onDismiss={clearError} compact />
+        <PGErrorBanner
+          error={error}
+          onDismiss={clearError}
+          onReport={() =>
+            useReportStore.getState().openReport(errorBannerText(error))
+          }
+          compact
+        />
       )}
       <PGToolbar
         right={

--- a/test/privacy.test.ts
+++ b/test/privacy.test.ts
@@ -143,9 +143,15 @@ const FORBIDDEN_NETWORK_APIS: Array<[RegExp, string]> = [
 const ALLOWED_HOSTS: Array<[string, string]> = [
   [
     "github.com",
-    "Placeholder text in the clone dialog's URL field " +
-      "(`https://github.com/org/repo.git`), so the input shows the shape it " +
-      "wants. It is rendered, never requested.",
+    "Two RENDERED strings, neither of them a request. (1) Placeholder text in " +
+      "the clone dialog's URL field (`https://github.com/org/repo.git`), so " +
+      "the input shows the shape it wants. (2) The base of the prefilled " +
+      "bug-report URL (`features/report/report.ts`): the app assembles an " +
+      "`issues/new?title=…&labels=bug&body=…` link and hands it to `openUrl`, " +
+      "which opens the USER'S OWN BROWSER. Nothing in the app fetches it, and " +
+      "the report itself never travels in that URL — it goes on the " +
+      "clipboard, the dialog shows the user every byte of it first, and only " +
+      "their own paste puts it on GitHub.",
   ],
   [
     "platypusgit.dev",


### PR DESCRIPTION
Lets a user file a diagnosable bug report from inside the app: the report is
assembled for them, shown in full, copied to the clipboard, and a prefilled
GitHub issue opens in their browser.

The log has been reachable since #274 — its path, and a *Copy last 500 lines*
button, live in Settings. What was missing was everything around it: knowing
Settings held the log at all, knowing the project is on GitHub, and filling in
an Environment section by hand from facts the app had already printed into the
log you just copied. Someone who hits a render throw got a screen that names
the problem correctly and then offers nothing but *Reload*.

## Four entry points, one dialog

| Where | Seeded with |
|---|---|
| the titlebar's `bug` button | nothing |
| `PGErrorBanner`'s new `report` action | `errorBannerText(error)` |
| Settings → Backup & diagnostics | nothing |
| `PGErrorBoundary`'s *Report this bug* | the throw's `message` |

`<ReportIssueDialog />` mounts **once**, in `AppShell`. Settings is a screen
below that point, so one mount serves the first three.

## Why the log travels by clipboard

A GitHub `issues/new?body=…` URL answers **HTTP 414** somewhere around 8 KB,
and `read_log_tail` returns up to `TAIL_CAP_BYTES`. Putting the log in the URL
works in testing, where the log is short, and fails on exactly the machine
that has been running long enough to have a bug worth reporting. So the split
is by size:

- **in the URL** — title, `labels=bug`, the body skeleton mirroring
  `bug_report.md`, and Environment prefilled with version / os / arch / git.
  `issueUrl` enforces `MAX_URL_LEN` by trimming the summary, the only
  unbounded part, so no amount of pasted prose can produce a 414.
- **on the clipboard** — the whole report, with a `<!-- Paste … -->` marker in
  the body saying so.

Copy therefore happens **strictly before** open: a failed copy does not open
the browser, because sending someone to a form that says "paste your report"
with an empty clipboard is worse than saying nothing.

## Privacy

No network call exists here — the app writes the clipboard and hands a URL to
`openUrl`, which is the user's own browser. The report is nonetheless the most
revealing text the app assembles in one place, so the preview renders the
**exact string** that will be copied, in full, and each part is independently
opt-out. A test pins that the checkboxes filter the **clipboard**, not just the
display — an opt-out that only filtered the preview would be worse than none,
because the user would believe they had removed the paths.

`test/privacy.test.ts`'s `github.com` entry now argues the new literal; that
prose is the review checkpoint the allow-list exists to force.

## The error boundary is the interesting bit

`PGDialogHost` and `ReportIssueDialog` are both mounted by `AppShell`, which is
mounted inside `PGErrorBoundary`. After a render throw React has unmounted that
whole subtree, so from the boundary there is no dialog host, no dialog, and
nothing subscribed to `useReportStore` — `openReport()` would set a flag nobody
reads and the button would silently do nothing.

So the boundary takes an `onReport?: (error: Error) => void`, on the same terms
as the `onReload` it already had, and `main.tsx` wires it to `fileBugReport`,
which needs no React tree. That callback also keeps IPC out of `src/design/`
(nothing there imports `@/lib/tauri`), which is why `PGErrorBanner` takes a
callback too rather than reaching for the store. `error-boundary.test.tsx`
renders with **no** host mounted at all — that absence is the boundary's real
world, not a simplification of it.

## Shape

```
src/features/report/
├── report.ts               PURE — buildReport + issueUrl, no React/IPC/clipboard
├── fileReport.ts           the side effects: gather → copy → open
├── ReportIssueDialog.tsx   the PGModal
└── useReportStore.ts       open/close + seed
```

No new backend command and no new dependency: this reuses `diagnostics_report`
and `read_log_tail`. Settings' *Copy last 500 lines* moves onto `buildReport`,
so the two surfaces produce the same text and cannot drift.

## Verification

- `pnpm test` — **359 files, 3590 tests, all passing** (up 34), run after the
  last edit and again on the curated history.
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test:e2e:docker` — **32/32 spec files, no retries**, 2:36. Run in full
  rather than one spec because the titlebar change is on every screen.
- The URL-budget tests were plant-verified: removing the truncation loop turns
  exactly the two budget assertions red.

Two findings worth calling out, both recorded in the code where they bite:

- **The log tail contains the environment line.** `environment_line` writes
  `host os=…` into the log at startup, so "the environment is excluded" cannot
  be checked by the absence of `host os=` while the log is included. Measured:
  unchecking the environment took the e2e preview from 2762 to 2700 characters
  and left a `host os=` line from the log behind. The e2e spec unchecks the log
  first for that reason.
- **`userEvent.setup()` replaces `navigator.clipboard`** with its own stub,
  which detaches any `writeText` spy installed before it. Every clipboard
  assertion then passes while asserting nothing about the app. These specs use
  `fireEvent`, which is also what `design/dialog.test.tsx` does.

The e2e spec deliberately stops before *Copy & open*: that hands a URL to the
OS browser, which under xvfb is either a hung `xdg-open` or a browser nobody
closes.

Spec: `docs/superpowers/specs/2026-09-07-issue-report-spec.md`.
Plan: `docs/superpowers/plans/2026-09-07-issue-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
