### PR TITLE
feat(history): say when the view is waiting on a long operation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,9 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   never a `finally` at the call site — that clears while the password dialog is
   still open). `RepoActivity` is what produces the status line, the progress bar
   and the Cancel button; a private `busy` field only says which row is busy.
+  It has TWO surfaces — the status bar and the history strip — and both render
+  from `useActivityView`, which owns every decision about what is said; a third
+  one lays out that hook rather than reading `activity` itself.
   (`docs/dev/frontend.md`)
 - **Diff surfaces:** one row model (`flattenDiffRows`); gate text rendering on
   `isTextualDiff`, scroll by offset (never `scrollIntoView` under windowing),

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1461,6 +1461,57 @@ cancellable in the backend but unstoppable from the UI for two releases.
   also keeps the 1 Hz re-render off the common case — and that re-render is why
   `ActivityStatus` is a leaf component rather than markup in `AppStatusBar`.
 
+#### The two activity surfaces (#431)
+
+`RepoActivity` has two readers on screen at once: `ActivityStatus` in the status
+bar, and `ActivityStrip` in the history view, directly above the commit list.
+The status bar answered the four questions well and answered them at the bottom
+edge of the window — but what a user watches during a checkout or a rebase is
+the list, which sits there showing the branch they just left. A four-second
+checkout read as a click that did nothing.
+
+- **`useActivityView` owns every DECISION; the surfaces own only layout**
+  (`features/repo/activityView.ts`). Which of several live ops is named, what
+  the label reads once a cancellation is asked for, whether Cancel can be
+  honoured, how many others go uncounted — all decided once. The status-bar item
+  renders an inline 52 px bar and the strip a full-width 2 px one, and they are
+  free to differ about *that*, because nobody is misinformed by it.
+  `activityView.test.tsx` mounts BOTH over one store and asserts they name the
+  same op, agree on cancellability for every `ActivityKey`, and both switch to
+  "Cancelling…" on one click of either one. Its case table is keyed by
+  `ActivityKey`, so a kind added later cannot skip it — and a third surface
+  lays out this hook rather than reading `activity` itself.
+- **The strip carries its own test hooks (`activity-strip-*`).** `cancel.e2e.ts`
+  waits on `activity-label` and CLICKS `activity-cancel`; WebdriverIO's `$`
+  takes the first match in document order, and the strip renders above the
+  status bar. Sharing the hooks would have silently re-pointed a passing spec at
+  a surface with a 400 ms delay in front of it — still green, testing something
+  else. A unit test asserts the strip renders neither of the status bar's ids.
+- **The strip has a flicker floor; the status bar does not need one.** The strip
+  is IN the layout, so every op it reports shoves the list down and back up, and
+  most ops — a checkout of a branch differing by three files, the refresh after
+  every commit — are over inside a tenth of a second. `SHOW_AFTER_MS` is 400,
+  matching `LoadingStatus`'s on purpose: two thresholds would mean the two
+  indicators appeared at different moments during one slow refresh.
+- **It mounts on BOTH of `History.tsx`'s render paths.** The `!commits.length`
+  early return renders its own toolbar, and that is the path a checkout to an
+  unborn branch lands on — and where a cold repository open sits for as long as
+  the first log read takes. The slowest waits the app has are exactly the ones a
+  strip mounted only in the populated branch would miss.
+- **The windowed list reflows around it on its own** (`useWindowedList` observes
+  `clientHeight`). On WebKitGTK, which has no `ResizeObserver`, the cached
+  viewport goes briefly stale — the strip appearing SHRINKS the viewport, so a
+  few extra rows render, which is harmless; it going grows the viewport and can
+  leave a short gap at the bottom until the next scroll. The same trade
+  `ShallowNotice` and the advanced-search panel already make in this screen.
+- **Indeterminate is the common case, not the fallback.** Only fetch, pull and
+  push run with `--progress`; a checkout, a rebase replay and a stash have no
+  number to report and must not imply one. `PGProgressBar`'s indeterminate fill
+  takes its width from `.pg-progress-indeterminate` rather than an inline style,
+  so `prefers-reduced-motion` can replace the width and the motion together — a
+  35 %-wide sliver that has merely stopped sliding reads as "35 % done", which
+  is the one thing an indeterminate bar must never say.
+
 #### `loadingTasks` — the detail behind `loading` (gap 8)
 
 `refreshAll` is TEN backend reads behind one `Promise.all` with one boolean to

--- a/src/design/primitives.progress.test.tsx
+++ b/src/design/primitives.progress.test.tsx
@@ -1,0 +1,51 @@
+// `PGProgressBar`'s two modes, and the one trap between them.
+//
+// The indeterminate fill's width belongs to `.pg-progress-indeterminate` in
+// `index.css`, NOT to an inline style — because that is the only way
+// `prefers-reduced-motion` can replace the width and the animation together.
+// Stopping the slide on a 35 %-wide sliver leaves a bar that reads as "35 %
+// done", and reporting progress without implying a position is the entire job
+// of the indeterminate mode. An inline `width` would win over the media query
+// and quietly restore the lie, so it is asserted against here.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import { PGProgressBar } from "./primitives";
+
+/** The moving part: the track is the bar's own element, the fill is inside it. */
+const fill = (c: HTMLElement) =>
+  c.firstElementChild!.firstElementChild as HTMLElement;
+
+describe("the indeterminate mode", () => {
+  it("takes its width from the class, never from an inline style", () => {
+    const { container } = render(<PGProgressBar indeterminate />);
+    expect(fill(container).className).toBe("pg-progress-indeterminate");
+    // The assertion that matters: an inline width would outrank the reduced
+    // motion override and there would be no way to tell from the screen.
+    expect(fill(container).style.width).toBe("");
+  });
+
+  it("does not animate a width it is not setting", () => {
+    const { container } = render(<PGProgressBar indeterminate />);
+    expect(fill(container).style.transition).toBe("");
+  });
+});
+
+describe("the determinate mode", () => {
+  it("paints the value as a percentage of the track", () => {
+    const { container } = render(<PGProgressBar value={62} />);
+    expect(fill(container).style.width).toBe("62%");
+    expect(fill(container).className).toBe("");
+  });
+
+  it("scales to a custom max", () => {
+    const { container } = render(<PGProgressBar value={5} max={20} />);
+    expect(fill(container).style.width).toBe("25%");
+  });
+
+  it("eases between values, so a progress tick is not a jump", () => {
+    const { container } = render(<PGProgressBar value={10} />);
+    expect(fill(container).style.transition).toContain("width");
+  });
+});

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -1608,15 +1608,21 @@ export function PGProgressBar({
       }}
     >
       <div
