### PR TITLE
fix(branches): open the menu on a picker row press, not a checkout

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1049,6 +1049,23 @@ that is only partly here — which is the whole reason the notice exists.
   the actions menu) and branch rows keep `data-branch-row` plus a
   `data-branch-name` with the FULL name, since a row's label is only the
   segments it owns.
+- **A press on a branch row OPENS ITS MENU — the picker checks nothing out
+  itself.** Click, Enter and → all land on the same actions menu, so no single
+  press in the popover can move the working tree; "Check out" is that menu's
+  first entry, disabled on the current branch. Until this, `onClick` called
+  `checkoutBranch` directly, and one misfire in a list of near-identical names
+  switched branches — while the current branch's row answered a click with
+  nothing at all. This is the split the Branches screen already had (a row
+  click selects, the menu acts); the picker was the last surface without it,
+  and `checkout()` is gone from it entirely.
+- **Choosing a menu entry dismisses the picker; dismissing the MENU does not.**
+  `PGContextMenu` fires one `onClose` for both, so the picker cannot hang its
+  own dismissal off it — `withPickerDismiss` wraps each built item's `onClick`
+  instead (recursing into submenus, passing dividers and `__menuTitle`
+  through). Without it every switch would leave a stale branch list over the
+  app; with the menu's own callback instead, backing out of a menu would close
+  the popover under the user. `BranchPicker.menuClick.test.tsx` pins both
+  halves.
 - **Acting on a row claims the picker's cursor.** Enter, → and ← all change the
   row set — a fold adds or removes rows — and the resting rule would otherwise
   re-park the cursor on HEAD the instant a folder opens, yanking it out from

