### PR TITLE
feat(ui): spin the Refresh button while a refresh is running

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -588,7 +588,11 @@ features/            Components + Zustand store colocated per feature:
 │                    pg-open-repos persistence), useTabsStore (open set +
 │                    activate/close/cycle + session restore), RepoTabs,
 │                    useRecentsStore, ops (shared runners), OperationBar
-│                    (repoState-driven bar), ownership (safe.directory confirm)
+│                    (repoState-driven bar), ownership (safe.directory confirm),
+│                    refreshSpinner (whether the titlebar's Refresh button
+│                    spins — s.loading strobes, so a refresh the USER asked
+│                    for is held visible and one nobody asked for waits out
+│                    the flicker floor; refreshOp is what marks the request)
 ├── actions/         User-defined commands (#225): customActions (the list, its
 │                    validation, and how a result is reported — a FAILURE is
 │                    always shown whatever the setting says, because an action

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1493,6 +1493,50 @@ in one or two of the ten and nothing said which.
   which must cover it. The shell root's `overflow: hidden` does not clip it,
   because it grows into the content area rather than out of the window.
 
+#### The Refresh button's spinner — `refreshSpinner.ts`
+
+The titlebar's Fetch, Pull and Push buttons pass `loading` to `PGButton` and get
+a spinning `sync` glyph for free. Refresh went years without one, and the reason
+the obvious fix is wrong is the same `SHOW_AFTER_MS` argument one bullet up —
+with the sign flipped on half the cases.
+
+- **`loading={s.loading}` is the wrong answer.** That flag is true during every
+  commit, every tab switch and the tail of every network op, and it usually
+  clears inside 100 ms. Bound straight to the button, the titlebar twitches all
+  day and the twitch means nothing.
+- **`useDelayedFlag(s.loading, SHOW_AFTER_MS)` is also the wrong answer.** It
+  never strobes, but in a warm repository a refresh finishes well inside 400 ms,
+  so clicking Refresh would produce no feedback at all — which is the entire
+  thing the animation is for. A status line may stay silent about work nobody
+  asked about; a button the user just pressed may not.
+- **So the two cases are told apart by WHO asked**, which is the only thing that
+  distinguishes them. A refresh the user asked for spins immediately and holds
+  for `MIN_SPIN_MS` (450) whatever the backend did — a 40 ms quarter-turn reads
+  as a rendering glitch, not as an acknowledgement. A refresh nobody asked for
+  spins only once it outlives `SHOW_AFTER_MS`, which still catches the
+  nine-second `/mnt/c` refresh.
+- **The two windows overlap on purpose.** `MIN_SPIN_MS` outlasts
+  `SHOW_AFTER_MS`, so a slow user-invoked refresh hands off from the hold to the
+  delayed flag rather than blinking off in the middle of itself.
+- **`refreshOp()` is where the request is marked**, after its `if
+  (!repo.current) return false` guard so a declined refresh spins nothing. That
+  op is already the shared entry point for the button, `Mod+Alt+Y` and the
+  palette command, which is what lets one marker cover all three — the palette
+  used to carry its own copy of the op's body and now routes through it. **A
+  fourth way to ask for a refresh gets the spinner by calling `refreshOp`**, not
+  by calling `markRefreshRequested` beside a bare `refreshAll`.
+- **The request counter is a module-level `useSyncExternalStore`, not a
+  `RepoSlice` field.** It is not repository state: it is per-window, transient,
+  and it has to survive the `emptySlice()` that a tab switch performs — a slice
+  field would be reset out from under a spin already in progress.
+- `SHOW_AFTER_MS` lives in `elapsed.ts` beside `useDelayedFlag` for this reason:
+  two surfaces now decide what "slow" means and a logic module should not have
+  to import a component to ask.
+- Planting both wrong answers is what `refreshSpinner.test.tsx` is for — the
+  naive binding trips the flicker-floor case, the delay-only binding trips the
+  immediate-feedback case, and removing `loading={refreshing}` from `AppShell`
+  is caught by `noUnusedLocals` rather than by a test.
+
 #### `statusLoaded` — "have we ever read this repo?" (#368)
 
 A third question the same boolean was being asked. `loading` means "a refresh is

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -47,7 +47,8 @@ import { primaryActivity } from "@/features/repo/repoActivity";
 import type { NetProgress, RebaseProgress } from "@/lib/types";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
-import { headUpstream, openRepoDialog } from "@/features/repo/ops";
+import { headUpstream, openRepoDialog, refreshOp } from "@/features/repo/ops";
+import { useRefreshSpinner } from "@/features/repo/refreshSpinner";
 import { windowTitleFor } from "@/features/repo/windowTitle";
 import { indexOfTab, labelTabs } from "@/features/repo/tabs";
 import { useNavStore } from "@/features/nav/useNavStore";
@@ -682,7 +683,9 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const fetching = useRepoStore((s) => !!s.activity.fetch);
   const pulling = useRepoStore((s) => !!s.activity.pull);
   const pushing = useRepoStore((s) => !!s.activity.push);
-  const refresh = useRepoStore((s) => s.refreshAll);
+  // Not `s.loading`: that flag flips on every commit and tab switch, and the
+  // reasoning behind the gate lives in `refreshSpinner.ts`.
+  const refreshing = useRefreshSpinner();
   const activePath = useTabsStore((s) => s.activePath);
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
 
@@ -743,7 +746,8 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                   size="sm"
                   variant="default"
                   icon="sync"
-                  onClick={() => refresh()}
+                  onClick={() => refreshOp()}
+                  loading={refreshing}
                   title="Refresh"
                 >
                   Refresh

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -25,7 +25,7 @@ import { runAction } from "@/features/actions/runAction";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
-import { headUpstream, resolveConflictsOp } from "@/features/repo/ops";
+import { headUpstream, refreshOp, resolveConflictsOp } from "@/features/repo/ops";
 import { isCancellable, primaryActivity } from "@/features/repo/repoActivity";
 import type { ActionId } from "@/features/keymap";
 import type { BranchInfo, CommitInfo, FileStatus } from "@/lib/types";
@@ -369,7 +369,9 @@ export function buildCommands(): PaletteItem[] {
     {
       type: "command", id: "action:refresh", search: "Refresh repository",
       label: "Refresh repository", icon: "sync", actionId: "repo.refresh",
-      run: direct(() => void repo.refreshAll()),
+      run: direct(() => {
+        refreshOp();
+      }),
     },
     {
       type: "command", id: "action:clone", search: "Clone repository git url",

--- a/src/features/repo/LoadingStatus.test.tsx
+++ b/src/features/repo/LoadingStatus.test.tsx
@@ -10,7 +10,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-import { LoadingStatus, SHOW_AFTER_MS } from "./LoadingStatus";
+import { LoadingStatus } from "./LoadingStatus";
+import { SHOW_AFTER_MS } from "./elapsed";
 import { useRepoStore } from "./useRepoStore";
 import { emptySlice } from "./repoSlice";
 import type { LoadingTask } from "./loadingTasks";

--- a/src/features/repo/LoadingStatus.tsx
+++ b/src/features/repo/LoadingStatus.tsx
@@ -14,20 +14,9 @@
 import React from "react";
 
 import { PGIcon, PGStatusItem } from "@/design";
-import { formatElapsed, useDelayedFlag, useElapsed } from "./elapsed";
+import { formatElapsed, SHOW_AFTER_MS, useDelayedFlag, useElapsed } from "./elapsed";
 import { byAge, loadingSummary, type LoadingTask } from "./loadingTasks";
 import { useRepoStore } from "./useRepoStore";
-
-/**
- * How long a refresh must run before it is worth mentioning.
- *
- * The flicker floor, and the reason this is tolerable in a status bar at all: a
- * refresh runs on every tab switch, every commit and after every network op,
- * and almost always finishes inside 100 ms. Without the delay the corner of the
- * screen would strobe all day. What survives the delay is the refresh that did
- * not finish quickly — the only one anybody wants to read about.
- */
-export const SHOW_AFTER_MS = 400;
 
 /** One row of the expanded panel: what it is, and how long it has been. */
 function TaskRow({ task }: { task: LoadingTask }) {

--- a/src/features/repo/elapsed.ts
+++ b/src/features/repo/elapsed.ts
@@ -36,6 +36,19 @@ export function useElapsed(startedAt: number | null): number | null {
 }
 
 /**
+ * How long a refresh must run before an indicator nobody asked for is worth
+ * showing.
+ *
+ * The flicker floor. A refresh runs on every tab switch, every commit and after
+ * every network op, and almost always finishes inside 100 ms. What survives the
+ * delay is the refresh that did NOT finish quickly — the only one anybody wants
+ * to read about. Shared by the status-bar popover (`LoadingStatus`) and the
+ * titlebar Refresh button (`refreshSpinner`) so the two agree on what "slow"
+ * means.
+ */
+export const SHOW_AFTER_MS = 400;
+
+/**
  * `active`, but only after it has been continuously true for `delayMs`.
  *
  * The flicker floor. A refresh is ten backend reads that usually finish inside

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -12,6 +12,7 @@ import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import { currentBranch, isConflicted, isStaged, isUnstaged } from "@/lib/derive";
 import type { FileStatus } from "@/lib/types";
+import { markRefreshRequested } from "./refreshSpinner";
 import { useRepoStore } from "./useRepoStore";
 import {
   describeUndo,
@@ -147,6 +148,8 @@ export function unstageAllOp(): boolean {
 export function refreshOp(): boolean {
   const repo = useRepoStore.getState();
   if (!repo.current) return false;
+  // After the guard, so declining to refresh never spins the button.
+  markRefreshRequested();
   void repo.refreshAll();
   return true;
 }

--- a/src/features/repo/refreshSpinner.test.tsx
+++ b/src/features/repo/refreshSpinner.test.tsx
@@ -1,0 +1,215 @@
+// The Refresh button's spinner — and specifically the two cases it has to tell
+// apart.
+//
+// Both wrong answers are one line long and look right in review. Bound straight
+// to `s.loading` the button twitches on every commit and tab switch; bound to
+// `useDelayedFlag(loading, 400)` a click on Refresh in a warm repository does
+// nothing visible at all. What is worth pinning is that neither happens.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import { PGButton } from "@/design";
+import { SHOW_AFTER_MS } from "./elapsed";
+import {
+  markRefreshRequested,
+  MIN_SPIN_MS,
+  resetRefreshRequests,
+  useRefreshSpinner,
+} from "./refreshSpinner";
+import { refreshOp } from "./ops";
+import { emptySlice } from "./repoSlice";
+import { useRepoStore } from "./useRepoStore";
+import { resetInvokeMock } from "@/test/invokeMock";
+
+/**
+ * The real button, so this covers the hook AND the `loading` → `.pg-spin`
+ * contract it depends on. A hook that returns the right boolean into a prop
+ * that no longer animates is still a button that does not spin.
+ */
+function Probe() {
+  return (
+    <PGButton icon="sync" loading={useRefreshSpinner()}>
+      Refresh
+    </PGButton>
+  );
+}
+
+function spinning(container: HTMLElement): boolean {
+  return container.querySelector(".pg-spin") !== null;
+}
+
+/** Let the mount effects settle without moving the clock. */
+function flush() {
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+}
+
+function setLoading(loading: boolean) {
+  act(() => {
+    useRepoStore.setState({ loading });
+  });
+}
+
+function tick(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  resetRefreshRequests();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "r1", path: "/repo", head: "main" },
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("a refresh nobody asked for", () => {
+  it("does not spin at all when nothing is loading", () => {
+    const { container } = render(<Probe />);
+    tick(SHOW_AFTER_MS + MIN_SPIN_MS);
+    expect(spinning(container)).toBe(false);
+  });
+
+  it("stays still through the flicker floor", () => {
+    // What a commit or a tab switch looks like: `loading` flips, and is back
+    // down inside 100 ms. The button must not notice.
+    const { container } = render(<Probe />);
+    setLoading(true);
+    tick(SHOW_AFTER_MS - 50);
+    expect(spinning(container)).toBe(false);
+    setLoading(false);
+    tick(MIN_SPIN_MS);
+    expect(spinning(container)).toBe(false);
+  });
+
+  it("does spin once it has run past the floor", () => {
+    // The `/mnt/c`-under-WSL case (#274): slow enough that saying nothing is
+    // the wrong answer, whoever started it.
+    const { container } = render(<Probe />);
+    setLoading(true);
+    tick(SHOW_AFTER_MS + 50);
+    expect(spinning(container)).toBe(true);
+    setLoading(false);
+    flush();
+    expect(spinning(container)).toBe(false);
+  });
+});
+
+describe("a refresh the user asked for", () => {
+  it("spins immediately, without waiting out the floor", () => {
+    const { container } = render(<Probe />);
+    act(() => {
+      markRefreshRequested();
+      useRepoStore.setState({ loading: true });
+    });
+    expect(spinning(container)).toBe(true);
+  });
+
+  it("keeps spinning for the minimum even when the work is already done", () => {
+    // The acknowledgement. A 40 ms quarter-turn reads as a rendering glitch,
+    // not as "I heard you".
+    const { container } = render(<Probe />);
+    act(() => {
+      markRefreshRequested();
+      useRepoStore.setState({ loading: true });
+    });
+    setLoading(false);
+    tick(MIN_SPIN_MS - 50);
+    expect(spinning(container)).toBe(true);
+  });
+
+  it("stops once the minimum has elapsed", () => {
+    const { container } = render(<Probe />);
+    act(() => {
+      markRefreshRequested();
+      useRepoStore.setState({ loading: true });
+    });
+    setLoading(false);
+    tick(MIN_SPIN_MS + 50);
+    expect(spinning(container)).toBe(false);
+  });
+
+  it("hands off to the slow path without a gap when the refresh is long", () => {
+    // The two windows overlap on purpose: the hold expires at MIN_SPIN_MS and
+    // the delayed flag came up at SHOW_AFTER_MS, so a nine-second refresh spins
+    // continuously rather than blinking off in the middle.
+    const { container } = render(<Probe />);
+    act(() => {
+      markRefreshRequested();
+      useRepoStore.setState({ loading: true });
+    });
+    let at = 0;
+    for (const target of [SHOW_AFTER_MS - 50, SHOW_AFTER_MS + 50, MIN_SPIN_MS + 50, 9000]) {
+      tick(target - at);
+      at = target;
+      expect(spinning(container), `still loading at ${at}ms`).toBe(true);
+    }
+    setLoading(false);
+    flush();
+    expect(spinning(container)).toBe(false);
+  });
+
+  it("restarts the hold when the user asks again", () => {
+    const { container } = render(<Probe />);
+    act(() => {
+      markRefreshRequested();
+      useRepoStore.setState({ loading: true });
+    });
+    setLoading(false);
+    tick(MIN_SPIN_MS - 50);
+    act(() => {
+      markRefreshRequested();
+    });
+    tick(MIN_SPIN_MS - 50);
+    expect(spinning(container)).toBe(true);
+    tick(100);
+    expect(spinning(container)).toBe(false);
+  });
+});
+
+describe("mounting", () => {
+  it("does not read earlier requests as one the user just made", () => {
+    // A second repository window, or a titlebar remounting on a tab switch,
+    // must not open already spinning.
+    act(() => {
+      markRefreshRequested();
+    });
+    const { container } = render(<Probe />);
+    flush();
+    expect(spinning(container)).toBe(false);
+  });
+});
+
+describe("refreshOp", () => {
+  // The button, `Mod+Alt+Y` and the palette all come through here — that shared
+  // entry point is what lets one marker cover all three.
+  it("marks the request, so the button spins for a hotkey too", () => {
+    const refreshAll = vi.fn(async () => {});
+    useRepoStore.setState({ refreshAll });
+    const { container } = render(<Probe />);
+    act(() => {
+      expect(refreshOp()).toBe(true);
+    });
+    expect(refreshAll).toHaveBeenCalledTimes(1);
+    expect(spinning(container)).toBe(true);
+  });
+
+  it("marks nothing when it declines for want of a repository", () => {
+    useRepoStore.setState({ current: null });
+    const { container } = render(<Probe />);
+    act(() => {
+      expect(refreshOp()).toBe(false);
+    });
+    tick(SHOW_AFTER_MS + MIN_SPIN_MS);
+    expect(spinning(container)).toBe(false);
+  });
+});

--- a/src/features/repo/refreshSpinner.ts
+++ b/src/features/repo/refreshSpinner.ts
@@ -1,0 +1,98 @@
+// Does the titlebar's Refresh button spin?
+//
+// The obvious wiring — `loading={useRepoStore(s => s.loading)}` — is wrong, and
+// `elapsed.ts` already explains why: `loading` flips on every tab switch, every
+// commit and after every network op, and almost always settles inside 100 ms.
+// Bound straight to the button it would twitch all day and mean nothing.
+//
+// The inverse is wrong too. `useDelayedFlag(loading, 400)` never strobes, but a
+// click on Refresh in a warm repository would then produce no feedback at all,
+// which is the whole reason the button wants an animation.
+//
+// So the two cases are told apart by WHO asked:
+//
+//   - The user asked (button, `Mod+Alt+Y`, the palette) → spin immediately, and
+//     keep spinning for `MIN_SPIN_MS` even when the work is already done. A
+//     60 ms quarter-turn reads as a glitch; the floor is what turns it into an
+//     acknowledgement.
+//   - Something else asked (a commit finishing, a tab switch) → spin only once
+//     it has run past `SHOW_AFTER_MS`, the same flicker floor the status-bar
+//     indicator uses. A refresh nobody asked for is worth showing exactly when
+//     it is slow enough to be in the way — a `/mnt/c` repository under WSL
+//     (#274) spends nine seconds here.
+//
+// The two overlap on purpose: `MIN_SPIN_MS` outlasts `SHOW_AFTER_MS`, so a slow
+// user-invoked refresh hands off from the hold to the delayed flag without a
+// gap in the middle.
+
+import React from "react";
+
+import { SHOW_AFTER_MS, useDelayedFlag } from "./elapsed";
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * How long the button spins for a refresh the user asked for, however fast the
+ * backend actually was.
+ */
+export const MIN_SPIN_MS = 450;
+
+// A plain counter rather than a field on `useRepoStore`: this is not repository
+// state. It is per-window, transient, and it must survive `emptySlice()` on a
+// tab switch — a slice field would be reset out from under a spin in progress.
+let requests = 0;
+const listeners = new Set<() => void>();
+
+/**
+ * Record that the USER asked for the refresh that is about to start.
+ *
+ * Called by `refreshOp()`, which is the single entry point the button, the
+ * keymap action and the palette command all share — so a fourth way to ask for
+ * a refresh gets the spinner by going through `refreshOp` too, and not by
+ * calling this.
+ */
+export function markRefreshRequested(): void {
+  requests += 1;
+  for (const l of listeners) l();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+const read = () => requests;
+
+/**
+ * Test seam: forget the requests made by earlier cases. Leaves `listeners`
+ * alone — dropping a live subscriber's callback would wedge it, and the test
+ * renderer unmounts between cases anyway.
+ */
+export function resetRefreshRequests(): void {
+  requests = 0;
+}
+
+/** Whether the Refresh button should be showing its spinner right now. */
+export function useRefreshSpinner(): boolean {
+  const loading = useRepoStore((s) => s.loading);
+  const slow = useDelayedFlag(loading, SHOW_AFTER_MS);
+
+  const seen = React.useSyncExternalStore(subscribe, read, read);
+  const [held, setHeld] = React.useState(false);
+
+  // The count at mount is the baseline, so mounting mid-session does not read
+  // every earlier refresh as one the user just asked for. It is deliberately
+  // never updated: after the first request the ref only exists to make that
+  // first comparison false, and the effect re-runs on each later increment.
+  const baseline = React.useRef(seen);
+
+  React.useEffect(() => {
+    if (seen === baseline.current) return;
+    setHeld(true);
+    const id = window.setTimeout(() => setHeld(false), MIN_SPIN_MS);
+    return () => window.clearTimeout(id);
+  }, [seen]);
+
+  return held || slow;
+}


### PR DESCRIPTION
The titlebar's Fetch, Pull and Push buttons already pass `loading` to
`PGButton` and get a spinning glyph for free. Refresh never did - so the one
button whose entire job is "reload" was the one that never said it was working.

### Why not the one-liner

Both obvious fixes are wrong, in opposite directions:

- **`loading={s.loading}`** - that flag flips on every tab switch, every commit
  and after every network op, and almost always settles inside 100 ms.
  `elapsed.ts` already documents it as something an indicator must not bind to
  directly; bound to the button, the titlebar twitches all day.
- **`useDelayedFlag(s.loading, SHOW_AFTER_MS)`** - never strobes, but in a warm
  repository a refresh finishes well inside 400 ms, so clicking Refresh would
  show nothing at all. A status line may stay silent about work nobody asked
  about; a button the user just pressed may not.

### What it does instead

`features/repo/refreshSpinner.ts` tells the two cases apart by **who asked**:

- A refresh the user asked for spins immediately and holds for `MIN_SPIN_MS`
  (450) whatever the backend did - a 40 ms quarter-turn reads as a rendering
  glitch, not as an acknowledgement.
- A refresh nobody asked for spins only past `SHOW_AFTER_MS`, which still
  catches the nine-second `/mnt/c` refresh under WSL (#274).
- The windows overlap on purpose, so a slow user-invoked refresh hands off from
  the hold to the delayed flag without blinking off in the middle.

The marker lives in `refreshOp()` - after its `if (!repo.current) return false`
guard, so a declined refresh spins nothing. That op is already the shared entry
point for the button, `Mod+Alt+Y` and the palette command, which is what lets
one marker cover all three; the palette carried its own copy of the op's body
and now routes through it.

The request counter is a module-level `useSyncExternalStore` rather than a
`RepoSlice` field: it is per-window and transient, and a slice field would be
reset by the `emptySlice()` a tab switch performs, out from under a spin already
in progress.

`SHOW_AFTER_MS` moves from `LoadingStatus.tsx` to `elapsed.ts` beside
`useDelayedFlag`, so both surfaces agree on what "slow" means without a logic
module importing a component.

### Verification

- `pnpm test` - 358 files, 3566 tests green (re-run after the doc edits).
- `pnpm tsc --noEmit` clean.
- **Both wrong answers planted and confirmed caught.** The naive
  `return loading` trips the flicker-floor case; `return slow` trips the
  immediate-feedback case. Removing `loading={refreshing}` from `AppShell` is
  caught by `noUnusedLocals` rather than by a test.
- e2e (Docker, snapshot rebuilt): `keymap.e2e.ts` 27 passing, `palette.e2e.ts`
  8 passing - the two specs that drive the refresh path.

Generated with [Claude Code](https://claude.com/claude-code)