+        // The indeterminate fill's width and motion are BOTH the class's, so
+        // that `prefers-reduced-motion` can replace them together: a 35 %-wide
+        // sliver that has simply stopped moving reads as "35 % done", which is
+        // a position this bar exists to avoid implying.
+        className={indeterminate ? "pg-progress-indeterminate" : undefined}
         style={{
           height: "100%",
           background: tones[tone],
-          width: indeterminate ? "35%" : `${(value / max) * 100}%`,
           borderRadius: height / 2,
-          animation: indeterminate
-            ? "pg-indeterminate 1.4s ease-in-out infinite"
-            : undefined,
-          transition: "width var(--t-med)",
+          ...(indeterminate
+            ? null
+            : {
+                width: `${(value / max) * 100}%`,
+                transition: "width var(--t-med)",
+              }),
         }}
       />
     </div>

--- a/src/features/repo/ActivityStatus.tsx
+++ b/src/features/repo/ActivityStatus.tsx
@@ -1,32 +1,25 @@
 // The status bar's "something is running" line (#296).
 //
 // One component rather than markup inlined in `AppStatusBar`, because it is the
-// only place in the app that answers all four of the questions a waiting user
-// has — what is running, how far along, how long it has been, and can I stop it
-// — and those answers should not drift apart across surfaces.
+// only place in the STATUS BAR that answers all four of the questions a waiting
+// user has — what is running, how far along, how long it has been, and can I
+// stop it. Those answers must not drift apart across surfaces, and since #431
+// there are two surfaces: the history view carries a strip of its own. So the
+// answers themselves are decided once, in `activityView.ts`, and this file is
+// only the status bar's layout of them.
 //
 // Its own file also keeps the 1 Hz elapsed-time re-render inside a leaf: the
 // whole status bar would otherwise re-render every second while any op is live.
 
 import { PGStatusItem } from "@/design";
+import { ELAPSED_AFTER_MS, useActivityView } from "./activityView";
 import { formatElapsed, useElapsed } from "./elapsed";
-import {
-  activityCount,
-  isCancellable,
-  primaryActivity,
-  type ActivityState,
-} from "./repoActivity";
-import { useRepoStore } from "./useRepoStore";
+import type { ActivityState } from "./repoActivity";
 