--- a/e2e/specs/branches.e2e.ts
+++ b/e2e/specs/branches.e2e.ts
@@ -6,6 +6,7 @@ import {
   openRepo,
   resetApp,
   switchScreen,
+  waitForMenuItem,
 } from "../support/app";
 
 describe("branches", () => {
@@ -44,7 +45,7 @@ describe("branches", () => {
     );
     expect(repo.git("branch", "--show-current").trim()).toBe("e2e-branch");
 
-    // checkout main again via picker row
+    // checkout main again via picker row — TWO presses, deliberately.
     // `data-branch-row` is a bare boolean attribute (no `${kind}:${name}`
     // value), so select the row by scoped text match instead of an exact
     // attribute-value selector.
@@ -54,7 +55,18 @@ describe("branches", () => {
       timeout: 10_000,
       timeoutMsg: "main branch row never appeared in picker",
     });
+
+    // A press on the row OPENS ITS ACTIONS MENU; it does not check out. The
+    // menu arriving is what proves the press was handled, and it is the whole
+    // guard: under the old one-click behaviour this press started a checkout
+    // and closed the picker, taking the menu with it, so this wait would time
+    // out rather than the branch quietly switching underneath.
     await mainRow.click();
+    await waitForMenuItem("Check out");
+    expect(repo.git("branch", "--show-current").trim()).toBe("e2e-branch");
+
+    // ...and the menu's first entry is what actually switches.
+    await jsClickMenuItem("Check out");
     await browser.waitUntil(
       async () => (await chip.getText()).includes("main"),
       { timeout: 20_000, timeoutMsg: "chip did not update back to main" },

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -706,8 +706,12 @@ export const jsContextMenu = (selector: string, opts?: { text?: string }) =>
  *  present synchronously. Locally the next driver round-trip is slower than
  *  those commits; under xvfb CI load it occasionally isn't, and a single-shot
  *  lookup throws "menu item not found" (seen with the History reset submenu).
- *  Bare execute is fine — the poll has no side effects. */
-async function waitForMenuItem(label: string): Promise<void> {
+ *  Bare execute is fine — the poll has no side effects.
+ *
+ *  Exported because "the menu opened" is a signal a spec sometimes needs on its
+ *  own: the branch picker answers a row press by opening this menu instead of
+ *  checking out, so the menu's arrival is what proves the press was handled. */
+export async function waitForMenuItem(label: string): Promise<void> {
   await browser.waitUntil(
     () =>
       browser.execute(

--- a/src/features/branches/BranchPicker.folders.test.tsx
+++ b/src/features/branches/BranchPicker.folders.test.tsx
@@ -67,6 +67,18 @@ const activeRow = () => {
   return folder === null ? el.getAttribute("data-branch-name") : `${folder}/`;
 };
 
+/**
+ * The `__menuTitle` of every menu currently rendered — the branch the actions
+ * menu belongs to. `[data-pg-menu]` is portalled to `document.body`, so this
+ * reads outside the picker on purpose.
+ */
+const menuTitles = () =>
+  Array.from(document.querySelectorAll("[data-pg-menu]")).map(
+    // `__menuTitle` renders as the menu's first child (a div, not an item row),
+    // and the uppercasing is CSS — so `textContent` is the raw branch name.
+    (m) => m.firstElementChild?.textContent,
+  );
+
 const folderRow = (path: string) =>
   document.querySelector(`[data-picker-folder="${path}"]`) as HTMLElement;
 
@@ -149,13 +161,19 @@ describe("BranchPicker folders", () => {
     expect(storedFolds()).toEqual([]);
   });
 
-  it("checks out a branch row on click, as it always did", () => {
+  // A branch row inside a folder answers a click the same way one at the top
+  // level does — by opening its actions menu, never by checking out. Pinned
+  // here as well as in `BranchPicker.menuClick.test.tsx` because the folder
+  // tree is what re-indexes the rows, and the keyboard path anchors its menu
+  // BY INDEX.
+  it("opens a branch row's actions menu on click, checking nothing out", () => {
     setup();
 
     fireEvent.click(
       document.querySelector('[data-branch-name="feat/beta"]') as HTMLElement,
     );
-    expect(checkoutBranch).toHaveBeenCalledWith("feat/beta");
+    expect(menuTitles()).toContain("feat/beta");
+    expect(checkoutBranch).not.toHaveBeenCalled();
   });
 
   it("rests on the current branch when its folder is open", () => {
@@ -164,7 +182,8 @@ describe("BranchPicker folders", () => {
   });
 
   // Enter acts on the resting row. With HEAD folded away the only harmless
-  // place to rest is the folder holding it — Enter there opens the folder.
+  // place to rest is the folder holding it — Enter there opens the folder
+  // rather than a branch's actions menu.
   it("rests on the folder holding the current branch when it is folded away", () => {
     storeFolds("feat");
     setup();

--- a/src/features/branches/BranchPicker.menuClick.test.tsx
+++ b/src/features/branches/BranchPicker.menuClick.test.tsx
@@ -1,14 +1,29 @@
-// A row's context menu is portalled to `document.body`, i.e. OUT of the
-// picker's popover — so the picker's dismiss-on-outside-press handler read the
-// press on its own menu as a press outside itself. The picker closed on
-// `mousedown` and took the menu with it, and the entry's `click` landed on a
-// detached node: "Merge into current" and every other entry on that menu did
-// nothing under a real mouse (#422).
+// A branch row's ACTIONS MENU is what a press on the row opens, and that menu
+// is portalled out of the picker. Two rules live here.
 //
-// The e2e specs (merge-window, merge-conflict) drive this end to end now that
-// jsClickMenuItem presses first; this is the fast guard on the press itself.
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { fireEvent, render } from "@testing-library/react";
+// 1. A left-click — and Enter — on a branch row OPENS the row's actions menu
+//    instead of checking the branch out. The picker used to spend a single
+//    click on a working-tree mutation: `onClick` called `checkoutBranch`
+//    straight away, so a misfired press in a list of near-identical names
+//    switched branches. "Check out" is the menu's FIRST entry, so the op costs
+//    one deliberate second press and nothing became unreachable — while the
+//    current branch's row, dead under the old click, now offers everything
+//    else it can do. This is the split the Branches screen already had (a row
+//    click selects, the menu acts); the picker was the last surface without it.
+//
+// 2. The menu must SURVIVE the press that runs one of its entries. A row's
+//    menu is portalled to `document.body`, i.e. OUT of the picker's popover —
+//    so the picker's dismiss-on-outside-press handler read the press on its own
+//    menu as a press outside itself. The picker closed on `mousedown` and took
+//    the menu with it, and the entry's `click` landed on a detached node:
+//    "Merge into current" and every other entry did nothing under a real mouse
+//    (#422). Rule 1 makes that path the ONLY way to check out with a mouse, so
+//    this guard now protects the picker's primary action, not just its menu.
+//
+// The e2e specs (branches, merge-window, merge-conflict) drive this end to end
+// now that jsClickMenuItem presses first; these are the fast guards.
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
 import { BranchPicker } from "./BranchPicker";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -28,6 +43,21 @@ const branch = (name: string, isHead = false): BranchInfo => ({
 });
 
 let anchor: HTMLElement;
+let checkoutBranch: ReturnType<typeof vi.fn>;
+// Typed to the prop's own signature: the bare `vi.fn()` type is a union with a
+// constructable, which `onClose: () => void` does not accept.
+let onClose: Mock<() => void>;
+
+function setup() {
+  checkoutBranch = vi.fn();
+  onClose = vi.fn();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    branches: [branch("main", true), branch("feature")],
+    checkoutBranch,
+  } as never);
+  return render(<BranchPicker anchor={anchor} open onClose={onClose} />);
+}
 
 beforeEach(() => {
   resetInvokeMock();
@@ -39,6 +69,11 @@ afterEach(() => {
   anchor.remove();
 });
 
+const row = (name: string) =>
+  document.querySelector(
+    `[data-branch-row][data-branch-name="${name}"]`,
+  ) as HTMLElement;
+
 function menuItem(label: string): HTMLElement | null {
   const menu = document.querySelector("[data-pg-menu]");
   if (!menu) return null;
@@ -48,18 +83,90 @@ function menuItem(label: string): HTMLElement | null {
   return (span?.closest("div") as HTMLElement | null) ?? null;
 }
 
+describe("branch picker row press", () => {
+  it("opens the row's actions menu instead of checking out", () => {
+    setup();
+
+    fireEvent.click(row("feature"));
+
+    expect(menuItem("Check out")).not.toBeNull();
+    // The press itself must not mutate anything, and must not dismiss the
+    // picker — the menu it just opened is rendered inside it.
+    expect(checkoutBranch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("checks out and dismisses the picker when Check out is chosen", () => {
+    setup();
+
+    fireEvent.click(row("feature"));
+    fireEvent.click(menuItem("Check out")!);
+
+    expect(checkoutBranch).toHaveBeenCalledWith("feature");
+    // The old one-click path closed the popover, so the two-press path has to
+    // as well: `PGContextMenu`'s own `onClose` cannot carry it, because it
+    // fires for a DISMISSAL too (see the test below).
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // The distinction `withPickerDismiss` exists for: `PGContextMenu` fires one
+  // `onClose` for "an entry ran" AND for "the user dismissed me", so the picker
+  // cannot hang its own dismissal off it. Backing out of a menu has to leave
+  // the picker exactly as it was.
+  it("leaves the picker open when the menu is merely dismissed", async () => {
+    setup();
+
+    fireEvent.click(row("feature"));
+    expect(menuItem("Check out")).not.toBeNull();
+
+    // The menu arms its own dismiss listeners on `document` in a `setTimeout`,
+    // so the press that opened it cannot immediately close it again.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(document.querySelector("[data-pg-menu]")).toBeNull();
+    expect(checkoutBranch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("opens a menu on the CURRENT branch's row, which the old click ignored", () => {
+    setup();
+
+    fireEvent.click(row("main"));
+
+    // Everything the current branch can still do — merge, rename, push — is
+    // reachable now; only Check out is disabled, so pressing it does nothing.
+    expect(menuItem("Rename…")).not.toBeNull();
+    fireEvent.click(menuItem("Check out")!);
+    expect(checkoutBranch).not.toHaveBeenCalled();
+  });
+
+  it("opens the active row's menu on Enter, not a checkout", () => {
+    setup();
+    // The cursor rests on HEAD with an empty query; a query moves it to the
+    // top match, so this aims Enter at `feature` without a mouse.
+    fireEvent.change(screen.getByPlaceholderText("Switch to branch…"), {
+      target: { value: "feature" },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText("Switch to branch…"), {
+      key: "Enter",
+    });
+
+    expect(menuItem("Check out")).not.toBeNull();
+    expect(checkoutBranch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
 describe("branch picker row menu", () => {
   it("survives the press on one of its own entries", () => {
-    const onClose = vi.fn();
-    useRepoStore.setState({
-      current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
-      branches: [branch("main", true), branch("feature")],
-    } as never);
-    render(<BranchPicker anchor={anchor} open onClose={onClose} />);
+    setup();
 
-    const row = document.querySelector('[data-branch-row][data-branch-name="feature"]');
-    expect(row).not.toBeNull();
-    fireEvent.contextMenu(row!);
+    const target = row("feature");
+    expect(target).not.toBeNull();
+    fireEvent.contextMenu(target);
 
     const merge = menuItem("Merge into current");
     expect(merge).not.toBeNull();
@@ -72,12 +179,7 @@ describe("branch picker row menu", () => {
   });
 
   it("still dismisses on a press outside the picker and its menu", () => {
-    const onClose = vi.fn();
-    useRepoStore.setState({
-      current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
-      branches: [branch("main", true), branch("feature")],
-    } as never);
-    render(<BranchPicker anchor={anchor} open onClose={onClose} />);
+    setup();
 
     fireEvent.mouseDown(document.body);
     expect(onClose).toHaveBeenCalled();

--- a/src/features/branches/BranchPicker.test.tsx
+++ b/src/features/branches/BranchPicker.test.tsx
@@ -2,8 +2,8 @@
 //
 // The comparator itself is tested in orderBranches.test.ts; this pins that the
 // picker actually calls it, that it calls it AFTER filtering, and where the
-// keyboard cursor starts — Enter checks out the active row, so that position is
-// a correctness question, not a cosmetic one.
+// keyboard cursor starts — Enter opens the active row's actions menu, so that
+// position is a correctness question, not a cosmetic one.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -97,8 +97,9 @@ describe("BranchPicker ordering", () => {
 
 describe("BranchPicker resting cursor", () => {
   it("rests on the current branch with an empty query", () => {
-    // Enter on the HEAD row is a no-op (`checkout` early-returns), so this is
-    // the only starting position where the stray keystroke checks nothing out.
+    // The HEAD row's menu is the harmless one: Check out is already disabled
+    // there, so this is the only starting position where a stray Enter offers
+    // nothing that moves the working tree.
     setup([
       branch({ name: "main", tipTime: 100, isDefault: true }),
       branch({ name: "feature/fresh", tipTime: 900, isHead: true }),

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -8,6 +8,7 @@ import {
   pressIsInsideMenu,
   branchMenuItems,
   remoteBranchMenuItems,
+  type ContextMenuItem,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import type { BranchInfo } from "@/lib/types";
@@ -30,6 +31,45 @@ interface BranchPickerProps {
 type Row = BranchInfo & { kind: "local" | "remote" };
 type TreeRow = BranchTreeRow<Row>;
 
+/**
+ * Re-wire a menu so choosing an entry also dismisses the picker.
+ *
+ * A press on a branch row opens that row's actions menu instead of checking
+ * out, which makes "Check out" the two-press replacement for a path that used
+ * to close the popover on the first press — so the popover has to close when
+ * the entry runs, or every switch leaves a stale branch list over the app.
+ *
+ * `PGContextMenu`'s own `onClose` cannot carry this: it fires for a DISMISSAL
+ * too (Escape, a press outside), and dismissing a menu must leave the picker
+ * exactly as it was before the menu opened. Dividers and the `__menuTitle`
+ * carry no handler and pass through untouched; submenus recurse, so a nested
+ * entry closes the picker the same way a top-level one does.
+ */
+function withPickerDismiss(
+  items: ContextMenuItem[],
+  onClose: () => void,
+): ContextMenuItem[] {
+  return items.map((item) => {
+    if (item.submenu) {
+      return { ...item, submenu: withPickerDismiss(item.submenu, onClose) };
+    }
+    if (!item.onClick) return item;
+    const run = item.onClick;
+    return {
+      ...item,
+      onClick: () => {
+        // Fire first, dismiss second — the order the old one-click checkout
+        // used. A handler that awaits a dialog (`Rename…`) has already opened
+        // it by the time this returns, and those dialogs render above the app,
+        // not inside the picker, so the dismissal cannot unmount them.
+        const pending = run();
+        onClose();
+        return pending;
+      },
+    };
+  });
+}
+
 const WIDTH = 400;
 const MAX_HEIGHT = 480;
 /** Pixels a nesting level indents a row by — the Branches screen's step. */
@@ -43,7 +83,6 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   // one repository has one notion of which folders are folded, and a picker
   // that disagreed with the screen would be a second answer to one question.
   const folders = useBranchFolders(repoPath);
-  const checkoutBranch = useRepoStore((s) => s.checkoutBranch);
   const createAndSwitchBranch = useRepoStore((s) => s.createAndSwitchBranch);
   const [query, setQuery] = React.useState("");
   const [activeIndex, setActiveIndex] = React.useState(0);
@@ -52,15 +91,18 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
 
   const { onContextMenu: onLocalCtx, openAt: openLocal, menu: localMenu } =
     useContextMenu<BranchInfo>((b) =>
-      branchMenuItems({
-        name: b?.name,
-        current: b?.isHead,
-        upstream: b?.upstream,
-      }),
+      withPickerDismiss(
+        branchMenuItems({
+          name: b?.name,
+          current: b?.isHead,
+          upstream: b?.upstream,
+        }),
+        onClose,
+      ),
     );
   const { onContextMenu: onRemoteCtx, openAt: openRemote, menu: remoteMenu } =
     useContextMenu<BranchInfo>((b) =>
-      remoteBranchMenuItems({ name: b?.name }),
+      withPickerDismiss(remoteBranchMenuItems({ name: b?.name }), onClose),
     );
 
   // Filter FIRST, order SECOND (#135). `orderBranches` only permutes, so
@@ -147,11 +189,12 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     aimed.current = false;
   }, [open, query]);
 
-  // Where the cursor rests before the user moves it. Enter checks out the
-  // active row, so with an empty query it sits on the CURRENT branch — the one
-  // row `checkout()` refuses to act on — rather than on whatever sorts first,
-  // which since #135 is the pinned default branch. Once a query is typed the
-  // top match IS the target, so it moves to row 0.
+  // Where the cursor rests before the user moves it. Enter opens the active
+  // row's actions menu, so this position decides which branch a stray
+  // keystroke offers to act on: with an empty query it sits on the CURRENT
+  // branch, whose menu answers with Check out already disabled, rather than on
+  // whatever sorts first, which since #135 is the pinned default branch. Once a
+  // query is typed the top match IS the target, so it moves to row 0.
   //
   // `flat` is in the deps on purpose: the popover can be opened before
   // `list_branches` resolves, and an effect keyed only on [open, query] would
@@ -178,8 +221,8 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     // HEAD can be folded away (#244). Then the cursor rests on the FOLDER
     // holding it — the first match is the outermost rendered one, since a
     // collapsed folder renders none of its children. Enter there opens the
-    // folder instead of checking anything out, which keeps the rule the
-    // resting position exists for: a stray Enter must be a no-op.
+    // folder rather than a branch's menu, which keeps the rule the resting
+    // position exists for: a stray Enter must be a no-op.
     const headName = branches.find((b) => !b.isRemote && b.isHead)?.name;
     const holding = headName
       ? flat.findIndex(
@@ -247,12 +290,6 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   );
   const top = rect.bottom + 4;
 
-  const checkout = (r: Row) => {
-    if (r.kind === "local" && r.isHead) return;
-    void checkoutBranch(r.name);
-    onClose();
-  };
-
   // The popover stays open across a fold: folding is navigation, not an answer.
   const toggleFolder = (path: string) => {
     if (folders.collapsed.has(path)) folders.expand([path]);
@@ -265,14 +302,35 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     if (i >= 0) aim(i);
   };
 
-  const activate = (row: TreeRow) => {
+  /**
+   * Open a branch row's actions menu from the KEYBOARD, anchored to the row.
+   *
+   * A mouse press anchors the menu at the pointer, the way every other menu in
+   * the app does; Enter and → have no pointer, so they anchor under the row's
+   * `⋯` button instead. The row is found by INDEX, which is why folder rows
+   * carry `data-picker-row` too — the cursor counts them.
+   */
+  const openRowMenu = (
+    row: Extract<TreeRow, { kind: "branch" }>,
+    idx: number,
+  ) => {
+    const rowEls =
+      popoverRef.current?.querySelectorAll<HTMLElement>("[data-picker-row]");
+    const r = rowEls?.[idx]?.getBoundingClientRect() ?? anchor.getBoundingClientRect();
+    if (row.branch.kind === "local") openLocal(r.right - 24, r.bottom, row.branch);
+    else openRemote(r.right - 24, r.bottom, row.branch);
+  };
+
+  const activate = (row: TreeRow, idx: number) => {
     if (row.kind === "folder") {
       // Folding the folder the cursor sits in would otherwise leave it on a
       // row that is still rendered — it is the folder — so nothing to fix up.
       toggleFolder(row.path);
       return;
     }
-    checkout(row.branch);
+    // NOT a checkout. Every branch op in this picker is chosen off the row's
+    // menu, so no single press here can move the working tree.
+    openRowMenu(row, idx);
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -300,12 +358,13 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       const row = flat[activeIndex];
       if (!row) return;
       claim();
-      activate(row);
+      activate(row, activeIndex);
       return;
     }
-    // → opens a folded folder, and on a branch keeps opening its actions menu.
-    // ← folds an open folder, and on anything else climbs to the folder the
-    // row sits in — the same pair the Branches screen's tree answers.
+    // → opens a folded folder, and on a branch opens its actions menu — the
+    // same thing Enter does there now, kept because → is what the Branches
+    // screen's tree answers with. ← folds an open folder, and on anything else
+    // climbs to the folder the row sits in.
     if (e.key === "ArrowLeft") {
       const row = flat[activeIndex];
       if (!row) return;
@@ -328,14 +387,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
         if (folders.collapsed.has(row.path)) folders.expand([row.path]);
         return;
       }
-      const rowEls =
-        popoverRef.current?.querySelectorAll<HTMLElement>("[data-picker-row]");
-      const rowEl = rowEls?.[activeIndex];
-      const r = rowEl?.getBoundingClientRect() ?? anchor.getBoundingClientRect();
-      const x = r.right - 24;
-      const y = r.bottom;
-      if (row.branch.kind === "local") openLocal(x, y, row.branch);
-      else openRemote(x, y, row.branch);
+      openRowMenu(row, activeIndex);
       return;
     }
   };
@@ -417,7 +469,15 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
         // the segments a row owns, and the tests and the drag both need the ref.
         data-branch-name={r.name}
         data-active={active ? "true" : "false"}
-        onClick={() => checkout(r)}
+        // A press OPENS the row's menu; it never checks out. One click in a
+        // list of near-identical names used to move the working tree, so a
+        // misfire switched branches — and "Check out" is the menu's first
+        // entry, so the op costs one deliberate second press. Same handler the
+        // right-click and the `⋯` button use, anchored at the pointer.
+        onClick={(e) => {
+          aim(idx);
+          handler(e, r);
+        }}
         onContextMenu={(e) => handler(e, r)}
         onMouseEnter={() => aim(idx)}
         style={{
@@ -430,7 +490,10 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
           // folder row spends there, so nested names line up under the label.
           paddingLeft: 10 + row.depth * INDENT + (row.depth > 0 ? 16 : 0),
           background: active ? "var(--bg-selection)" : "transparent",
-          cursor: r.kind === "local" && r.isHead ? "default" : "pointer",
+          // Every row is actionable now, the current branch included: its menu
+          // is where "you are already here" reads off a disabled Check out
+          // beside everything the branch can still do.
+          cursor: "pointer",
           fontFamily: "var(--font-mono)",
           fontSize: "var(--fs-12)",
         }}


### PR DESCRIPTION
Clicking a branch in the titlebar branch picker now opens that row's **actions
menu** instead of immediately checking the branch out.

## Why

The picker spent a single click on a working-tree mutation: a row's `onClick`
called `checkoutBranch` directly, so one misfire in a list of near-identical
names switched branches — while the current branch's row answered a click with
nothing at all.

This is the split the **Branches screen already had** (a row click selects, the
menu acts). The picker was the last surface without it.

## What changed

- **Click, Enter and → all open the row's actions menu.** No single press in the
  popover can move the working tree any more. "Check out" is that menu's FIRST
  entry (disabled on the current branch), so nothing became unreachable — the op
  costs one deliberate second press. `checkout()` is gone from the picker
  entirely, and the current branch's row now offers everything it can still do
  (merge, rename, push) rather than nothing.
- **Choosing a menu entry dismisses the picker; dismissing the MENU does not.**
  The one-click path used to close the popover, so the two-press path has to as
  well, or every switch leaves a stale branch list over the app.
  `PGContextMenu` fires one `onClose` for "an entry ran" AND for "the user
  backed out", so the picker cannot hang its own dismissal off it —
  `withPickerDismiss` wraps each built item's handler instead, recursing into
  submenus and passing dividers and `__menuTitle` through untouched.
- Right-click and the row's `⋯` button are unchanged as entry points; they now
  dismiss the picker on a chosen entry like the left-click path does.

Both answers here were the reporter's calls: full keyboard/mouse symmetry (Enter
opens the menu too, rather than staying a checkout fast path), and no
double-click shortcut back to a direct checkout.

## Testing

- `BranchPicker.menuClick.test.tsx` — broadened from the issue-422 press
  regression to cover the press *behaviour* too: a click opens the menu and
  checks nothing out, Enter does the same on the active row, the HEAD row opens
  a menu whose Check out is inert, choosing Check out both checks out and
  dismisses the picker, and merely dismissing the menu leaves the picker open.
- `BranchPicker.folders.test.tsx` — the "checks out a branch row on click" test
  became "opens its actions menu, checking nothing out"; a row inside a folder
  has to answer the same way, and the keyboard path anchors its menu BY INDEX.
- `branches.e2e.ts` — the picker checkout step is now two presses, and the wait
  on the menu is the guard: under the old behaviour that press started a
  checkout and closed the picker, taking the menu with it, so the wait times out
  instead of the branch quietly switching underneath.
- Prose in `BranchPicker.test.tsx` and `docs/dev/frontend.md` updated — several
  comments were written around "Enter checks out the active row", including the
  resting-cursor rule.

### Verified

- `pnpm test` — 3560 passed (357 files)
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test:e2e:docker build`, then the three specs that drive the picker:
  `branches` (4 passing), `merge-conflict` (5 passing), `merge-window`
  (2 passing) — 0 stalled driver scripts on each. The two merge specs matter
  because the dismiss wrapper also changes their right-click path; the
  operation bar they wait on is app-level, and the popover no longer overlays
  it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