-/**
- * How long an operation must run before its elapsed time appears.
- *
- * Every fetch shows a number for a moment otherwise, which is noise: the reason
- * to show elapsed time at all is "this is taking longer than I expected", and
- * nothing under a few seconds is. It also keeps the 1 Hz re-render off the
- * common case, where the op is over before the first tick.
- */
-export const ELAPSED_AFTER_MS = 3000;
+// Where the threshold lives moved to `activityView.ts` when the strip started
+// sharing it; it is still importable from here, which is where every caller
+// looked for it first.
+export { ELAPSED_AFTER_MS };
 
 /** The determinate bar, shown only once git has reported a real percentage. */
 function ProgressBar({ percent }: { percent: number }) {
@@ -81,42 +74,30 @@ function ActivityLine({ state }: { state: ActivityState }) {
 }
 
 export function ActivityStatus() {
-  const activity = useRepoStore((s) => s.activity);
-  const cancelRequested = useRepoStore((s) => s.cancelRequested);
-  const primary = primaryActivity(activity);
-  if (!primary) return null;
+  const view = useActivityView();
+  if (!view) return null;
 
   // More than one op at a time stopped being hypothetical once LFS, submodule
   // and forge checkouts joined `activity` (#296). Naming the count beats
   // silently hiding the others behind whichever one sorts first.
-  const others = activityCount(activity) - 1;
+  const { state, others, cancellable, cancelRequested, cancel } = view;
 
   return (
     <>
       <PGStatusItem
         icon="sync"
         tone="accent"
-        label={
-          <ActivityLine
-            state={
-              // Once Cancel has been clicked the transfer is being torn down,
-              // so the label says that and the bar goes (#263). A percentage
-              // still climbing after the click is the clearest possible way to
-              // tell the user their click did nothing — which is what makes
-              // them click again, and the second click is SIGKILL.
-              cancelRequested
-                ? { ...primary.state, label: "Cancelling…", percent: undefined }
-                : primary.state
-            }
-          />
-        }
+        // `state` is already the state to render, not the state the store
+        // holds: the "Cancelling…" override lives in `useActivityView` so the
+        // history strip cannot disagree with this line about it.
+        label={<ActivityLine state={state} />}
       />
       {others > 0 && (
         <PGStatusItem
           label={`+${others} more`}
         />
       )}
-      {isCancellable(primary.key) && (
+      {cancellable && (
         /*
           The way out of a stalled fetch, pull or push (#234), and the only one
           the toolbar's spinning buttons do not offer. It sits beside the label
@@ -147,7 +128,7 @@ export function ActivityStatus() {
           icon="x"
           label={cancelRequested ? "Force stop" : "Cancel"}
           tone="danger"
-          onClick={() => void useRepoStore.getState().cancelNetworkOps()}
+          onClick={cancel}
         />
       )}
     </>

--- a/src/features/repo/ActivityStrip.test.tsx
+++ b/src/features/repo/ActivityStrip.test.tsx
@@ -1,0 +1,203 @@
+// The history view's "something is running" strip (#431).
+//
+// The status bar has answered "what is running, how far along, how long, can I
+// stop it" since #296 — but it answers it at the very bottom edge of the
+// window, and the thing a user stares at while a checkout or a rebase runs is
+// the commit list. These tests pin the two properties that make the strip worth
+// having rather than noise: it says the same thing the status bar says, and it
+// says nothing at all about an operation that was over before you could read it.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { ActivityStrip, SHOW_AFTER_MS } from "./ActivityStrip";
+import { ELAPSED_AFTER_MS } from "./activityView";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+import type { RepoActivity } from "./repoActivity";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const NOW = 1_700_000_000_000;
+
+function show(activity: RepoActivity) {
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    activity,
+  });
+  return render(<ActivityStrip />);
+}
+
+const running = (label: string, extra: Partial<RepoActivity["fetch"]> = {}) => ({
+  label,
+  startedAt: NOW,
+  ...extra,
+});
+
+/** Push past the flicker floor, the way a slow operation does. */
+function waitOut(ms = SHOW_AFTER_MS + 1) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+const bar = () => screen.queryByTestId("activity-strip-bar");
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the flicker floor", () => {
+  it("shows nothing at all while the app is idle", () => {
+    const { container } = show({});
+    waitOut();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays silent through an operation that finishes quickly", () => {
+    // The strip sits IN the layout, above the commit list. With no floor, every
+    // 80 ms checkout and every background refresh would shove the rows the user
+    // is reading down and back up again — which is worse than saying nothing,
+    // because the ops worth reporting are exactly the slow ones.
+    const { container } = show({ branch: running("Switching to main…") });
+    waitOut(SHOW_AFTER_MS - 1);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the operation once it has run long enough to notice", () => {
+    show({ branch: running("Switching to feat/loading-ui…") });
+    waitOut();
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent(
+      "Switching to feat/loading-ui…",
+    );
+  });
+});
+
+describe("what it shows", () => {
+  it("runs an indeterminate bar when the operation reports no percentage", () => {
+    // A checkout, a rebase replay and a stash have no progress protocol to
+    // read. The bar still moves, because "working" is the fact being reported;
+    // it just must not imply a position.
+    show({ branch: running("Switching to feat/loading-ui…") });
+    waitOut();
+    expect(bar()).toHaveAttribute("data-indeterminate", "true");
+    expect(screen.queryByTestId("activity-strip-percent")).toBeNull();
+  });
+
+  it("switches to a determinate bar once a progress tick has landed", () => {
+    show({
+      fetch: running("Fetching origin…", { phase: "Receiving objects", percent: 62 }),
+    });
+    waitOut();
+    expect(bar()).toHaveAttribute("data-percent", "62");
+    expect(bar()).not.toHaveAttribute("data-indeterminate", "true");
+    expect(screen.getByTestId("activity-strip-percent")).toHaveTextContent("62%");
+  });
+
+  it("counts the operations it is not naming", () => {
+    show({
+      push: running("Pushing origin/main…"),
+      submodule: running("Updating submodules…"),
+      lfs: running("Fetching LFS objects…"),
+    });
+    waitOut();
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent(
+      "Pushing origin/main…",
+    );
+    expect(screen.getByTestId("activity-strip-others")).toHaveTextContent("+2 more");
+  });
+
+  it("holds the elapsed clock back until the wait is worth reporting", () => {
+    show({ rebase: running("Rebasing 40 commits…") });
+    waitOut();
+    expect(screen.queryByTestId("activity-strip-elapsed")).toBeNull();
+
+    waitOut(ELAPSED_AFTER_MS);
+    expect(screen.getByTestId("activity-strip-elapsed")).toHaveTextContent("3s");
+  });
+
+  it("reads as a live region, so the wait is announced rather than just drawn", () => {
+    show({ branch: running("Switching to main…") });
+    waitOut();
+    expect(screen.getByTestId("activity-strip")).toHaveAttribute("aria-live", "polite");
+  });
+});
+
+describe("Cancel", () => {
+  it.each([
+    ["fetch", "Fetching origin…"],
+    ["pull", "Pulling origin/main…"],
+    ["push", "Pushing origin/main…"],
+    ["lfs", "Fetching LFS objects…"],
+    ["submodule", "Updating submodules…"],
+    ["forge", "Checking out #42…"],
+  ] as const)("is offered for %s", (key, label) => {
+    show({ [key]: running(label) });
+    waitOut();
+    expect(screen.getByTestId("activity-strip-cancel")).toBeInTheDocument();
+  });
+
+  it.each([
+    // Same gate as the status bar, for the same reason: a rebase replay runs
+    // inside one blocking libgit2 call with nothing to signal, and the rest are
+    // over before a click could land. A button that cannot honour itself is
+    // worse than no button.
+    ["rebase", "Rebasing 12 of 200: fix a thing"],
+    ["stash", "Stashing changes…"],
+    ["branch", "Switching to main…"],
+  ] as const)("is NOT offered for %s", (key, label) => {
+    show({ [key]: running(label) });
+    waitOut();
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent(label);
+    expect(screen.queryByTestId("activity-strip-cancel")).toBeNull();
+  });
+
+  it("cancels the repository's network ops when clicked", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    show({ fetch: running("Fetching origin…") });
+    waitOut();
+
+    fireEvent.click(screen.getByTestId("activity-strip-cancel"));
+    await vi.waitFor(() =>
+      expect(getInvokeCalls().filter((c) => c.cmd === "cancel_network_op")).toHaveLength(1),
+    );
+  });
+
+  it("escalates on the second click, and says so first", () => {
+    mockInvoke("cancel_network_op", () => 1);
+    show({ fetch: running("Fetching origin…", { percent: 61 }) });
+    waitOut();
+
+    fireEvent.click(screen.getByTestId("activity-strip-cancel"));
+
+    // Every part of #263's contract, because the strip is now a second place
+    // the first click has to visibly change something: the label says what is
+    // happening, the climbing percentage goes, and the button names the
+    // escalation instead of repeating itself.
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent("Cancelling…");
+    expect(screen.queryByTestId("activity-strip-percent")).toBeNull();
+    expect(screen.getByTestId("activity-strip-cancel")).toHaveTextContent("Force stop");
+  });
+});
+
+// `cancel.e2e.ts` waits on `activity-label` and CLICKS `activity-cancel`.
+// WebdriverIO's `$` takes the first match in document order, and the strip
+// renders above the status bar — so reusing those hooks would silently
+// re-point a passing spec at a surface with a 400 ms delay in front of it.
+describe("the status bar's hooks stay unambiguous", () => {
+  it("carries its own test hooks rather than the status bar's", () => {
+    show({ fetch: running("Fetching origin…") });
+    waitOut();
+
+    expect(screen.getByTestId("activity-strip-label")).toBeInTheDocument();
+    expect(screen.getByTestId("activity-strip-cancel")).toBeInTheDocument();
+    expect(screen.queryByTestId("activity-label")).toBeNull();
+    expect(screen.queryByTestId("activity-cancel")).toBeNull();
+  });
+});

--- a/src/features/repo/ActivityStrip.tsx
+++ b/src/features/repo/ActivityStrip.tsx
@@ -1,0 +1,174 @@
+// "Something is running" where the user is actually looking (#431).
+//
+// The status bar has reported running operations since #296, and it reports
+// them well — but it reports them at the very bottom edge of the window, and
+// what a user watches while a checkout or a rebase runs is the commit list.
+// A four-second checkout therefore looked like a click that did nothing: the
+// list sat there showing the branch that had just been left, and the only
+// contradiction was a small line as far from the pointer as the window allows.
+//
+// So this is the same information, pinned directly above the rows it is warning
+// you about. It is deliberately NOT a second opinion: `useActivityView` decides
+// what is said and this file only lays it out — see `activityView.ts`.
+
+import { PGButton, PGProgressBar, PGSpinner } from "@/design";
+
+import { useActivityView, ELAPSED_AFTER_MS } from "./activityView";
+import { formatElapsed, useDelayedFlag, useElapsed } from "./elapsed";
+
+/**
+ * How long an operation must run before the strip appears at all.
+ *
+ * The flicker floor, and it is load-bearing here in a way it is not in the
+ * status bar: the strip sits IN the layout, so every operation it reports
+ * shoves the commit list down and back up again. Most operations finish inside
+ * a tenth of a second — a checkout of a branch that differs by three files, the
+ * refresh that follows every commit — and reporting those would turn ordinary
+ * use into a twitching list for no information at all.
+ *
+ * Matches `LoadingStatus`'s floor on purpose: both answer "is this taking
+ * longer than I expected", and two different thresholds would mean the two
+ * indicators appeared at different moments during the same slow refresh.
+ */
+export const SHOW_AFTER_MS = 400;
+
+/**
+ * The elapsed clock, in its own leaf.
+ *
+ * `useElapsed` re-renders once a second for the life of the operation, and the
+ * strip contains a progress bar with a CSS animation — keeping the tick down
+ * here means the second hand does not re-render the bar with it.
+ */
+function ElapsedReadout({ startedAt }: { startedAt: number }) {
+  const elapsed = useElapsed(startedAt);
+  if (elapsed === null || elapsed < ELAPSED_AFTER_MS) return null;
+  return (
+    <span
+      data-testid="activity-strip-elapsed"
+      style={{ color: "var(--fg-3)", fontVariantNumeric: "tabular-nums" }}
+    >
+      {formatElapsed(elapsed)}
+    </span>
+  );
+}
+
+export function ActivityStrip() {
+  const view = useActivityView();
+  const shown = useDelayedFlag(view !== null, SHOW_AFTER_MS);
+  if (!view || !shown) return null;
+
+  const { state, others, cancellable, cancelRequested, cancel } = view;
+  const determinate = state.percent !== undefined;
+
+  return (
+    <div
+      data-testid="activity-strip"
+      // `polite`, and the whole strip rather than the label alone: a screen
+      // reader user gets the same "still working" that the bar draws, without
+      // it interrupting whatever they are reading in the list.
+      role="status"
+      aria-live="polite"
+      style={{
+        background: "var(--bg-1)",
+        display: "flex",
+        flexDirection: "column",
+        fontSize: "var(--fs-11)",
+        color: "var(--fg-1)",
+        // The list below is windowed and measures its own viewport, so it
+        // reflows around this on its own — but it must never be the thing that
+        // shrinks, or a slow operation would eat the rows being read.
+        flex: "0 0 auto",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          minWidth: 0,
+          padding: "5px 12px 6px",
+        }}
+      >
+        <PGSpinner size={12} style={{ color: "var(--accent)", flex: "0 0 auto" }} />
+        <span
+          data-testid="activity-strip-label"
+          style={{
+            // The labels carry branch and remote names, which are arbitrarily
+            // long; the strip is one line and truncates rather than wrapping,
+            // because a two-line strip moves the list twice.
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={state.label}
+        >
+          {state.label}
+        </span>
+        {determinate && (
+          <span
+            data-testid="activity-strip-percent"
+            style={{ color: "var(--fg-2)", flex: "0 0 auto", fontVariantNumeric: "tabular-nums" }}
+          >
+            {state.percent}%
+          </span>
+        )}
+        <ElapsedReadout startedAt={state.startedAt} />
+        {others > 0 && (
+          <span
+            data-testid="activity-strip-others"
+            style={{ color: "var(--fg-3)", flex: "0 0 auto" }}
+          >
+            +{others} more
+          </span>
+        )}
+        <span style={{ flex: 1 }} />
+        {cancellable && (
+          /*
+            The way out of a stalled fetch, and the reason the strip carries one
+            at all: travelling to the bottom of the window to stop the thing
+            being complained about here is the trip this feature exists to
+            remove. Two labels and never disabled, exactly as in the status bar
+            — the first click SIGTERMs so git can clean up its own lock files,
+            the second SIGKILLs, and a git that ignores SIGTERM is escapable
+            only by clicking again (#263).
+
+            Its own test hook, NOT the status bar's: `cancel.e2e.ts` waits on
+            `activity-label` and clicks `activity-cancel`, WebdriverIO's `$`
+            takes the first match in document order, and this renders above the
+            status bar. Sharing the hooks would silently re-point a passing spec
+            at a surface with a 400 ms delay in front of it.
+          */
+          <PGButton
+            data-testid="activity-strip-cancel"
+            variant="ghost"
+            size="xs"
+            tone="danger"
+            icon="x"
+            onClick={cancel}
+            style={{ flex: "0 0 auto" }}
+          >
+            {cancelRequested ? "Force stop" : "Cancel"}
+          </PGButton>
+        )}
+      </div>
+      <div
+        data-testid="activity-strip-bar"
+        // Full-bleed, and the strip has no border of its own: the bar's track
+        // IS the edge between the strip and the list. A 2 px bar inset inside a
+        // bordered box put three horizontal lines within four pixels of each
+        // other, and the moving one read as a stray tick rather than progress.
+        data-percent={determinate ? state.percent : undefined}
+        // Indeterminate is the common case, not the fallback: only fetch, pull
+        // and push run with `--progress`, so a checkout, a rebase replay and a
+        // stash have no number to report and must not imply one.
+        data-indeterminate={determinate ? undefined : "true"}
+      >
+        <PGProgressBar
+          height={3}
+          indeterminate={!determinate}
+          value={state.percent ?? 0}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/repo/activityView.test.tsx
+++ b/src/features/repo/activityView.test.tsx
@@ -1,0 +1,136 @@
+// The anti-drift test for the two activity surfaces (#431).
+//
+// `ActivityStatus.tsx` has said since #296 that it is "the only place in the app
+// that answers all four of the questions a waiting user has — what is running,
+// how far along, how long it has been, and can I stop it — and those answers
+// should not drift apart across surfaces." Adding the history strip made that
+// sentence a promise about two components instead of a description of one.
+//
+// `useActivityView` is how the promise is kept: it decides WHICH op is named,
+// what its label says, and whether Cancel is honourable. The two surfaces lay
+// that out differently — a status-bar item versus a strip with a full-width bar
+// — but they may not disagree about it. This renders both against the same
+// store and asserts they say the same thing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { ActivityStatus } from "./ActivityStatus";
+import { ActivityStrip, SHOW_AFTER_MS } from "./ActivityStrip";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+import type { ActivityKey, RepoActivity } from "./repoActivity";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const NOW = 1_700_000_000_000;
+
+/** One case per activity kind, so a kind added later cannot skip this test. */
+const CASES: Record<ActivityKey, string> = {
+  push: "Pushing origin/main…",
+  pull: "Pulling origin/main…",
+  fetch: "Fetching origin…",
+  rebase: "Rebasing 12 of 200: fix a thing",
+  stash: "Stashing changes…",
+  branch: "Switching to feat/loading-ui…",
+  forge: "Checking out #42…",
+  difftool: "Opening kdiff3 on src/main.rs…",
+  action: "Running Format all…",
+  lfs: "Fetching LFS objects…",
+  submodule: "Updating submodules…",
+};
+
+function prime(activity: RepoActivity) {
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    activity,
+  });
+}
+
+/** Both surfaces, mounted over one store, past the strip's flicker floor. */
+function renderBoth(activity: RepoActivity) {
+  prime(activity);
+  const view = render(
+    <>
+      <ActivityStrip />
+      <ActivityStatus />
+    </>,
+  );
+  act(() => {
+    vi.advanceTimersByTime(SHOW_AFTER_MS + 1);
+  });
+  return view;
+}
+
+const text = (id: string) => screen.getByTestId(id).textContent ?? "";
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the two surfaces agree", () => {
+  it.each(Object.entries(CASES) as [ActivityKey, string][])(
+    "name the same operation for %s",
+    (key, label) => {
+      renderBoth({ [key]: { label, startedAt: NOW } });
+      expect(text("activity-strip-label")).toBe(text("activity-label"));
+      expect(text("activity-label")).toBe(label);
+    },
+  );
+
+  it.each(Object.entries(CASES) as [ActivityKey, string][])(
+    "agree on whether %s can be cancelled",
+    (key, label) => {
+      renderBoth({ [key]: { label, startedAt: NOW } });
+      const inBar = screen.queryByTestId("activity-cancel") !== null;
+      const inStrip = screen.queryByTestId("activity-strip-cancel") !== null;
+      expect(inStrip).toBe(inBar);
+    },
+  );
+
+  it("pick the same op out of several, and count the rest the same way", () => {
+    renderBoth({
+      // Priority order is the hook's, not each surface's: a background
+      // submodule fetch must not outrank the push the user just started in one
+      // place and lose in the other.
+      submodule: { label: CASES.submodule, startedAt: NOW },
+      push: { label: CASES.push, startedAt: NOW },
+      lfs: { label: CASES.lfs, startedAt: NOW },
+    });
+    expect(text("activity-strip-label")).toBe(text("activity-label"));
+    expect(text("activity-label")).toBe(CASES.push);
+    expect(text("activity-strip-others")).toContain("+2 more");
+    // One reading of the count per surface, and the same reading in both.
+    expect(screen.getAllByText("+2 more")).toHaveLength(2);
+  });
+
+  it("both switch to the cancellation wording on one click", () => {
+    mockInvoke("cancel_network_op", () => 1);
+    renderBoth({ fetch: { label: CASES.fetch, startedAt: NOW, percent: 61 } });
+
+    // Clicking EITHER surface must change BOTH, because the escalation to
+    // SIGKILL is on the second click and the user may well click the other one.
+    fireEvent.click(screen.getByTestId("activity-strip-cancel"));
+
+    expect(text("activity-strip-label")).toBe("Cancelling…");
+    expect(text("activity-label")).toBe("Cancelling…");
+    expect(screen.queryByTestId("activity-strip-percent")).toBeNull();
+    expect(screen.queryByTestId("activity-percent")).toBeNull();
+  });
+
+  it("both fall silent together when the operation ends", () => {
+    const { container } = renderBoth({ fetch: { label: CASES.fetch, startedAt: NOW } });
+    expect(screen.getByTestId("activity-strip-label")).toBeInTheDocument();
+
+    act(() => {
+      prime({});
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/features/repo/activityView.ts
+++ b/src/features/repo/activityView.ts
@@ -1,0 +1,85 @@
+/**
+ * What the app tells a waiting user, decided once for every surface (#431).
+ *
+ * `ActivityStatus.tsx` opens by saying it is "the only place in the app that
+ * answers all four of the questions a waiting user has — what is running, how
+ * far along, how long it has been, and can I stop it — and those answers should
+ * not drift apart across surfaces". That was a description of one component
+ * until the history view grew a strip of its own; now it is a promise about
+ * two, and this hook is how the promise is kept.
+ *
+ * Everything that is a DECISION lives here: which of several live operations
+ * gets named, what its label reads once a cancellation has been asked for, and
+ * whether Cancel can be honoured at all. Everything that is LAYOUT stays in the
+ * surfaces — the status bar renders items with an inline 52 px bar, the strip
+ * renders a line with a full-width one, and they are free to differ about that
+ * because nobody is misinformed by it.
+ *
+ * `activityView.test.tsx` mounts both surfaces over one store and asserts they
+ * say the same thing, so a future third surface cannot quietly disagree.
+ */
+
+import React from "react";
+
+import {
+  activityCount,
+  isCancellable,
+  primaryActivity,
+  type ActivityKey,
+  type ActivityState,
+} from "./repoActivity";
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * How long an operation must run before its elapsed time appears.
+ *
+ * Every fetch shows a number for a moment otherwise, which is noise: the reason
+ * to show elapsed time at all is "this is taking longer than I expected", and
+ * nothing under a few seconds is. It also keeps the 1 Hz re-render off the
+ * common case, where the op is over before the first tick.
+ */
+export const ELAPSED_AFTER_MS = 3000;
+
+/** The one live operation to report, already resolved to what should be said. */
+export interface ActivityView {
+  key: ActivityKey;
+  /**
+   * The state to RENDER — which is not always the state the store holds. Once
+   * Cancel has been clicked the transfer is being torn down, so the label says
+   * that and the percentage goes (#263): a bar still climbing after the click
+   * is the clearest possible way to tell the user their click did nothing,
+   * which is what makes them click again, and the second click is SIGKILL.
+   */
+  state: ActivityState;
+  /** How many other operations are live and therefore going unnamed. */
+  others: number;
+  /** Whether `cancel` can actually reach this kind of operation. */
+  cancellable: boolean;
+  cancelRequested: boolean;
+  cancel: () => void;
+}
+
+/** The operation every activity surface should be reporting, or null when idle. */
+export function useActivityView(): ActivityView | null {
+  const activity = useRepoStore((s) => s.activity);
+  const cancelRequested = useRepoStore((s) => s.cancelRequested);
+  // Above the early return, or a surface that mounts while idle and then sees an
+  // operation start renders a different number of hooks on its second pass.
+  const cancel = React.useCallback(() => {
+    void useRepoStore.getState().cancelNetworkOps();
+  }, []);
+
+  const primary = primaryActivity(activity);
+  if (!primary) return null;
+
+  return {
+    key: primary.key,
+    state: cancelRequested
+      ? { ...primary.state, label: "Cancelling…", percent: undefined }
+      : primary.state,
+    others: activityCount(activity) - 1,
+    cancellable: isCancellable(primary.key),
+    cancelRequested,
+    cancel,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -286,9 +286,31 @@ kbd {
   100% { transform: scale(2); opacity: 0; }
 }
 
+/* The sweep never leaves the track entirely. The fill is 35% wide, so
+   translateX(-100%) parks it completely off the left edge and translateX(400%)
+   completely off the right — which left a visibly EMPTY bar for a chunk of
+   every cycle. On an indeterminate bar that dead frame reads as "finished" or
+   "stalled", and it is the shape a checkout and a rebase replay get, because
+   they have no percentage to report. -90%/280% keeps a sliver on the track at
+   both extremes, so the bar always says "working". */
 @keyframes pg-indeterminate {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(400%); }
+  0% { transform: translateX(-90%); }
+  100% { transform: translateX(280%); }
+}
+/* `PGProgressBar`'s indeterminate fill. Width lives here with the motion so
+   that reduced motion can replace both at once: stopping the slide on a
+   35%-wide sliver leaves something that reads as "35% done", and an
+   indeterminate bar's whole job is to report progress WITHOUT a position. */
+.pg-progress-indeterminate {
+  width: 35%;
+  animation: pg-indeterminate 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pg-progress-indeterminate {
+    width: 100%;
+    opacity: 0.5;
+    animation: none;
+  }
 }
 
 @keyframes pg-fade-in {

--- a/src/screens/History.activity.test.tsx
+++ b/src/screens/History.activity.test.tsx
@@ -1,0 +1,143 @@
+// The history view says when it is waiting on something (#431).
+//
+// Before this, a checkout that took four seconds left the commit list sitting
+// there showing the branch you had just left, and the only hint anything was
+// happening was a small line at the very bottom edge of the window. These tests
+// pin that the strip lands in the history view, above the rows it is warning
+// you about, on BOTH of the screen's render paths — the populated list and the
+// one that has no commits to show yet.
+import { describe, expect, it, beforeEach } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { HistoryScreen } from "./History";
+import { setActivity, useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import type { CommitInfo } from "@/lib/types";
+
+const oid = (label: string) => label.repeat(40).slice(0, 40);
+
+const mk = (label: string, parents: string[] = []): CommitInfo => ({
+  oid: oid(label),
+  shortOid: oid(label).slice(0, 7),
+  summary: `subject ${label}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const COMMITS = [mk("a", [oid("b")]), mk("b", [oid("c")]), mk("c")];
+
+function primeStore(over: Record<string, unknown> = {}) {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    searchResults: null,
+    searching: false,
+    searchCommits: async () => {},
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        tip: oid("a"),
+      },
+    ],
+    status: [],
+    loading: false,
+    activity: {},
+    ...over,
+  } as never);
+  useNavStore.setState({ intent: null });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+}
+
+/** The strip has a flicker floor in front of it, so every wait is a real one. */
+const strip = () =>
+  waitFor(() => screen.getByTestId("activity-strip"), { timeout: 2000 });
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe("a long operation on a populated log", () => {
+  it("names what it is waiting on", async () => {
+    primeStore({ activity: { branch: { label: "Switching to feat/x…", startedAt: Date.now() } } });
+    render(<HistoryScreen />);
+
+    expect(await strip()).toBeInTheDocument();
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent(
+      "Switching to feat/x…",
+    );
+  });
+
+  it("sits above the rows it is warning you about", async () => {
+    // Below the list it would be off-screen on any repository with more than a
+    // window's worth of history — which is the case this exists for.
+    primeStore({ activity: { pull: { label: "Pulling origin/main…", startedAt: Date.now() } } });
+    render(<HistoryScreen />);
+
+    const el = await strip();
+    const firstRow = screen.getAllByTestId("commit-row")[0];
+    expect(
+      el.compareDocumentPosition(firstRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("says nothing while the repository is idle", async () => {
+    primeStore();
+    render(<HistoryScreen />);
+    await waitFor(() => expect(screen.getAllByTestId("commit-row").length).toBe(3));
+
+    // Long enough for the floor to have elapsed twice over, so this is
+    // "deliberately silent", not "not yet shown".
+    await new Promise((r) => setTimeout(r, 900));
+    expect(screen.queryByTestId("activity-strip")).toBeNull();
+  });
+
+  it("appears when an operation starts after the screen is already up", async () => {
+    primeStore();
+    render(<HistoryScreen />);
+    await waitFor(() => expect(screen.getAllByTestId("commit-row").length).toBe(3));
+
+    setActivity("r1", "rebase", "Continuing rebase…");
+
+    expect(await strip()).toBeInTheDocument();
+    expect(screen.getByTestId("activity-strip-label")).toHaveTextContent(
+      "Continuing rebase…",
+    );
+  });
+});
+
+describe("a long operation with no commits on screen", () => {
+  it("still reports the wait beside the skeleton", async () => {
+    // The path a checkout to an unborn branch lands on, and the one a cold
+    // repository open sits in for as long as the first log read takes. The
+    // early return in `History.tsx` renders its own toolbar, so a strip mounted
+    // only in the populated branch would be invisible in exactly the slowest
+    // case the app has.
+    primeStore({
+      commits: [],
+      loading: true,
+      activity: { branch: { label: "Switching to feat/x…", startedAt: Date.now() } },
+    });
+    render(<HistoryScreen />);
+
+    expect(await strip()).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading commits")).toBeInTheDocument();
+  });
+});

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -39,6 +39,7 @@ import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { CommitBody } from "@/features/commits/body";
 import { CommitNotes } from "@/features/commits/CommitNotes";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { ActivityStrip } from "@/features/repo/ActivityStrip";
 import { ShallowNotice } from "@/features/repo/ShallowNotice";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { useNavStore } from "@/features/nav/useNavStore";
@@ -767,6 +768,11 @@ export function HistoryScreen() {
       <>
         <PGToolbar left={toolbarLeft} right={toolbarRight} />
         {advancedPanel}
+        {/* Also on this path, not just the populated one below: a checkout to
+            an unborn branch lands here, and so does a cold repository open for
+            as long as the first log read takes — the slowest waits the app
+            has, and the ones a skeleton alone does not explain. */}
+        <ActivityStrip />
         {loading ? (
           // Initial load only — this branch is reached solely when no commits
           // are on screen yet. A page-append must never blank the list the
@@ -1056,6 +1062,13 @@ export function HistoryScreen() {
     <>
       <PGToolbar left={toolbarLeft} right={toolbarRight} />
       {advancedPanel}
+      {/* What the app is waiting on, directly above the rows that are about to
+          change because of it (#431). The status bar says the same thing, but
+          it says it at the bottom edge of the window, and a four-second
+          checkout with a list still showing the branch you just left reads as
+          a click that did nothing. Same slot as on the empty-log path above,
+          so the strip does not move between them. */}
+      <ActivityStrip />
       {/* The log is a prefix of history at the best of times; in a shallow clone
           it is a prefix of a history that stops. Above the list rather than at
           the end of it (#255): a reader with five hundred commits loaded never


### PR DESCRIPTION
Checking out a branch, pulling, and the final stretch of a rebase can all take a
noticeable moment — and while they do, the history view says nothing. The commit
list sits there showing the branch you just left, and the only sign anything is
happening is a small line at the very bottom edge of the window. A four-second
checkout reads as a click that did nothing.

`RepoActivity` has known what is running since #296. This puts that answer where
the user is actually looking: a strip pinned directly above the commit list,
carrying the op's label, git's percentage when there is one, the elapsed clock
past three seconds, a `+N more` when ops overlap, and Cancel for the ops that can
honour it.

```
┌──────────────────────────────────────────┐
│ [search…]        ref▾  filter▾  ⋯ export │  toolbar
├──────────────────────────────────────────┤
│ ⟳ Switching to feat/loading-ui…    4s  ✕ │  NEW
│ ▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
├──────────────────────────────────────────┤
│ ● a73f5ef  feat(design): replace the …   │
│ │ 70227e0  feat(palette): offer the …    │
└──────────────────────────────────────────┘
```

## One hook, two surfaces

`ActivityStatus.tsx` opened by saying it was "the only place in the app that
answers all four of the questions a waiting user has — what is running, how far
along, how long it has been, and can I stop it — and those answers should not
drift apart across surfaces". Adding a second surface turned that from a
description into a promise about two components.

So every *decision* moved into `useActivityView` (`features/repo/activityView.ts`):
which of several live ops is named, what the label reads once a cancellation has
been asked for, whether Cancel can be honoured, how many others go uncounted. The
surfaces own only layout — the status bar renders an inline 52 px bar, the strip
a full-width 2 px one — and `activityView.test.tsx` mounts **both** over one store
and asserts they agree, with a case table keyed by `ActivityKey` so a kind added
later cannot skip it.

`ActivityStatus.test.tsx` passes **unchanged**, which is the evidence the refactor
did not move the status bar.

## The details that are easy to undo by accident

- **Its own test hooks (`activity-strip-*`).** `cancel.e2e.ts` waits on
  `activity-label` and *clicks* `activity-cancel`; WebdriverIO's `$` takes the
  first match in document order and the strip renders above the status bar.
  Sharing the hooks would have re-pointed a passing spec at a surface with a
  400 ms delay in front of it — still green, testing something else. A unit test
  asserts the strip renders neither of the status bar's ids.
- **A 400 ms flicker floor.** The strip is *in* the layout, so every op it reports
  shoves the list down and back up; most ops are over inside a tenth of a second.
  Matches `LoadingStatus`'s threshold deliberately.
- **Both of `History.tsx`'s render paths.** The `!commits.length` early return is
  where a checkout to an unborn branch lands, and where a cold repository open
  sits for as long as the first log read takes — the slowest waits the app has.
- **Indeterminate is the common case.** Only fetch/pull/push run with
  `--progress`. `PGProgressBar` had no callers until now, and giving it its first
  exposed two faults, both fixed here: its 35 %-wide fill swept from fully off
  the left edge to fully off the right, leaving the bar visibly **empty** for
  part of every cycle (on an indeterminate bar that reads as finished or
  stalled); and `pg-indeterminate` had no `prefers-reduced-motion` guard, while
  the fill's width was inline — so the only available override would have
  stopped the slide and left a static sliver reading as "35 % done".

## Verification

- `pnpm exec vitest run` — **361 files, 3610 tests, all passing**.
- `pnpm tsc --noEmit` — clean.
- Every new guard was **planted against** to prove it bites:
  removing the flicker floor fails only the flicker-floor test; making the strip
  naively always-cancellable fails the agreement test on exactly rebase, stash,
  branch, difftool and action; renaming the strip's testids to the status bar's
  fails the collision guard; dropping the empty-log mount fails only the skeleton
  test; putting an inline width back on the indeterminate fill fails the progress
  test.
- E2E in Docker against a freshly built snapshot: `cancel.e2e.ts` **2/2** (it is
  the spec that drives `activity-label`/`activity-cancel`, so it proves the
  selectors stay unambiguous against the real binary) and `history-ops.e2e.ts`
  **6/6**. CI runs the full suite.
- Screenshotted headless at four states — determinate fetch, a checkout with no
  percentage, an over-long branch name, and the post-cancel "Force stop" — which
  is what caught both progress-bar faults and the three-stacked-horizontal-lines
  layout. Those were fixed before this was pushed.

Scope is the history view, as asked. `ActivityStrip` is standalone, so
`RepoBrowser` or `Branches` can take it later with one line.
