### PR TITLE
feat(commits): reword, drop and undo a commit from the History menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,14 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   file starts behaving differently depending on where you opened it; the blob
   ceiling is `blob_ceiling`, raised per file and never removed.
   (`docs/dev/frontend.md`, `docs/dev/backend.md`)
+- **One rewrite confirm — `confirmRewrite`** (`features/commits/
+  rewriteWarning.ts`). Every entry that rewrites history (reword, undo, fixup,
+  squash, drop) goes through it, so all five say the same thing about a commit
+  already on the upstream; a sixth joins it rather than asking its own way.
+  `isPublished` is `aheadBehind(oid, upstream).behind === 0` and reversing that
+  pair inverts the warning SILENTLY. Rewording HEAD is a message-only amend, not
+  a one-step rebase plan — the engine refuses a dirty worktree.
+  (`docs/dev/frontend.md`, `docs/dev/backend.md`)
 - **One commit-message composition surface** — `features/commits/message/`
   (`useCommitComposer` + `CommitMessageBar`). A new way to compose message text
   joins it; it never grows a second surface beside it. The box stays plain text

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -405,7 +405,17 @@ commands/        Thin Tauri handlers, one file per area:
 │                explorer.exe / xdg-open exit-code traps). LOG_FILE here must
 │                track the file_name configured in lib.rs — the plugin does not
 │                report what it picked. Thin over src-tauri/src/diagnostics.rs
-├── commits.rs   get_log, commit, file_history, verify_commit (SELECTED commit
+├── commits.rs   get_log, commit, amend_head_message (HEAD's message and
+│                NOTHING else — `tree: None` on Commit::amend reuses the
+│                original tree, so the index is never read. That is what
+│                separates it from commit(amend: true), which writes the index
+│                tree and would fold staged changes into the commit being
+│                reworded, and it is why it works on a dirty worktree — which
+│                the rebase engine refuses, making a one-step Reword plan
+│                useless for the most common reword of all. Takes the oid the
+│                caller believed was HEAD and refuses a mismatch, checked
+│                under the SAME lock as the amend), file_history,
+│                verify_commit (SELECTED commit
 │                only, never per row), commit_notes, which is lazy for the
 │                same reason (#253 — the log walk is the hot path, so notes are
 │                read for the selected commit and cost the page nothing), and

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -1496,6 +1496,51 @@ Two things about it that are easy to get wrong:
   because a timing test in a parallel test binary gets warmed by a sibling and
   passes vacuously.
 
+## `amend_head_message` — HEAD's message and nothing else
+
+The reword path for the commit HEAD is on. `Commit::amend` with **`tree: None`**
+reuses the commit's original tree, so the index is never read — git's
+`commit --amend --only -m`.
+
+- **Why HEAD does not go through the rebase engine.** `RebaseAction::Reword` has
+  worked end to end for as long as the Rebase screen has existed, but
+  `rebase_start_with_progress` refuses any worktree or index modification
+  (`libgit2.rs`, the `is_wt_modified()` block). Rewording the commit you are
+  sitting on, while you have uncommitted work, is the most common reword there
+  is — so it gets a path that needs no replay, and nothing downstream changes id.
+- **Why not `commit` with `amend: true`.** That writes the **index** tree
+  (`fresh_index(repo)?; index.write_tree()?`), so it would silently fold staged
+  changes into the commit being reworded. `amend_ignores_staged_changes` is the
+  assertion that fails if anyone reimplements this on top of it.
+- **`expected_oid` is checked TWICE, and both checks earn their place.** An
+  advisory read first, so a doomed reword does not run the user's `commit-msg`
+  hook; then the authoritative one **inside the same `with_repo` closure as the
+  amend**, because the hooks run outside the lock and have just given HEAD time
+  to move. Measured: deleting the second check leaves every other test in
+  `tests/amend_message.rs` green — the early check absorbs them all. The one
+  test that catches it is
+  `a_head_move_during_the_hook_window_is_refused`, whose `commit-msg` hook makes
+  its own commit (with `--no-verify` and a one-shot marker, or it forks until the
+  OS refuses). A mismatch returns `InvalidArgument` and writes nothing.
+- **The author is preserved; only the committer is refreshed**, as git's
+  `--amend` does. Note this deliberately differs from `commit(amend: true)`,
+  which passes the current signature as the author too.
+- **It goes through `commit_signed`**, so a repository that signs its commits
+  does not get an unsigned one back and a signing failure creates nothing
+  (`signing.rs::a_reworded_commit_keeps_a_signature`,
+  `a_reword_whose_signing_fails_changes_nothing`).
+- **Hooks: the message ones run, `pre-commit` does not.** A documented deviation
+  from git, which runs all three. A hook that validates message format is
+  exactly what should fire on a reword; one that runs tests has nothing to
+  inspect when the tree cannot change by construction. `post-commit` runs with
+  its exit code discarded, as in `commit`. `no_verify` skips them all.
+
+**Known gap, pre-existing and not fixed here:** the rebase engine's own `Reword`
+arm calls `Commit::amend` directly and therefore **drops a signature**. That
+affects every reword of an older commit and every `Reword` step run from the
+Rebase screen, so it predates this op and belongs to its own change with its own
+tests.
+
 ## Stacked branches: `--update-refs` is implemented, not passed through (#240)
 
 Our rebase is our **own replay** — `rebase_start_with_progress` detaches at the

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -845,6 +845,56 @@ therefore belongs in `features/`, not `design/`.
   `MAX_BARREN_PAGES`, or it walks the whole repository. New client-side log
   filters inherit that trap.
 
+## Rewriting one commit from the History menu
+
+Five entries in `commitMenuItems` rewrite history — *Edit commit message*,
+*Undo this commit*, *Fixup*, *Squash*, *Drop this commit*. Each flow lives in
+its own `features/commits/` module and the menu entry is a few lines calling it,
+which is the shape `buildRebasePlan` / `runRebasePlan` / `squashMessage` already
+have. Splitting `context-menu.tsx` was considered and rejected — see the spec
+(`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`); the short
+version is that `commitMenuItems` cannot leave without also extracting the
+`ContextMenuItem` type and `customActionItems`, which every other builder shares.
+
+- **`rewriteCtx(commits)` is gathered at menu-BUILD time and is synchronous.**
+  Menu building runs on every right-click; the one async thing a rewrite needs —
+  the published-commit check — is made by the flow inside `onClick`. A store read
+  moved into a flow would make the flows untestable without a store, which is
+  the reason the context is a parameter rather than something they fetch.
+- **`confirmRewrite` is the single confirm for all five.** It appends
+  `rewriteWarning`'s sentence when `isPublished` says the commit is already
+  contained in the branch's upstream. `isPublished` is
+  `aheadBehind(repoId, oid, upstream).behind === 0` — "on `a`, not on `b`" — and
+  **reversing that pair inverts the warning silently**, so the argument order has
+  its own test. An unresolvable upstream answers `false` rather than throwing: a
+  warning is a courtesy and must never block the operation.
+- **Squash puts the warning in its PROMPT's body, not a confirm in front of it.**
+  Squash already asks a question, and a second modal over the first cannot be
+  dismissed predictably (see the queue note in `dialog.tsx`). Same sentence, one
+  dialog.
+- **Reword takes two paths, and the split is load-bearing.** For HEAD it calls
+  `useRepoStore.amendMessage`, a message-only amend that needs no replay and so
+  tolerates a dirty worktree; for an older commit it builds a one-target
+  `Reword` plan. The rebase engine refuses a dirty worktree, so routing HEAD
+  through a plan would fail the most common reword there is. See
+  `docs/dev/backend.md` for the op.
+- **An unchanged message is a no-op.** Accepting the reword prompt without
+  editing returns early: rewriting the commit would give every descendant a new
+  id for nothing, and on a published commit it would demand a force-push for
+  nothing.
+- **A merge is refused per MECHANISM, not per commit shape.** *Edit commit
+  message* disables a merge only on the rebase path — `buildRebasePlan` always
+  emits `Drop` for a merge, so rewording an older one would flatten history —
+  while a merge sitting at HEAD stays editable, because amending keeps its
+  parents. *Drop* refuses every merge for the same underlying reason.
+- **Each disabled entry says WHY in its own label**, as the neighbouring rebase
+  entries do. `context-menu.rewrite.test.tsx` asserts the label text, so it is
+  the contract rather than decoration.
+- **No keybindings and no keymap actions.** Rider's `Ctrl+R, R` is a two-stroke
+  sequence and `chord.ts` is single-stroke only (modifiers + one base key, plus
+  the synthetic `DoubleShift`), so matching it needs a prefix-key layer in the
+  chord core — a separate feature from these entries.
+
 ## How a commit date is written (#354)
 
 - **`lib/commitDate.ts` is the ONE place a timestamp becomes text.** History

--- a/docs/superpowers/plans/2026-09-08-commit-menu-parity-pr1-rewrite-entries.md
+++ b/docs/superpowers/plans/2026-09-08-commit-menu-parity-pr1-rewrite-entries.md
@@ -1,0 +1,1673 @@
+# Commit menu parity — PR1: the history-rewriting entries
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add *Edit commit message…*, *Drop this commit* and *Undo this commit…*
+to the History commit context menu, behind a shared warning that names the
+force-push when the commit is already published.
+
+**Architecture:** Each entry's flow lives in its own `features/commits/` module
+and the menu entry is a few lines that call it — the shape `buildRebasePlan` /
+`runRebasePlan` / `squashMessage` already have. Rewording an *older* commit
+reuses the rebase engine's existing `Reword` action through a new
+`buildRebasePlan` mode; rewording **HEAD** takes a new message-only amend
+backend op, because the rebase engine refuses a dirty worktree.
+
+**Tech Stack:** Tauri 2 / Rust (git2), React 19 / TypeScript, Zustand, vitest,
+`cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md` — read
+it first; this plan argues from it and does not repeat its reasoning.
+
+## Global Constraints
+
+- **Node 22 + pnpm**, Rust stable. This session's shell does not inherit the
+  interactive rc, and the worktree guard refuses the `export PATH="$HOME/…"`
+  line from CLAUDE.md — invoke tools by absolute path instead:
+  `~/Library/pnpm/pnpm`, `~/.cargo/bin/cargo`.
+- **The worktree guard also refuses compound shell commands containing a `git`
+  token** (`libgit2.rs`, `.github/`, `pgit`). Run those as plain, separate
+  commands.
+- **Every IPC-crossing fn returns `AppResult<T>`.** No new `AppError` variant in
+  this PR — the HEAD-moved refusal reuses `InvalidArgument(String)`, which
+  already carries a message and already has `appErrorDetail` prose. Adding a
+  variant would require the TS union and `appErrorDetail` in the same commit
+  (`test/appErrors.test.ts` fails the build otherwise), and this refusal does not
+  need its own remedy surface.
+- **Never `Command::new` outside `src-tauri/src/proc.rs`** — a guard test fails
+  the build. Nothing in this PR spawns a process.
+- **`git2::Repository` is `Send` not `Sync`.** Wrap git2 work in
+  `spawn_blocking`; use `with_repo` (the exclusive/write path), and **verify and
+  mutate under ONE lock acquisition** — the amend's HEAD check and the amend
+  itself go in the same `with_repo` closure.
+- **A new command must be added to `docs/dev/architecture.md` in the same
+  commit** or `test/docs.test.ts` fails the build.
+- **No native `<select>`, no `window.confirm`/`prompt`** — `pgConfirm` /
+  `pgPrompt` from `@/design`; a dismissal is "no answer", never a choice.
+- **Menu building stays synchronous and allocation-cheap.** It runs on every
+  right-click. Every `await` in this PR happens inside an `onClick`.
+- Commit style: `feat(scope): …` / `fix(scope): …` / `test: …` / `docs: …`,
+  imperative subject under 72 chars, optional body with **Why:**, trailing
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `fullCommitMessage` — one owner for "this commit's message as text"
+
+`combinedSquashMessage` (`src/features/commits/squashMessage.ts`) already renders
+`summary\n\nbody` per commit. The reword prompt needs exactly that for one
+commit, so the single-commit case is extracted and the squash helper is rewritten
+to call it. Two renderers of a commit message would drift.
+
+**Files:**
+- Create: `src/features/commits/commitMessageText.ts`
+- Create: `src/features/commits/commitMessageText.test.ts`
+- Modify: `src/features/commits/squashMessage.ts`
+
+**Interfaces:**
+- Consumes: `CommitInfo` from `@/lib/types` (`summary: string`, `body: string | null`).
+- Produces: `fullCommitMessage(commit: Pick<CommitInfo, "summary" | "body">): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/features/commits/commitMessageText.test.ts
+import { describe, expect, it } from "vitest";
+import { fullCommitMessage } from "./commitMessageText";
+
+describe("fullCommitMessage", () => {
+  it("joins summary and body with a blank line", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: "Why: y" })).toBe(
+      "feat: x\n\nWhy: y",
+    );
+  });
+
+  it("is the summary alone when there is no body", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: null })).toBe("feat: x");
+  });
+
+  it("treats a whitespace-only body as no body", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: "  \n\n " })).toBe("feat: x");
+  });
+
+  it("trims trailing whitespace off the body but keeps its internal blank lines", () => {
+    expect(
+      fullCommitMessage({ summary: "s", body: "one\n\ntwo\n\n" }),
+    ).toBe("s\n\none\n\ntwo");
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/commitMessageText.test.ts`
+Expected: FAIL — cannot resolve `./commitMessageText`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/features/commits/commitMessageText.ts
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * One commit's message as editable text: `summary`, then its body after a blank
+ * line. The same starting point `git rebase -i` hands you in an editor, minus
+ * the comment lines.
+ *
+ * The single owner of that rendering — `combinedSquashMessage` calls it per
+ * commit, and the reword prompt calls it for one. A whitespace-only body is
+ * treated as absent rather than rendered as trailing blanks, because the value
+ * goes straight into a prompt the user then edits.
+ */
+export function fullCommitMessage(
+  commit: Pick<CommitInfo, "summary" | "body">,
+): string {
+  const body = commit.body?.trim();
+  return body ? `${commit.summary}\n\n${body}` : commit.summary;
+}
+```
+
+- [ ] **Step 4: Rewrite `combinedSquashMessage` to call it**
+
+In `src/features/commits/squashMessage.ts`, replace the loop body so the
+rendering lives in one place:
+
+```ts
+import type { CommitInfo } from "@/lib/types";
+import { fullCommitMessage } from "./commitMessageText";
+
+export function combinedSquashMessage(
+  oids: readonly string[],
+  byOid: ReadonlyMap<string, CommitInfo>,
+): string {
+  const parts: string[] = [];
+  for (const oid of oids) {
+    const c = byOid.get(oid);
+    if (!c) continue;
+    parts.push(fullCommitMessage(c));
+  }
+  return parts.join("\n\n");
+}
+```
+
+- [ ] **Step 5: Run both suites and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/commitMessageText.test.ts src/features/commits/squashMessage.test.ts`
+Expected: PASS, including every pre-existing `squashMessage` assertion — the
+extraction must be behaviour-preserving.
+
+- [ ] **Step 6: Commit**
+
+```
+test(commits): pin a commit's message-as-text and reuse it for squash
+```
+
+---
+
+### Task 2: `buildRebasePlan` gains `reword` and `drop` modes
+
+**Files:**
+- Modify: `src/features/commits/buildRebasePlan.ts`
+- Modify: `src/features/commits/buildRebasePlan.test.ts`
+
+**Interfaces:**
+- Produces: two new `mode` shapes on the existing `buildRebasePlan(commits, fromOid, mode)`:
+  - `{ kind: "reword"; targetOid: string; message: string }`
+  - `{ kind: "drop"; targetOid: string }`
+
+  Callers pass the target's **first parent** as `fromOid`, so the target is
+  inside the plan. Return type is unchanged: `RebaseStep[] | null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/features/commits/buildRebasePlan.test.ts`. Match the existing
+file's fixture style — read the top of it first and reuse its commit factory
+rather than inventing a second one.
+
+```ts
+describe("reword mode", () => {
+  it("marks only the target Reword and carries its message", () => {
+    // c3 <- c2 <- c1 (newest first), reword c2 with base c1
+    const commits = [commit("c3", ["c2"]), commit("c2", ["c1"]), commit("c1", [])];
+    const plan = buildRebasePlan(commits, "c1", {
+      kind: "reword",
+      targetOid: "c2",
+      message: "new subject",
+    });
+    expect(plan).toEqual([
+      { oid: "c2", action: "Reword", message: "new subject" },
+      { oid: "c3", action: "Pick", message: null },
+    ]);
+  });
+
+  it("still drops a merge commit it replays over", () => {
+    const commits = [commit("m", ["c2", "side"]), commit("c2", ["c1"]), commit("c1", [])];
+    const plan = buildRebasePlan(commits, "c1", {
+      kind: "reword",
+      targetOid: "c2",
+      message: "new",
+    });
+    expect(plan).toEqual([
+      { oid: "c2", action: "Reword", message: "new" },
+      { oid: "m", action: "Drop", message: null },
+    ]);
+  });
+
+  it("returns null when the base is outside the loaded range", () => {
+    const commits = [commit("c2", ["c1"]), commit("c1", [])];
+    expect(
+      buildRebasePlan(commits, "nope", { kind: "reword", targetOid: "c2", message: "x" }),
+    ).toBeNull();
+  });
+});
+
+describe("drop mode", () => {
+  it("marks only the target Drop and leaves newer commits picked", () => {
+    const commits = [commit("c3", ["c2"]), commit("c2", ["c1"]), commit("c1", [])];
+    expect(buildRebasePlan(commits, "c1", { kind: "drop", targetOid: "c2" })).toEqual([
+      { oid: "c2", action: "Drop", message: null },
+      { oid: "c3", action: "Pick", message: null },
+    ]);
+  });
+
+  it("carries no message on the dropped step", () => {
+    const commits = [commit("c2", ["c1"]), commit("c1", [])];
+    const plan = buildRebasePlan(commits, "c1", { kind: "drop", targetOid: "c2" });
+    expect(plan?.[0].message).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/buildRebasePlan.test.ts`
+Expected: FAIL — TypeScript rejects the new `mode` shapes, and the `reword`/
+`drop` steps come back as `Pick`.
+
+- [ ] **Step 3: Extend the mode union and the doc comment**
+
+In `buildRebasePlan.ts`, add to the `mode` parameter union:
+
+```ts
+    | { kind: "reword"; targetOid: string; message: string }
+    | { kind: "drop"; targetOid: string }
+```
+
+and to the doc comment's `mode` list, above the merge paragraph:
+
+```
+ *   - { kind: "reword", targetOid, message }: target becomes "Reword" carrying
+ *     the new message. Base is the target's first parent, so the target is
+ *     inside the plan.
+ *   - { kind: "drop", targetOid }: target becomes "Drop"; everything newer stays
+ *     a pick and replays onto the target's parent.
+```
+
+- [ ] **Step 4: Add the two arms**
+
+In the `oldestFirst.map` callback, after the existing `fixup` arm and before the
+`squash` arm — order does not matter functionally, but keep the arms in the same
+order as the union so a reader can check coverage at a glance:
+
+```ts
+    } else if (mode.kind === "reword" && c.oid === mode.targetOid) {
+      action = "Reword";
+      message = mode.message;
+    } else if (mode.kind === "drop" && c.oid === mode.targetOid) {
+      action = "Drop";
+```
+
+The merge check stays FIRST in the chain, so a merge is still emitted as `Drop`
+whatever the mode asks — that is git's own default and the backend refuses
+anything else on a merge.
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/buildRebasePlan.test.ts src/features/commits/buildRebasePlan.merge.test.ts`
+Expected: PASS, new and pre-existing.
+
+- [ ] **Step 6: Commit**
+
+```
+feat(rebase): build reword and drop plans from one commit
+```
+
+---
+
+### Task 3: the message-only amend backend op
+
+The op the HEAD reword path needs. `commit.amend` with `tree: None` reuses the
+commit's original tree, which is `git commit --amend --only -m`: it ignores the
+index, so it works with a dirty worktree and cannot fold in staged changes.
+
+**Files:**
+- Modify: `src-tauri/src/git/mod.rs` (the `// === commit ===` block, after `fn commit`)
+- Modify: `src-tauri/src/git/libgit2.rs` (beside the `fn commit` impl)
+- Modify: `src-tauri/src/git/cli.rs` (stub beside `fn commit`)
+- Modify: `src-tauri/src/commands/commits.rs` (after `pub async fn commit`)
+- Modify: `src-tauri/src/lib.rs` (`invoke_handler![…]`, beside `commands::commits::commit`)
+- Modify: `docs/dev/architecture.md` (the `commands/commits.rs` entry — same commit, or the docs test fails)
+- Create: `src-tauri/tests/amend_message.rs`
+
+**Interfaces:**
+- Produces:
+  - Trait: `fn amend_head_message(&self, repo_id: &RepoId, expected_oid: &str, message: &str, no_verify: bool) -> AppResult<CommitResult>`
+  - Command: `amend_head_message(repo_id: String, expected_oid: String, message: String, no_verify: Option<bool>) -> AppResult<CommitResult>`
+  - `CommitResult` is the existing type `fn commit` already returns — reused, not redefined.
+
+- [ ] **Step 1: Write the failing Rust tests**
+
+```rust
+// src-tauri/tests/amend_message.rs
+mod support;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+/// The whole point of the op: the message changes, the tree does not.
+#[test]
+fn amend_changes_the_message_and_keeps_the_tree() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let before = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_before = before.tree_id();
+    let author_before = before.author().when().seconds();
+
+    let out = backend
+        .amend_head_message(&handle.id, &before.id().to_string(), "reworded", false)
+        .expect("amend");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "reworded");
+    assert_eq!(after.tree_id(), tree_before, "tree must be untouched");
+    assert_ne!(after.id(), before.id(), "a reworded commit is a new object");
+    assert_eq!(out.oid, after.id().to_string());
+    // Author is preserved; only the committer is refreshed, as git does.
+    assert_eq!(after.author().when().seconds(), author_before);
+    assert_eq!(after.parent_count(), before.parent_count());
+}
+
+/// The reason the op takes `expected_oid` at all: HEAD can move between the
+/// menu opening and the click landing.
+#[test]
+fn amend_refuses_when_head_has_moved() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let stale = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    tr.add_commit("other.txt", "x\n", "a second commit");
+
+    let err = backend
+        .amend_head_message(&handle.id, &stale, "reworded", false)
+        .expect_err("must refuse a stale oid");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    // And it changed nothing.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.message().unwrap(), "a second commit");
+}
+
+/// A dirty worktree is exactly the case the rebase engine cannot serve, so this
+/// op must serve it — and must leave the dirt alone.
+#[test]
+fn amend_works_with_a_dirty_worktree_and_does_not_consume_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello, edited\n");
+    write_file(tr.path(), "untracked.txt", "new\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_before = head.tree_id();
+
+    backend
+        .amend_head_message(&handle.id, &head.id().to_string(), "reworded", false)
+        .expect("amend with a dirty worktree");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "reworded");
+    assert_eq!(after.tree_id(), tree_before, "the edit must NOT be committed");
+    assert_eq!(
+        support::fs::read_file(tr.path(), "README.md"),
+        "hello, edited\n",
+        "the working tree must be left as it was"
+    );
+}
+
+/// The index is the other half of that guarantee: `commit(amend: true)` writes
+/// the index tree, and this op must not.
+#[test]
+fn amend_ignores_staged_changes() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "staged.txt", "staged\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("staged.txt")).unwrap();
+        index.write().unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+
+    backend
+        .amend_head_message(&handle.id, &head.id().to_string(), "reworded", false)
+        .expect("amend");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.tree_id(), head.tree_id());
+    assert!(
+        after.tree().unwrap().get_name("staged.txt").is_none(),
+        "the staged file must not be in the reworded commit"
+    );
+    // Still staged afterwards.
+    let idx = tr.repo.index().unwrap();
+    assert!(idx.get_path(std::path::Path::new("staged.txt"), 0).is_some());
+}
+
+/// An empty message is refused on this side of the IPC boundary, as `commit` does.
+#[test]
+fn amend_refuses_an_empty_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let err = backend
+        .amend_head_message(&handle.id, &head, "   \n ", false)
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+}
+
+/// An unborn HEAD has no commit to reword.
+#[test]
+fn amend_refuses_on_an_unborn_head() {
+    let tr = TempRepo::fresh();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .amend_head_message(&handle.id, "0000000", "x", false)
+        .expect_err("must refuse");
+    assert!(
+        matches!(err, AppError::Unborn | AppError::InvalidArgument(_)),
+        "got {err:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml --test amend_message`
+Expected: FAIL to compile — `amend_head_message` is not a method on `GitBackend`.
+
+- [ ] **Step 3: Add the trait method**
+
+In `src-tauri/src/git/mod.rs`, in the `// === commit ===` block right after
+`fn commit`:
+
+```rust
+    /// Replace HEAD's commit message and nothing else.
+    ///
+    /// `git commit --amend --only -m <msg>`: `tree: None` on `Commit::amend`
+    /// reuses the commit's ORIGINAL tree, so the index is not read and a dirty
+    /// worktree is fine. That is the difference from `commit(amend: true)`,
+    /// which writes the index tree and would fold staged changes into the
+    /// commit being reworded.
+    ///
+    /// `expected_oid` is what the caller believed HEAD was. HEAD can move
+    /// between a context menu opening and its click landing, so the check and
+    /// the amend happen under ONE lock acquisition; a mismatch refuses and
+    /// writes nothing.
+    fn amend_head_message(
+        &self,
+        repo_id: &RepoId,
+        expected_oid: &str,
+        message: &str,
+        no_verify: bool,
+    ) -> AppResult<CommitResult>;
+```
+
+- [ ] **Step 4: Add the `CliBackend` stub**
+
+In `src-tauri/src/git/cli.rs`, beside `fn commit`:
+
+```rust
+    fn amend_head_message(
+        &self,
+        _repo_id: &RepoId,
+        _expected_oid: &str,
+        _message: &str,
+        _no_verify: bool,
+    ) -> AppResult<CommitResult> {
+        Err(AppError::NotImplemented)
+    }
+```
+
+- [ ] **Step 5: Implement it in `Libgit2Backend`**
+
+In `src-tauri/src/git/libgit2.rs`, directly after the `fn commit` impl. Read
+`fn commit` first — this mirrors its hook and signing structure deliberately,
+and the differences are the point.
+
+```rust
+    fn amend_head_message(
+        &self,
+        repo_id: &RepoId,
+        expected_oid: &str,
+        message: &str,
+        no_verify: bool,
+    ) -> AppResult<CommitResult> {
+        use crate::git::hooks;
+        use crate::git::signature::default_signature;
+
+        // Refused HERE, before any hook runs, exactly as `commit` does: every
+        // caller of this method meant to write history.
+        if message.trim().is_empty() {
+            return Err(AppError::InvalidArgument(
+                "the commit message is empty".to_string(),
+            ));
+        }
+
+        let repo_path = self.repo_path(repo_id)?;
+
+        // `pre-commit` is deliberately NOT run: this op cannot change the tree
+        // (see `tree: None` below), so a hook that lints content has nothing to
+        // inspect. The MESSAGE hooks do run — a `commit-msg` that enforces a
+        // format is exactly what should fire on a reword. A documented
+        // deviation from `git commit --amend --only`, which runs all three.
+        let message = if no_verify {
+            message.to_string()
+        } else {
+            let git_dir = self.with_repo(repo_id, |repo| Ok(repo.path().to_path_buf()))?;
+            let msg_path = git_dir.join("COMMIT_EDITMSG");
+            std::fs::write(&msg_path, message).map_err(|e| AppError::Io(e.to_string()))?;
+            let msg_arg = msg_path
+                .to_str()
+                .ok_or_else(|| AppError::InvalidPath(msg_path.display().to_string()))?;
+
+            for (name, args) in [
+                ("prepare-commit-msg", vec![msg_arg, "message"]),
+                ("commit-msg", vec![msg_arg]),
+            ] {
+                let out = hooks::run_hook(&repo_path, name, &args)?;
+                if out.rejected() {
+                    return Err(AppError::HookRejected(crate::error::HookRejection {
+                        hook: name.to_string(),
+                        output: out.output,
+                    }));
+                }
+            }
+
+            // Either hook may have rewritten the file; what it left is what git
+            // would commit.
+            std::fs::read_to_string(&msg_path).map_err(|e| AppError::Io(e.to_string()))?
+        };
+
+        // ONE acquisition for verify-and-mutate. Splitting these is the stash
+        // TOCTOU bug: HEAD could move between the check and the amend.
+        let oid = self.with_repo(repo_id, |repo| {
+            let head_ref = repo.head().map_err(|_| AppError::Unborn)?;
+            let head = head_ref.peel_to_commit().map_err(|_| AppError::Unborn)?;
+            if head.id().to_string() != expected_oid {
+                return Err(AppError::InvalidArgument(format!(
+                    "HEAD has moved since this commit was chosen — it is now {}, not {}",
+                    &head.id().to_string()[..7.min(head.id().to_string().len())],
+                    &expected_oid[..7.min(expected_oid.len())],
+                )));
+            }
+
+            let sig = default_signature(repo)?;
+
+            // The signing chain, so a signed commit stays signed (CLAUDE.md:
+            // one signing chain for commits AND tags). `commit_signed` needs the
+            // tree and the parents explicitly; both come from the commit being
+            // reworded, which is what makes this message-only.
+            if crate::git::signing::should_sign(repo, None)? {
+                let tree = head.tree()?;
+                return commit_signed(repo, &sig, &message, &tree, Some(&head_ref), true);
+            }
+
+            // Unsigned path. `tree: None` reuses the original tree; `author:
+            // None` preserves the author. Only the committer is refreshed.
+            let new_oid = head.amend(Some("HEAD"), None, Some(&sig), None, Some(&message), None)?;
+            Ok(new_oid.to_string())
+        })?;
+
+        Ok(CommitResult { oid })
+    }
+```
+
+**Before writing this, verify three things in the tree and adjust rather than
+assume** — this plan was written from a read of `fn commit`, not from a compile:
+
+1. `CommitResult`'s real fields (`grep -n "struct CommitResult" -A 10
+   src-tauri/src/git/types.rs`). If it carries more than `oid`, fill the rest the
+   way `fn commit` does.
+2. Whether a `should_sign`-shaped helper exists. `fn commit` decides signing
+   somewhere — find how (`grep -n "sign" src-tauri/src/git/libgit2.rs | sed -n
+   '/fn commit/,$p'` around the commit impl, and read `git/signing.rs`). Reuse
+   that decision function verbatim; do NOT re-derive the `commit.gpgsign` rule.
+   If the helper takes different arguments, match them.
+3. `commit_signed`'s signature (it is at `libgit2.rs:1415`) — it takes
+   `head: Option<&git2::Reference>` and an `amend: bool`, and it already handles
+   "an amend inherits HEAD's parents" plus the `commit (amend):` reflog message.
+
+- [ ] **Step 6: Add the Tauri command**
+
+In `src-tauri/src/commands/commits.rs`, after `pub async fn commit`:
+
+```rust
+/// Replace HEAD's commit message, leaving the tree and the index alone.
+///
+/// The reword path for HEAD. An older commit is reworded by the rebase engine
+/// instead (`RebaseAction::Reword`) — but the engine refuses a dirty worktree,
+/// and rewording the commit you are sitting on is the common case, so it gets a
+/// path that does not need one.
+#[tauri::command]
+pub async fn amend_head_message(
+    state: State<'_, AppState>,
+    repo_id: String,
+    // What the caller believed HEAD was; a mismatch refuses. See the trait doc.
+    expected_oid: String,
+    message: String,
+    // Skip the message hooks for this reword only, matching `commit`'s option.
+    no_verify: Option<bool>,
+) -> AppResult<CommitResult> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let no_verify = no_verify.unwrap_or(false);
+    tokio::task::spawn_blocking(move || {
+        backend.amend_head_message(&repo_id, &expected_oid, &message, no_verify)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+```
+
+- [ ] **Step 7: Register it**
+
+In `src-tauri/src/lib.rs`, in `invoke_handler![…]`, on the line after
+`commands::commits::commit,`:
+
+```rust
+            commands::commits::amend_head_message,
+```
+
+- [ ] **Step 8: Document it — same commit**
+
+In `docs/dev/architecture.md`, find the `commands/commits.rs` entry in the
+backend tree and add `amend_head_message` to its command list, with a clause
+saying it is message-only and why HEAD has its own path. `test/docs.test.ts`
+fails the build if a registered command appears in no doc.
+
+- [ ] **Step 9: Run the Rust tests**
+
+Run: `~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml --test amend_message`
+Expected: PASS, all six.
+
+Then the whole backend suite, because a new trait method touches every
+implementor:
+Run: `~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: PASS. Do not `cargo fmt` — CI runs no fmt/clippy gate and the crate is
+already broadly unformatted, so a formatted focused diff becomes unreviewable.
+
+- [ ] **Step 10: Prove the TOCTOU guard actually guards**
+
+A passing check proves little until you have watched it fail. Temporarily delete
+the `head.id().to_string() != expected_oid` block, re-run
+`amend_refuses_when_head_has_moved`, and confirm it FAILS. Restore the block and
+confirm it passes again. Note in the test file which test catches the removal.
+
+- [ ] **Step 11: Commit**
+
+```
+feat(commits): amend HEAD's message without touching the tree
+```
+
+---
+
+### Task 4: TS wrapper and store action
+
+**Files:**
+- Modify: `src/lib/tauri.ts` (after `export async function commit`)
+- Modify: `src/features/repo/useRepoStore.ts` (the `RepoStore` interface + the action, beside `commit`)
+- Create: `src/features/repo/useRepoStore.amendMessage.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `amendHeadMessage(repoId: string, expectedOid: string, message: string, noVerify?: boolean): Promise<CommitResult>`
+  - store action `amendMessage(expectedOid: string, message: string): Promise<boolean>` — `true` when the message was rewritten.
+
+- [ ] **Step 1: Write the failing store test**
+
+Read `src/features/repo/useRepoStore.*.test.ts` for the house mocking pattern
+(`mockInvoke`, `getInvokeCalls`) and follow it — do not invent a second one.
+
+```ts
+// src/features/repo/useRepoStore.amendMessage.test.ts
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRepoStore } from "./useRepoStore";
+// ...plus the same test setup imports the sibling store tests use.
+
+describe("amendMessage", () => {
+  beforeEach(() => {
+    // ...reset the store and the invoke mock exactly as the sibling tests do.
+  });
+
+  it("sends the expected oid so a moved HEAD is refused by the backend", async () => {
+    mockInvoke("amend_head_message", () => ({ oid: "new1234" }));
+    await useRepoStore.getState().amendMessage("old1234", "reworded");
+    const call = getInvokeCalls().find((c) => c.cmd === "amend_head_message");
+    expect(call?.args).toMatchObject({ expectedOid: "old1234", message: "reworded" });
+  });
+
+  it("refreshes the repo, so the log repaints with the new oid", async () => {
+    mockInvoke("amend_head_message", () => ({ oid: "new1234" }));
+    await useRepoStore.getState().amendMessage("old1234", "reworded");
+    expect(getInvokeCalls().some((c) => c.cmd === "get_status")).toBe(true);
+  });
+
+  it("routes a hook refusal to hookRejection, not the error banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "HookRejected", message: { hook: "commit-msg", output: "nope" } };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "bad");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().hookRejection).toMatchObject({ hook: "commit-msg" });
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("puts a missing identity in noSignature, not the error banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "NoSignature" };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "x");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().noSignature).toBe(true);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("reports any other failure in the banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "InvalidArgument", message: "HEAD has moved" };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "x");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().error).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/repo/useRepoStore.amendMessage.test.ts`
+Expected: FAIL — `amendMessage` is not a function.
+
+- [ ] **Step 3: Add the `lib/tauri.ts` wrapper**
+
+Never call `invoke` directly from a feature; the typed wrapper is the boundary.
+
+```ts
+/**
+ * Replace HEAD's commit message and nothing else — the reword path for the
+ * commit you are sitting on.
+ *
+ * `expectedOid` is what the caller believed HEAD was. The backend refuses a
+ * mismatch rather than rewording whatever happens to be there now: HEAD can
+ * move between a context menu opening and its click landing.
+ */
+export async function amendHeadMessage(
+  repoId: string,
+  expectedOid: string,
+  message: string,
+  noVerify = false,
+): Promise<CommitResult> {
+  return invoke<CommitResult>("amend_head_message", {
+    repoId,
+    expectedOid,
+    message,
+    noVerify,
+  });
+}
+```
+
+- [ ] **Step 4: Add the store action**
+
+Mirror `commit`'s catch arms — the same three failures need the same three
+surfaces, and `refreshAll()` comes before `set({ error })` in every danger-op
+catch arm. Add to the `RepoStore` interface beside `commit`:
+
+```ts
+  /**
+   * Reword HEAD in place (message only). Resolves true when history changed.
+   *
+   * `expectedOid` guards against HEAD moving under the menu — see
+   * `amendHeadMessage`.
+   */
+  amendMessage: (expectedOid: string, message: string) => Promise<boolean>;
+```
+
+and the implementation beside `async commit(`:
+
+```ts
+  async amendMessage(expectedOid, message) {
+    const repo = get().current;
+    if (!repo) return false;
+    setFor(repo.id, { hookRejection: null, noSignature: false });
+    const before = headSnapshot();
+    try {
+      await amendHeadMessageFn(repo.id, expectedOid, message);
+      await get().refreshAll();
+      // Undoable like any other history rewrite: before/after already
+      // describes putting the original commit back.
+      noteUndo(repo.id, "commit", "reword", before);
+      return true;
+    } catch (e) {
+      if (isAppError(e) && e.kind === "HookRejected") {
+        await get().refreshAll();
+        setFor(repo.id, { hookRejection: e.message as HookRejection });
+        return false;
+      }
+      if (isNoSignatureError(e)) {
+        setFor(repo.id, { noSignature: true });
+        return false;
+      }
+      setErrorFor(repo.id, e);
+      return false;
+    }
+  },
+```
+
+Import it at the top of the store the way its siblings are imported —
+`amendHeadMessage as amendHeadMessageFn`.
+
+- [ ] **Step 5: Run the test and the type-check**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/repo/useRepoStore.amendMessage.test.ts`
+Expected: PASS.
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```
+feat(commits): wire the message-only amend through the repo store
+```
+
+---
+
+### Task 5: the published-commit warning
+
+**Files:**
+- Create: `src/features/commits/rewriteWarning.ts`
+- Create: `src/features/commits/rewriteWarning.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `isPublished(repoId: string, oid: string, upstream: string | null): Promise<boolean>`
+  - `rewriteWarning(upstream: string | null, published: boolean): string | null` — the sentence, or null when there is nothing to warn about.
+  - `confirmRewrite(opts: { title: string; body: string; confirmLabel: string; danger?: boolean; repoId: string; oid: string; upstream: string | null }): Promise<boolean>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/features/commits/rewriteWarning.test.ts
+import { describe, expect, it } from "vitest";
+import { rewriteWarning } from "./rewriteWarning";
+
+describe("rewriteWarning", () => {
+  it("names the upstream and the force-push when the commit is published", () => {
+    expect(rewriteWarning("origin/main", true)).toBe(
+      "This commit is already on origin/main. Rewriting it means your next push has to be forced.",
+    );
+  });
+
+  it("is silent for an unpublished commit", () => {
+    expect(rewriteWarning("origin/main", false)).toBeNull();
+  });
+
+  it("is silent when the branch tracks nothing — there is nothing to force", () => {
+    expect(rewriteWarning(null, true)).toBeNull();
+  });
+});
+```
+
+Then the containment predicate, which is the part worth pinning because the
+argument order of `ahead_behind` is easy to get backwards:
+
+```ts
+import { isPublished } from "./rewriteWarning";
+
+describe("isPublished", () => {
+  it("is true when the commit is contained in the upstream", async () => {
+    // `behind` is what a has and b does not, so 0 means fully contained.
+    mockInvoke("ahead_behind", () => ({ ahead: 3, behind: 0, mergeBase: "abc" }));
+    expect(await isPublished("r1", "abc1234", "origin/main")).toBe(true);
+  });
+
+  it("is false when the commit is not in the upstream yet", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 2, mergeBase: "abc" }));
+    expect(await isPublished("r1", "abc1234", "origin/main")).toBe(false);
+  });
+
+  it("asks about the commit against the upstream, in that order", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 0, mergeBase: null }));
+    await isPublished("r1", "abc1234", "origin/main");
+    const call = getInvokeCalls().find((c) => c.cmd === "ahead_behind");
+    expect(call?.args).toMatchObject({ a: "abc1234", b: "origin/main" });
+  });
+
+  it("is false, not a throw, when the upstream cannot be resolved", async () => {
+    mockInvoke("ahead_behind", () => {
+      throw { kind: "InvalidRef", message: "no such ref" };
+    });
+    expect(await isPublished("r1", "abc1234", "origin/gone")).toBe(false);
+  });
+
+  it("does not ask at all when the branch tracks nothing", async () => {
+    expect(await isPublished("r1", "abc1234", null)).toBe(false);
+    expect(getInvokeCalls().some((c) => c.cmd === "ahead_behind")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/rewriteWarning.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/features/commits/rewriteWarning.ts
+import { pgConfirm } from "@/design";
+import { aheadBehind } from "@/lib/tauri";
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * Everything a rewrite flow reads, gathered by the CALLER.
+ *
+ * Shared vocabulary rather than any one flow's own type. Keeping the store reads
+ * at the call site — where menu building already reads the store synchronously —
+ * is what makes the flows unit-testable without mounting a store.
+ */
+export interface RewriteCtx {
+  /** HEAD's ancestry, newest first — what a rebase plan is defined over. */
+  commits: CommitInfo[];
+  repoId: string;
+  /** The current branch's upstream, for the published-commit warning. */
+  upstream: string | null;
+  headOid: string | null;
+}
+
+/**
+ * Is this commit already contained in the branch's upstream?
+ *
+ * `ahead_behind(a, b).behind` is "what `a` has and `b` does not", so zero means
+ * `a` is fully contained in `b` — the commit is published. One IPC call, made
+ * from an `onClick` and never while building a menu.
+ *
+ * A branch that tracks nothing is not published and is not asked about. An
+ * unresolvable upstream (a deleted remote branch, a stale config) answers
+ * "false" rather than throwing: a warning is a courtesy, and failing to compute
+ * one must never block the operation the user asked for.
+ */
+export async function isPublished(
+  repoId: string,
+  oid: string,
+  upstream: string | null,
+): Promise<boolean> {
+  if (!upstream) return false;
+  try {
+    const ab = await aheadBehind(repoId, oid, upstream);
+    return ab.behind === 0;
+  } catch {
+    return false;
+  }
+}
+
+/** The sentence a rewrite confirm gains when the commit is already pushed. */
+export function rewriteWarning(
+  upstream: string | null,
+  published: boolean,
+): string | null {
+  if (!upstream || !published) return null;
+  return `This commit is already on ${upstream}. Rewriting it means your next push has to be forced.`;
+}
+
+/**
+ * The one confirm every history-rewriting menu entry goes through, so all five
+ * of them (reword, drop, undo, squash, fixup) say the same thing about a
+ * published commit.
+ *
+ * No force-push is offered. A network write behind a menu item that does not
+ * mention pushing is a surprise, and force-with-lease is its own design
+ * question.
+ */
+export async function confirmRewrite(opts: {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  danger?: boolean;
+  repoId: string;
+  oid: string;
+  upstream: string | null;
+}): Promise<boolean> {
+  const warning = rewriteWarning(
+    opts.upstream,
+    await isPublished(opts.repoId, opts.oid, opts.upstream),
+  );
+  return pgConfirm({
+    title: opts.title,
+    body: warning ? `${opts.body}\n\n${warning}` : opts.body,
+    confirmLabel: opts.confirmLabel,
+    danger: opts.danger,
+  });
+}
+```
+
+Check `aheadBehind`'s real exported name and parameter names in
+`src/lib/tauri.ts` before writing this, and match them.
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/rewriteWarning.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+feat(commits): warn once when a rewrite touches a published commit
+```
+
+---
+
+### Task 6: the three flow modules
+
+**Files:**
+- Create: `src/features/commits/rewordCommit.ts` + `.test.ts`
+- Create: `src/features/commits/dropCommit.ts` + `.test.ts`
+- Create: `src/features/commits/undoCommit.ts` + `.test.ts`
+
+**Interfaces:**
+- Consumes: `fullCommitMessage` (Task 1), `buildRebasePlan`'s `reword`/`drop`
+  modes (Task 2), `amendMessage` (Task 4), `confirmRewrite` (Task 5),
+  `runRebasePlanNow` (existing).
+- Produces:
+  - `rewordCommit(target: { oid: string }, ctx: RewriteCtx): Promise<void>`
+  - `dropCommit(target: { oid: string }, ctx: RewriteCtx): Promise<void>`
+  - `undoCommit(target: { oid: string }, ctx: RewriteCtx): Promise<void>`
+  - `interface RewriteCtx { commits: CommitInfo[]; repoId: string; upstream: string | null; headOid: string | null }`
+    — declared in `rewriteWarning.ts` beside `confirmRewrite`, because it is the
+    shared vocabulary of every rewrite flow rather than any one flow's own type.
+    All three flow modules and `context-menu.tsx` import it from there.
+
+  One context type for all three keeps the menu's three call sites identical and
+  keeps every store read at the call site rather than inside the flows, which is
+  what makes the flows unit-testable.
+
+- [ ] **Step 1: Write the failing reword tests**
+
+The behaviours worth pinning are the branch between the two paths and the no-op
+guard — not the dialog plumbing.
+
+```ts
+// src/features/commits/rewordCommit.test.ts
+describe("rewordCommit", () => {
+  it("amends in place when the target is HEAD, with no rebase", async () => {
+    // prompt resolves "new message"
+    await rewordCommit({ oid: "head123" }, ctx({ headOid: "head123" }));
+    expect(amendMessageSpy).toHaveBeenCalledWith("head123", "new message");
+    expect(rebaseStartSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs a one-step Reword plan for an older commit", async () => {
+    await rewordCommit({ oid: "c2" }, ctx({ headOid: "c3" }));
+    expect(amendMessageSpy).not.toHaveBeenCalled();
+    expect(rebaseStartSpy).toHaveBeenCalledWith([
+      { oid: "c2", action: "Reword", message: "new message" },
+      { oid: "c3", action: "Pick", message: null },
+    ]);
+  });
+
+  it("does nothing when the message comes back unchanged", async () => {
+    // prompt resolves exactly fullCommitMessage(target)
+    await rewordCommit({ oid: "head123" }, ctx({ headOid: "head123" }));
+    expect(amendMessageSpy).not.toHaveBeenCalled();
+    expect(rebaseStartSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the prompt is dismissed", async () => {
+    // prompt resolves null
+    await rewordCommit({ oid: "head123" }, ctx({ headOid: "head123" }));
+    expect(amendMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefills the prompt with the commit's full existing message", async () => {
+    await rewordCommit({ oid: "c2" }, ctx({ headOid: "c3" }));
+    expect(promptSpy.mock.calls[0][0].initialValue).toBe("c2 subject\n\nc2 body");
+  });
+});
+```
+
+Mock `pgPrompt` / `pgConfirm` from `@/design` and the store, following the
+mocking conventions in `src/test/setup.ts` and the existing
+`context-menu.squash.test.tsx`. **Use `fireEvent`, never
+`userEvent.setup()`, anywhere a clipboard is involved** — `userEvent.setup()`
+replaces `navigator.clipboard` and silently detaches spies on it.
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/rewordCommit.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `rewordCommit.ts`**
+
+```ts
+import { pgFlash, pgPrompt } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { CommitInfo } from "@/lib/types";
+import { buildRebasePlan } from "./buildRebasePlan";
+import { fullCommitMessage } from "./commitMessageText";
+import { runRebasePlanNow } from "./runRebasePlan";
+import { confirmRewrite, type RewriteCtx } from "./rewriteWarning";
+
+/**
+ * Edit one commit's message.
+ *
+ * TWO paths, and the split is not an optimisation. The rebase engine refuses a
+ * dirty worktree, and rewording the commit you are sitting on is the common
+ * case — so HEAD gets a message-only amend that ignores the index, and only an
+ * older commit pays for a replay.
+ */
+export async function rewordCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  if (!self) return;
+
+  const existing = fullCommitMessage(self);
+  const next = await pgPrompt({
+    title: "Edit commit message",
+    body: `Rewriting ${target.oid.slice(0, 7)}.`,
+    initialValue: existing,
+    confirmLabel: "Save",
+    requireValue: true,
+    multiline: 8,
+  });
+  if (next === null) return;
+
+  // An unchanged message must not rewrite the SHA. Every downstream ref would
+  // move for nothing, and on a published commit it would demand a force-push
+  // for nothing.
+  if (next === existing) return;
+
+  const isHead = ctx.headOid === target.oid;
+  const baseOid = self.parents[0] ?? null;
+
+  if (
+    !(await confirmRewrite({
+      title: `Reword ${target.oid.slice(0, 7)}?`,
+      body: isHead
+        ? "The commit keeps its changes, author and date; only the message and the commit id change."
+        : "Every commit after this one is replayed, so they all get new ids.",
+      confirmLabel: "Reword",
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  if (isHead) {
+    if (await useRepoStore.getState().amendMessage(target.oid, next)) {
+      pgFlash("message updated");
+    }
+    return;
+  }
+
+  if (!baseOid) return;
+  const plan = buildRebasePlan(ctx.commits, baseOid, {
+    kind: "reword",
+    targetOid: target.oid,
+    message: next,
+  });
+  if (!plan) return;
+  const outcome = await runRebasePlanNow(plan);
+  if (outcome === "done") pgFlash("message updated");
+  else if (outcome === "paused") pgFlash("reword paused — see the Conflicts screen");
+}
+```
+
+- [ ] **Step 4: Run, confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/rewordCommit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing drop tests, then implement `dropCommit.ts`**
+
+```ts
+describe("dropCommit", () => {
+  it("runs a plan that drops the target and picks everything newer", async () => {
+    await dropCommit({ oid: "c2" }, ctx({ headOid: "c3" }));
+    expect(rebaseStartSpy).toHaveBeenCalledWith([
+      { oid: "c2", action: "Drop", message: null },
+      { oid: "c3", action: "Pick", message: null },
+    ]);
+  });
+
+  it("does nothing when the confirm is declined", async () => {
+    // confirm resolves false
+    await dropCommit({ oid: "c2" }, ctx({ headOid: "c3" }));
+    expect(rebaseStartSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a root commit — there is no base to replay onto", async () => {
+    await dropCommit({ oid: "c1" }, ctx({ headOid: "c3" })); // c1 has no parents
+    expect(rebaseStartSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+```ts
+// src/features/commits/dropCommit.ts — same imports as rewordCommit
+/**
+ * Remove one commit from history, replaying everything after it.
+ *
+ * Danger-confirmed: unlike a revert, nothing records that this commit existed.
+ */
+export async function dropCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  const baseOid = self?.parents[0] ?? null;
+  if (!self || !baseOid) return;
+
+  if (
+    !(await confirmRewrite({
+      title: `Drop ${target.oid.slice(0, 7)}?`,
+      body: `"${self.summary}" is removed from history and every commit after it is replayed with a new id. Nothing records that it existed — use Revert instead to undo its changes with a new commit.`,
+      confirmLabel: "Drop",
+      danger: true,
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  const plan = buildRebasePlan(ctx.commits, baseOid, {
+    kind: "drop",
+    targetOid: target.oid,
+  });
+  if (!plan) return;
+  const outcome = await runRebasePlanNow(plan);
+  if (outcome === "done") pgFlash("commit dropped");
+  else if (outcome === "paused") pgFlash("drop paused — see the Conflicts screen");
+}
+```
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/dropCommit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Write the failing undo tests, then implement `undoCommit.ts`**
+
+```ts
+describe("undoCommit", () => {
+  it("soft-resets to the parent, leaving the work staged", async () => {
+    await undoCommit({ oid: "head123" }, ctx({ headOid: "head123" }));
+    expect(resetSpy).toHaveBeenCalledWith("parent1", "Soft");
+  });
+
+  it("does nothing for a commit that is not HEAD", async () => {
+    await undoCommit({ oid: "c2" }, ctx({ headOid: "c3" }));
+    expect(resetSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a root commit — there is no parent to reset to", async () => {
+    await undoCommit({ oid: "c1" }, ctx({ headOid: "c1" })); // c1 has no parents
+    expect(resetSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+```ts
+// src/features/commits/undoCommit.ts
+/**
+ * Undo the last commit, keeping its changes staged — `reset --soft HEAD^`.
+ *
+ * HEAD only, which is the only commit this means anything for: undoing an older
+ * commit is a drop or a revert, and both have their own entry. It exists as its
+ * own entry because the alternative is right-clicking a DIFFERENT commit (the
+ * parent) and reaching into the reset submenu — this names the intent instead of
+ * the mechanism.
+ */
+export async function undoCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  if (ctx.headOid !== target.oid) return;
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  const parent = self?.parents[0] ?? null;
+  if (!self || !parent) return;
+
+  if (
+    !(await confirmRewrite({
+      title: `Undo ${target.oid.slice(0, 7)}?`,
+      body: `"${self.summary}" stops being a commit. Its changes stay in your working tree, staged and ready to commit again.`,
+      confirmLabel: "Undo commit",
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  await useRepoStore.getState().reset(parent, "Soft");
+  pgFlash("commit undone — changes are staged");
+}
+```
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/undoCommit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+feat(commits): add the reword, drop and undo-commit flows
+```
+
+---
+
+### Task 7: the three menu entries, and the squash/fixup retrofit
+
+**Files:**
+- Modify: `src/design/context-menu.tsx` (`commitMenuItems`, ~line 476-720)
+- Create: `src/design/context-menu.rewrite.test.tsx`
+
+**Interfaces:**
+- Consumes: `rewordCommit` / `dropCommit` / `undoCommit` / `RewriteCtx` (Task 6),
+  `confirmRewrite` (Task 5).
+
+- [ ] **Step 1: Write the failing menu tests**
+
+Follow `src/design/context-menu.squash.test.tsx` exactly — it already builds the
+store fixture `commitMenuItems` reads (`commits`, `branches`, `headInfo`) and has
+a `labeled(items, /re/)` helper. Reuse both.
+
+```ts
+describe("Edit commit message", () => {
+  it("is offered for a commit on this branch", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /Edit commit message/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is offered for HEAD even when HEAD is a merge — an amend keeps its parents", () => {
+    // headInfo.headOid = MERGE, and MERGE has two parents
+    const item = labeled(commitMenuItems({ sha: MERGE }), /Edit commit message/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is refused for an OLDER merge commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: OLD_MERGE }), /Edit commit message/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/merge commit/);
+  });
+
+  it("is refused for a commit that is not on this branch, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: OFF_BRANCH }), /Edit commit message/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/not on this branch/);
+  });
+});
+
+describe("Drop this commit", () => {
+  it("is refused for a merge commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: MERGE }), /Drop/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/merge commit/);
+  });
+
+  it("is refused for the root commit", () => {
+    const item = labeled(commitMenuItems({ sha: ROOT }), /Drop/);
+    expect(item.disabled).toBe(true);
+  });
+});
+
+describe("Undo this commit", () => {
+  it("is offered for HEAD", () => {
+    const item = labeled(commitMenuItems({ sha: HEAD_SHA }), /Undo this commit/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is refused for any other commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /Undo this commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/only the last commit/);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/context-menu.rewrite.test.tsx`
+Expected: FAIL — no such menu entries.
+
+- [ ] **Step 3: Add a `RewriteCtx` builder next to `ancestryLog`**
+
+In `context-menu.tsx`, beside the existing private helpers (~line 728). Reads the
+store synchronously, which is all menu building may do:
+
+```ts
+/** The store reads the rewrite flows need, gathered at menu-build time. */
+function rewriteCtx(commits: CommitInfo[]): RewriteCtx {
+  const s = useRepoStore.getState();
+  return {
+    commits,
+    repoId: s.current?.id ?? "",
+    upstream: currentBranch(s.branches)?.upstream ?? null,
+    headOid: s.headInfo?.headOid ?? null,
+  };
+}
+```
+
+Import `currentBranch` from `@/lib/derive` if it is not already imported there.
+
+- [ ] **Step 4: Add the three entries**
+
+Inside `commitMenuItems`, in the rewrite group — after the `Reset current branch
+to here` submenu and before `Fixup this commit into its parent`, so the order
+matches the spec's menu layout. `isHead` is computed once beside the existing
+`onBranch` / `isMerge` / `baseOid`:
+
+```ts
+  const headOid = useRepoStore.getState().headInfo?.headOid ?? null;
+  const isHead = !!commit?.sha && commit.sha === headOid;
+```
+
+then:
+
+```ts
+    {
+      icon: "edit",
+      label: !onBranch
+        ? "Edit commit message — not on this branch"
+        : isMerge && !isHead
+          ? "Edit commit message — merge commit"
+          : "Edit commit message…",
+      // A merge is only refused on the REBASE path: buildRebasePlan emits Drop
+      // for a merge, so rewording an older one would flatten history. Amending
+      // HEAD's own message keeps its parents, so a merge at HEAD is fine.
+      disabled: !onBranch || (isMerge && !isHead) || (!isHead && !baseOid),
+      onClick: () => {
+        if (!commit?.sha) return;
+        void rewordCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+    {
+      icon: "undo",
+      label: !isHead
+        ? "Undo this commit — only the last commit can be undone"
+        : !baseOid
+          ? "Undo this commit — root commit"
+          : "Undo this commit…",
+      disabled: !isHead || !baseOid,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void undoCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+```
+
+and after the `Squash this commit into its parent` entry:
+
+```ts
+    {
+      icon: "trash",
+      label: !onBranch
+        ? "Drop this commit — not on this branch"
+        : isMerge
+          ? "Drop this commit — merge commit"
+          : !baseOid
+            ? "Drop this commit — root commit"
+            : "Drop this commit",
+      danger: true,
+      disabled: !onBranch || isMerge || !baseOid,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void dropCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+```
+
+Check `"edit"`, `"undo"` and `"trash"` are declared in `IconName`
+(`src/design/icons.tsx`) — `test/iconSet.test.ts` fails the build for a literal
+the union does not declare. All three are already used elsewhere in this file, so
+they should be fine; verify rather than assume.
+
+- [ ] **Step 5: Retrofit the warning onto Squash and Fixup**
+
+Both already `await` inside `onClick`, so this is replacing their bare run with
+the shared confirm. In the **Fixup** entry, before `buildRebasePlan`:
+
+```ts
+        if (
+          !(await confirmRewrite({
+            title: `Fixup ${sha.slice(0, 7)} into its parent?`,
+            body: "The two commits become one, keeping the parent's message.",
+            confirmLabel: "Fixup",
+            repoId: useRepoStore.getState().current?.id ?? "",
+            oid: commit.sha,
+            upstream: currentBranch(useRepoStore.getState().branches)?.upstream ?? null,
+          }))
+        )
+          return;
+```
+
+In the **Squash** entry, the prompt already asks a question, so the warning must
+not become a second modal in front of it — a modal over a modal cannot be
+dismissed predictably (see the queue note in `dialog.tsx`). Instead, put the
+warning in the PROMPT's own `body`:
+
+```ts
+        const ctx = rewriteCtx(commits);
+        const warning = rewriteWarning(
+          ctx.upstream,
+          await isPublished(ctx.repoId, target, ctx.upstream),
+        );
+        const msg = await pgPrompt({
+          title: "Squash into parent",
+          body: warning
+            ? `Message for the combined commit — the parent's, then this one's.\n\n${warning}`
+            : "Message for the combined commit — the parent's, then this one's.",
+          // ...the rest unchanged
+        });
+```
+
+Add a test for each:
+
+```ts
+it("warns in the fixup confirm when the commit is published", async () => {
+  // ahead_behind -> { behind: 0 }
+  await labeled(commitMenuItems({ sha: B }), /Fixup/).onClick?.();
+  expect(confirmSpy.mock.calls[0][0].body).toMatch(/already on origin\/main/);
+});
+
+it("warns inside the squash PROMPT, not a second dialog in front of it", async () => {
+  await labeled(commitMenuItems({ sha: B }), /Squash/).onClick?.();
+  expect(promptSpy.mock.calls[0][0].body).toMatch(/already on origin\/main/);
+  expect(confirmSpy).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 6: Run the menu suites and the type-check**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/`
+Expected: PASS — the new file plus every pre-existing `context-menu.*` suite. The
+squash and commitdiff suites assert menu label sets, so a new entry may require
+updating an expected list; update those assertions to include the new labels.
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```
+feat(commits): reword, drop and undo a commit from the History menu
+```
+
+---
+
+### Task 8: docs, then the full gates
+
+**Files:**
+- Modify: `docs/dev/frontend.md` (the commit-menu / rewrite-flow area)
+- Modify: `docs/dev/backend.md` (beside the commit + signing notes)
+- Modify: `CLAUDE.md` — **only** if a load-bearing rule changed. One did: the
+  published-commit warning is now shared by all five rewrite entries, which is
+  exactly the kind of "one surface" rule that file records. Add at most two
+  lines with a pointer; keep it short, as its own header demands.
+
+- [ ] **Step 1: Write the docs**
+
+`docs/dev/frontend.md`: the `features/commits/` rewrite modules, the two reword
+paths and why HEAD has its own, the no-op-on-unchanged-message guard, and the
+reason the squash warning lives in the prompt body rather than a second dialog.
+
+`docs/dev/backend.md`: `amend_head_message` — message-only via `tree: None`,
+verify-and-mutate under one lock, which hooks run and the deliberate `pre-commit`
+omission, and **the known gap**: the rebase engine's `Reword` arm
+(`libgit2.rs:971`) uses bare `head.amend` and drops a signature, which this op
+does not. Recording it is the point; it is not fixed here.
+
+- [ ] **Step 2: Run every gate**
+
+Run each and read the output — a watcher's exit code is not evidence.
+
+```
+~/Library/pnpm/pnpm tsc --noEmit
+~/Library/pnpm/pnpm test
+~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: all green, including the `docs` vitest project (`test/docs.test.ts`),
+`test/appErrors.test.ts` (no new variant, so it should be untouched),
+`test/iconSet.test.ts` and `test/privacy.test.ts`.
+
+Note: `ImageDiffView`'s delta test flakes about 1 run in 111. A red `unit` on a
+diff that never touched `features/diff` is that flake — re-run rather than audit.
+
+- [ ] **Step 3: Commit**
+
+```
+docs(commits): document the rewrite entries and the reword paths
+```
+
+---
+
+### Task 9: e2e
+
+Run e2e only now, at the end, and only the relevant spec.
+
+- [ ] **Step 1: Read the skill first**
+
+`.claude/skills/e2e-testing/SKILL.md` — required before writing or debugging any
+spec. Note in particular that `isDisplayed` caches an element id and never
+re-resolves, so a re-render kills the wait; `waitForExist` is immune.
+
+- [ ] **Step 2: Add coverage to the existing history-ops spec**
+
+Reword HEAD with a dirty worktree (the case the rebase engine cannot serve — this
+is the assertion that would have caught a one-step-rebase implementation), then
+reword an older commit, asserting the subject in the log afterwards.
+
+- [ ] **Step 3: Rebuild the snapshot, then run only that spec**
+
+A `src/` or `src-tauri/` change means the snapshot is stale. One cold container
+build at a time across ALL worktrees.
+
+```
+~/Library/pnpm/pnpm test:e2e:docker build
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/history-ops.e2e.ts
+```
+
+Never run e2e natively, and never run a full vitest suite alongside a Docker e2e
+build — the contention fakes a red.
+
+- [ ] **Step 4: Commit, push, open the PR**
+
+`gh pr create` with `--body-file` (a `--body` with prose is refused in this
+worktree). The PR body should link the spec and this plan, and state plainly that
+the rebase reword path drops signatures and that this is pre-existing.
+
+---
+
+## The remaining PRs
+
+Each gets its own plan, written when it starts, against the same spec:
+
+| PR | Entries | New backend op |
+| --- | --- | --- |
+| 2 | Show Repository at Revision, Go to Parent / Child Commit | — |
+| 3 | View in browser | commit web URL |
+| 4 | Create Patch… | format-patch |
+| 5 | Push All up to Here… | push refspec |

--- a/docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md
+++ b/docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md
@@ -1,0 +1,371 @@
+# Commit context-menu parity with Rider
+
+Status: approved for implementation.
+Issue: none — raised in session from a screenshot of Rider's commit context menu.
+
+## Goal
+
+Bring the History commit context menu up to what Rider's offers. The user
+supplied Rider's menu; this spec covers the entries we do not have.
+
+The app already defaults to `RIDER_PRESET` for keybindings
+(`src/features/keymap/presets.ts:265`), so matching Rider's *menu* is a
+continuation of a choice this codebase already made, not a new direction.
+
+## What already works, verified in the tree
+
+Read, not assumed. `commitMenuItems` (`src/design/context-menu.tsx:476`) already
+covers 11 of Rider's 20 entries:
+
+| Rider | ours |
+| --- | --- |
+| Copy Revision Number | `Copy SHA` (plus `Copy subject line`) |
+| Cherry-Pick | `Cherry-pick onto current` |
+| Checkout Revision | `Check out this commit`, plus a `Check out branch` submenu Rider lacks |
+| Compare with Local | `Compare with HEAD` |
+| Reset Current Branch to Here… | `Reset current branch to here` → Soft/Mixed/Hard |
+| Revert Commit | `Revert commit` |
+| Fixup… | `Fixup this commit into its parent` |
+| Squash Into… | `Squash this commit into its parent` |
+| Interactively Rebase from Here… | `Interactive rebase from here` |
+| New Branch… | `Create branch from here…` |
+| New Tag… | `Create tag here…` |
+
+We also carry entries Rider does not: `Rebase current branch onto this`, the
+bisect submenu, `View diff`, user-defined custom actions, and a multi-select
+menu with combined diff + squash-range.
+
+Machinery the new entries reuse rather than re-invent:
+
+- **`buildRebasePlan`** (`src/features/commits/buildRebasePlan.ts`) already has
+  `edit-from` / `fixup` / `squash` / `squash-range` modes, and
+  **`runRebasePlanNow`** (`runRebasePlan.ts`) already runs a plan straight from
+  the menu without a detour through the Rebase screen. Squash and Fixup are
+  built exactly this way today, so Reword and Drop are new *modes*, not new
+  plumbing.
+- **`RebaseAction::Reword` already exists end to end** — the TS union
+  (`src/lib/types.ts:502`), the Rust enum (`git/types.rs:762`), and a working
+  backend arm (`git/libgit2.rs:971`). Nothing in the backend needs teaching what
+  a reword is; only the menu cannot reach it.
+- **`RepoBrowser` already browses at a revision** — `listFilesAtRev`,
+  `readFileContentAtRev`, a "Browsing {rev}" header and an `@ {rev}` badge
+  (`src/screens/RepoBrowser.tsx:202,262,963,1161`). `rev` is set from exactly one
+  place today, the toolbar (line 1022). It has no entry point from a commit.
+- **`ahead_behind`** (`commands/commits.rs:128`) returns `{ahead, behind,
+  mergeBase}`, so "is this commit already published" is one IPC call:
+  `behind === 0` against the branch's upstream means the commit is contained in
+  it.
+- **`forge/remote.rs`** already parses a remote into host / owner / repo / kind,
+  and `forge/mod.rs:12` documents `github.rs` / `gitlab.rs` as "per-forge URL
+  builders and response parsers. Pure." A commit URL is a new builder beside the
+  ones already there.
+- **`open_url`** is the one validated opener path — https-only via
+  `opener::safe_url`, already used by `useForgeStore.openInBrowser`.
+- **`dialog:allow-open` is already granted** in
+  `src-tauri/capabilities/default.json:25`, and `open({directory: true})` is the
+  same call Clone / Init / Worktree dialogs already make. Create Patch needs **no
+  new Tauri permission** — `format-patch` names its own files, so no
+  `dialog:allow-save`.
+- **`pgChoose` / `pgPrompt` / `pgConfirm`** (`src/design/dialog.tsx`) cover every
+  dialog below. Squash already composes its message in `pgPrompt({multiline: 8})`,
+  so a reword prompt is a use of an established surface, not a second
+  commit-message composer beside `features/commits/message/`.
+
+### Four findings that shape the design
+
+1. **The rebase engine refuses a dirty worktree.** `rebase_start_with_progress`
+   (`git/libgit2.rs:6190`) checks `repo.statuses` and bails on any wt/index
+   modification (`libgit2.rs:6242`). Rewording HEAD — the most common reword —
+   would therefore fail whenever anything is uncommitted. This is why HEAD gets
+   its own path instead of a one-step rebase plan.
+
+2. **`commit(amend: true)` is not a message-only amend.** It writes the *index*
+   tree (`fresh_index(repo)?; index.write_tree()?` at `libgit2.rs:5075`), so it
+   would silently fold staged changes into the commit being reworded. A
+   message-only amend must pass `tree: None` to `commit.amend`, which reuses the
+   original tree — git's `commit --amend --only -m`.
+
+3. **The chord model is single-stroke only.** `chord.ts` normalizes modifiers +
+   one base key, plus a synthetic `DoubleShift`. Rider's `Ctrl+R, R` is a
+   two-stroke sequence that cannot be expressed today. Combined with the decision
+   below, no keybindings are in scope.
+
+4. **History's selection is local component state**, not a store —
+   `React.useState<Selection>` at `src/screens/History.tsx:135`. A menu builder
+   living in `src/design/` cannot reach it, which is why Go to Parent/Child takes
+   a callback.
+
+## The eight entries
+
+### 1. Edit Commit Message…
+
+Two paths, forced by finding 1.
+
+**HEAD** → a new backend op. `commit.amend` with `tree: None` is message-only:
+it ignores the index and works with a dirty worktree. The op takes the oid the
+menu was built from and **verifies HEAD still equals it inside the same
+`with_repo` acquisition as the amend** — the stash-TOCTOU rule; HEAD can move
+between opening a menu and clicking it. It routes through the existing
+`commit_signed` chain, so a signed commit stays signed.
+
+**An older commit on HEAD's ancestry** → `buildRebasePlan` gains
+`{ kind: "reword", targetOid, message }`, run through `runRebasePlanNow`. Base is
+the commit's first parent, so the target is inside the plan.
+
+Prompt: `pgPrompt({ multiline: 8, requireValue: true })` prefilled with the full
+existing message. `combinedSquashMessage` already renders `summary\n\nbody` for a
+list of oids; the single-commit case is extracted as `fullCommitMessage(commit)`
+and `combinedSquashMessage` is rewritten to call it, so one function owns "what
+is this commit's message as text".
+
+**An unchanged message is a no-op.** Rewriting a SHA because someone opened the
+prompt and pressed Save changes every downstream ref for nothing.
+
+Enablement:
+
+- Not on HEAD's ancestry → disabled, label says why (matching how the existing
+  rebase entries name their own refusal).
+- A merge commit is disabled **on the rebase path only**. `buildRebasePlan`
+  always emits `Drop` for a merge, so rewording an older merge would flatten
+  history. Amending HEAD's own message keeps its parents, so a merge at HEAD
+  stays allowed — the restriction follows the mechanism, not the commit shape.
+
+### 2. The published-commit warning (cross-cutting)
+
+A shared helper: for the commit about to be rewritten, `ahead_behind` against the
+current branch's upstream; `behind === 0` means it is already published, and the
+confirm dialog gains a line saying the next push will have to be forced.
+
+Wired into **all five** rewrite entries — Edit Commit Message, Drop Commit, Undo
+Commit, and **retrofitted onto the existing Squash and Fixup**. Five entries that
+rewrite history splitting into two behaviours is the inconsistency this codebase's
+conventions exist to prevent.
+
+Cost is one IPC call per *invoked action*, not per right-click: the check runs
+inside `onClick`, never while building the menu. Building the menu must stay
+synchronous and free — it is rebuilt on every right-click.
+
+No force-push is offered. A network write behind a menu item that does not
+mention pushing is a surprise, and force-with-lease is its own design question.
+
+### 3. Drop Commit
+
+`buildRebasePlan` gains `{ kind: "drop", targetOid }`: the target becomes `Drop`,
+everything newer stays `Pick`, base is the target's first parent. Danger-styled
+`pgConfirm` plus the §2 warning.
+
+Disabled for a merge: `buildRebasePlan` already emits `Drop` for merges to mean
+*flatten this branch*, which is not what a reader clicking "drop this commit"
+asks for.
+
+### 4. Undo Commit…
+
+HEAD only — Rider greys it elsewhere too. Soft-reset to the parent, leaving the
+commit's changes staged, which is what "undo the commit, keep the work" means.
+
+No new backend op: this is a named entry over `reset(parentOid, "Soft")` with a
+confirm that states the outcome. It earns its place because discovering it today
+means right-clicking a *different* commit (the parent) and reaching into a
+submenu — the entry names the intent instead of the mechanism.
+
+### 5. Show Repository at Revision
+
+New `NavIntent { kind: "browse-rev"; rev: string; label: string }`, routed in
+`AppShell` — compile-enforced by `assertNever` and pinned by
+`AppShell.navroutes.test.tsx` — and consumed by `RepoBrowser`, which already has
+everything else it needs.
+
+### 6. Go to Parent / Child Commit
+
+`commitMenuItems(commit, opts?)` gains an optional `onGoTo?: (oid: string) =>
+void`. History supplies it; the callback owns selection and scroll. This is the
+same callback-parameter shape `PGErrorBanner`'s `onReport` uses, and for the same
+architectural reason: `src/design/` cannot reach the state it needs.
+
+- **Parent**: `parents[0]` as an inline entry; a merge offers a submenu of all
+  parents, each labelled `<short> — <subject>`.
+- **Child**: a reverse-parent scan of the loaded log. **The log is paged** —
+  `s.commits` is a prefix of history, never the answer to a containment
+  question — so a child that is not loaded gives a *disabled entry naming why*,
+  never a wrong jump. Zero children → disabled; one → inline; several → submenu.
+- When `onGoTo` is absent (the menu used outside History) both entries are
+  **omitted entirely** rather than rendered dead.
+
+Scrolling goes by offset, not `scrollIntoView`: History's list is windowed and
+the target row is usually unmounted.
+
+### 7. View in browser
+
+A pure `commit_web_url` builder per forge beside the existing ones — GitHub
+`https://<host>/<owner>/<repo>/commit/<sha>`, GitLab
+`https://<host>/<owner>/<repo>/-/commit/<sha>` — behind a command returning
+`Option<String>`. `None` (no remote, or a remote that is neither forge) disables
+the entry.
+
+Opened through `open_url`. **Privacy gates stay green by construction**: the host
+comes from the user's own remote, so no hostname is hard-coded and
+`test/privacy.test.ts`'s allow-list is untouched; and nothing is sent — the app
+hands a URL to the user's browser, exactly as the issue reporter does.
+
+### 8. Create Patch…
+
+libgit2 has no `format-patch`, so this shells out — via `proc::git`, never
+`Command::new` (a guard test fails the build otherwise). Per commit, in ancestry
+order:
+
+```
+git format-patch -1 <sha> -o <dir> --start-number <n>
+```
+
+One invocation per commit with an explicit `--start-number` is what makes a
+multi-select come out correctly numbered; separate invocations would each restart
+at `0001`.
+
+Format is the **mailbox** form, not a plain unified diff: it preserves author,
+date and full message, so `git am` reconstructs the commit exactly. Rider's own
+Create Patch emits a plain diff, and this is a deliberate divergence — a
+git-native tool should hand you the artifact a maintainer expects to receive. A
+plain diff is already partly served by `diff.copy` / `fileDiffToText`.
+
+Directory chosen with `open({ directory: true })`. Disabled for a merge, which
+`format-patch` skips by default. Joins the multi-select menu beside
+`Squash N into one…`.
+
+### 9. Push All up to Here…
+
+Pushes `<oid>:refs/heads/<branch>` through
+`commands::net::run_git_authenticated` — the one credential path. Secrets in env,
+never argv; `--` before user-supplied values.
+
+Target is the current branch's upstream; disabled without one, and disabled for a
+commit not on the current branch. **Fast-forward only — no force in this batch.**
+A non-fast-forward is refused by the remote and the refusal surfaces in
+`PGErrorBanner` like any other network error.
+
+The confirm names the real effect — "Push 3 of your 7 commits to origin/main?" —
+using `ahead_behind` for both counts. Being a long-running op that can raise a
+credential challenge, it joins `RepoActivity` with `withAuthRetry` owning the
+label via `{ key, label }`, never a `finally` at the call site.
+
+## Menu order
+
+Grouped to follow Rider's own grouping, since the keymap already defaults to
+Rider's:
+
+```
+commit <short>
+  Check out branch ▸ / Check out this commit
+  Show repository at this revision      ← new
+  Compare with HEAD
+  ─
+  Cherry-pick onto current
+  Create patch…                         ← new
+  ─
+  Reset current branch to here ▸
+  Revert commit
+  Undo this commit…                     ← new
+  ─
+  Edit commit message…                  ← new
+  Fixup this commit into its parent
+  Squash this commit into its parent
+  Drop this commit                      ← new
+  Interactive rebase from here
+  Rebase current branch onto this…
+  Push all up to here…                  ← new
+  ─
+  Create branch from here…
+  Create tag here…
+  ─
+  Go to parent commit / ▸               ← new
+  Go to child commit / ▸                ← new
+  ─
+  Bisect ▸
+  ─
+  View diff
+  Copy SHA / Copy subject line
+  View in browser                       ← new
+  ─
+  <custom actions>
+```
+
+## The file this lands in
+
+`src/design/context-menu.tsx` is 2522 lines and `commitMenuItems` is ~250 of
+them. Eight more entries plus helpers makes a bad file worse, so the work opens
+with a **move-only commit**: `commitMenuItems`, `commitMultiMenuItems` and their
+private helpers move to `src/design/context-menu.commit.tsx`, re-exported from
+`context-menu.tsx` so every existing import and every guard test keeps working
+unchanged. Reviewable as a no-op diff.
+
+This is a targeted improvement to code the work is already inside, not a
+refactor of its own — no other menu builder moves.
+
+## Decisions taken, with reasons
+
+1. **Hooks on a message-only amend: run `prepare-commit-msg` and `commit-msg`,
+   skip `pre-commit`.** Git runs all three, so this is a documented deviation. A
+   hook that validates message format is exactly what should fire on a reword; a
+   hook that runs tests has nothing to check when the tree is unchanged by
+   construction. `no_verify` skips all of them, as everywhere else.
+2. **The HEAD path preserves signatures; the rebase path does not.** The engine's
+   `Reword` arm uses bare `head.amend` (`libgit2.rs:971`) and drops the
+   signature. That is a pre-existing gap in the rebase engine, recorded here and
+   **not fixed in this batch** — it affects every existing rebase reword, so it
+   is its own change with its own tests.
+3. **No force-push anywhere.** Not offered after a rewrite, not available on Push
+   all up to here.
+4. **Undo Commit is HEAD-only.**
+5. **Squash stays parent-only.** Rider's "Squash Into…" picks an arbitrary
+   target; our multi-select squash-range covers the common case and widening it
+   is not part of this work.
+6. **No keybindings and no keymap actions.** Finding 3 rules out Rider's
+   `Ctrl+R, R` without a new sequence layer in the chord core, and that layer is
+   a separate feature from these menu entries. The new entries are menu-only,
+   consistent with how Squash, Fixup and Reset ship today.
+
+## Out of scope
+
+- A prefix-key / two-stroke chord layer (finding 3).
+- Signing on the rebase engine's reword path (decision 2).
+- Force-push, with or without lease (decision 3).
+- Plain-unified-diff patch export (§8).
+- Squash into an arbitrary target (decision 5).
+- Rider's `Show Repository at Revision` opening a *second window* — ours reuses
+  the RepoBrowser screen in place.
+
+## Testing
+
+Per layer, following `docs/dev/testing.md`:
+
+- **Rust integration** (`cargo test`, real temp repos): the message-only amend
+  keeps the tree and the author while changing the message and the oid; it
+  refuses when HEAD has moved off `expected_oid`; it preserves a signature; it
+  works with a dirty worktree and a dirty index, and leaves both untouched.
+  `format-patch` numbering across a multi-commit export. The push refspec builds
+  what is expected.
+- **Frontend logic** (`pnpm test`): `buildRebasePlan`'s new `reword` and `drop`
+  modes; `fullCommitMessage`; the published-commit predicate; child lookup
+  returning zero / one / several and the not-loaded case; the per-forge URL
+  builders.
+- **Component**: each new entry's enabled/disabled state and the reason in its
+  label; the no-op guard on an unchanged message; `onGoTo` absent → entries
+  omitted.
+- **Doc invariants** (`pnpm test`, `docs` project): every new command is added to
+  `docs/dev/architecture.md` in the same commit, or `test/docs.test.ts` fails the
+  build.
+- **E2E**: the reword flow and the browse-at-revision flow, in the existing
+  history-ops spec. Read the `e2e-testing` skill before writing them; run only
+  the touched specs, in Docker, after rebuilding the snapshot.
+
+## Delivery
+
+Five PRs, grouped by shared machinery rather than by menu entry, each merged
+before the next branches off `main`:
+
+| PR | Entries | New backend op |
+| --- | --- | --- |
+| 1 | move-only split, §2 warning, Edit Commit Message, Drop, Undo Commit | message-only amend |
+| 2 | Show Repository at Revision, Go to Parent / Child | — |
+| 3 | View in browser | commit web URL |
+| 4 | Create Patch… | format-patch |
+| 5 | Push All up to Here… | push refspec |

--- a/docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md
+++ b/docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md
@@ -291,14 +291,33 @@ commit <short>
 ## The file this lands in
 
 `src/design/context-menu.tsx` is 2522 lines and `commitMenuItems` is ~250 of
-them. Eight more entries plus helpers makes a bad file worse, so the work opens
-with a **move-only commit**: `commitMenuItems`, `commitMultiMenuItems` and their
-private helpers move to `src/design/context-menu.commit.tsx`, re-exported from
-`context-menu.tsx` so every existing import and every guard test keeps working
-unchanged. Reviewable as a no-op diff.
+them, so eight more entries with their flows inline makes a bad file worse.
 
-This is a targeted improvement to code the work is already inside, not a
-refactor of its own — no other menu builder moves.
+**Splitting that file was considered and rejected.** Moving `commitMenuItems`
+out requires also extracting the `ContextMenuItem` type (declared there,
+consumed by ~15 builders), `customActionItems` and `headBranch`, all three
+shared with the file and file-multi builders — otherwise the new module and
+`context-menu.tsx` import each other. That is three new modules and a
+restructure of the type every menu builder depends on, for a file the work only
+passes through. It also invites exactly the conflict class recorded in
+`docs/dev/` about large `main` refactors: several sessions work this repo at
+once, and a moved 2500-line file makes every other branch that touched it look
+partly unlanded.
+
+Instead, **each entry's flow lives in its own `features/commits/` module** and
+the menu entry is a few lines that call it. That is already this codebase's
+shape — `buildRebasePlan`, `runRebasePlan`, `squashMessage` and `stackedRefs`
+all live there and are all called from `commitMenuItems` today. The menu file
+grows by tens of lines rather than hundreds, and every flow becomes unit
+testable without rendering a menu:
+
+| module | owns |
+| --- | --- |
+| `features/commits/commitMessageText.ts` | `fullCommitMessage(commit)` — a commit's message as text; `combinedSquashMessage` is rewritten to call it |
+| `features/commits/rewriteWarning.ts` | the §2 published-commit check and the confirm line it adds |
+| `features/commits/rewordCommit.ts` | prompt → HEAD amend or reword plan |
+| `features/commits/dropCommit.ts` | confirm → drop plan |
+| `features/commits/undoCommit.ts` | confirm → soft reset to parent |
 
 ## Decisions taken, with reasons
 
@@ -364,7 +383,7 @@ before the next branches off `main`:
 
 | PR | Entries | New backend op |
 | --- | --- | --- |
-| 1 | move-only split, §2 warning, Edit Commit Message, Drop, Undo Commit | message-only amend |
+| 1 | §2 warning, Edit Commit Message, Drop, Undo Commit | message-only amend |
 | 2 | Show Repository at Revision, Go to Parent / Child | — |
 | 3 | View in browser | commit web URL |
 | 4 | Create Patch… | format-patch |

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -206,3 +206,89 @@ describe("history multi cherry-pick", () => {
     expect(repo.git("branch", "--show-current").trim()).toBe("main");
   });
 });
+
+describe("rewording a commit", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  // THE case a one-step rebase plan cannot serve: the rebase engine refuses any
+  // worktree or index modification, so routing HEAD through a plan would fail
+  // for anyone with uncommitted work — which is most reword attempts. This
+  // asserts the message changed AND that the dirt is still exactly where it was.
+  it("rewords HEAD with a dirty worktree, consuming none of it", async () => {
+    repo = cherryRepo(); // main: 3 commits, HEAD = "fix: update a.txt"
+    // Dirty BEFORE openRepo — the store reads status once, on open.
+    repo.write("a.txt", "dirty unstaged\n");
+    repo.write("untracked.txt", "not staged\n");
+    repo.write("staged.txt", "staged before the reword\n");
+    repo.git("add", "staged.txt");
+    const treeBefore = repo.git("rev-parse", "HEAD^{tree}").trim();
+
+    await openRepo(repo.path);
+    await stubNativeDialogs({ promptText: "reworded by e2e", confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("fix: update a.txt");
+    await $('[data-testid="commit-row"]*=fix: update a.txt').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "HEAD row missing",
+    });
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "fix: update a.txt" });
+    await jsClickMenuItem("Edit commit message…");
+
+    // History repaints only once the backend call has returned, so this cannot
+    // match an intermediate state the way a `log -1` poll could.
+    await $('[data-testid="commit-row"]*=reworded by e2e').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "History never showed the reworded commit",
+    });
+
+    // Message rewritten, tree untouched, history the same length: an amend, not
+    // a replay.
+    expect(repo.git("log", "-1", "--pretty=%B")).toContain("reworded by e2e");
+    expect(repo.git("rev-parse", "HEAD^{tree}").trim()).toBe(treeBefore);
+    expect(repo.git("rev-list", "--count", "HEAD").trim()).toBe("3");
+
+    // And every kind of dirt survived, unconsumed. The staged file in
+    // particular must NOT be in the reworded commit — that is what separates
+    // this op from commit(amend: true).
+    expect(repo.read("a.txt")).toBe("dirty unstaged\n");
+    expect(repo.read("untracked.txt")).toBe("not staged\n");
+    expect(repo.git("diff", "--cached", "--name-only")).toContain("staged.txt");
+    expect(repo.git("ls-tree", "--name-only", "HEAD")).not.toContain("staged.txt");
+  });
+
+  // The other path: an older commit goes through the rebase engine's Reword
+  // action, which replays every commit after it.
+  it("rewords an older commit and replays the commits after it", async () => {
+    repo = cherryRepo();
+    const headBefore = repo.git("rev-parse", "HEAD").trim();
+
+    await openRepo(repo.path);
+    await stubNativeDialogs({ promptText: "reworded parent", confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("feat: add b.txt");
+    await $('[data-testid="commit-row"]*=feat: add b.txt').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "target row missing",
+    });
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsClickMenuItem("Edit commit message…");
+
+    await $('[data-testid="commit-row"]*=reworded parent').waitForDisplayed({
+      timeout: 25_000, timeoutMsg: "History never showed the reworded commit",
+    });
+
+    // The reworded message is in history, the descendant survived, and HEAD is a
+    // NEW commit because it was replayed onto the reworded parent.
+    const log = repo.git("log", "--pretty=%s");
+    expect(log).toContain("reworded parent");
+    expect(log).toContain("fix: update a.txt");
+    expect(log).not.toContain("feat: add b.txt");
+    expect(repo.git("rev-parse", "HEAD").trim()).not.toBe(headBefore);
+    expect(repo.git("rev-list", "--count", "HEAD").trim()).toBe("3");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+});

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -170,6 +170,35 @@ pub async fn commit(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Replace HEAD's commit message, leaving the tree and the index alone.
+///
+/// The reword path for HEAD. An older commit is reworded by the rebase engine
+/// instead (`RebaseAction::Reword`), but the engine refuses a dirty worktree and
+/// rewording the commit you are sitting on is the common case — so it gets a
+/// path that does not need a replay. See the trait doc for why this is not
+/// `commit` with `amend: true`.
+#[tauri::command]
+pub async fn amend_head_message(
+    state: State<'_, AppState>,
+    repo_id: String,
+    // What the caller believed HEAD was; a mismatch refuses and writes nothing.
+    // HEAD can move between a context menu opening and its click landing.
+    expected_oid: String,
+    message: String,
+    // Skip the message hooks for this reword only, matching `commit`'s option.
+    // Optional so a caller that omits it keeps hooks ON, the safe default.
+    no_verify: Option<bool>,
+) -> AppResult<CommitResult> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let no_verify = no_verify.unwrap_or(false);
+    tokio::task::spawn_blocking(move || {
+        backend.amend_head_message(&repo_id, &expected_oid, &message, no_verify)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// The repository's `commit.template` + comment prefix (#252).
 ///
 /// Called once per commit-screen visit. A configured template that cannot be

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -264,6 +264,16 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
 
+    fn amend_head_message(
+        &self,
+        _repo_id: &RepoId,
+        _expected_oid: &str,
+        _message: &str,
+        _no_verify: bool,
+    ) -> AppResult<CommitResult> {
+        Err(AppError::NotImplemented)
+    }
+
     fn commit_template(
         &self,
         _repo_id: &RepoId,

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1412,6 +1412,20 @@ fn find_delta_index(diff: &git2::Diff, path: &Path) -> AppResult<usize> {
 ///
 /// A signing failure returns an error and leaves HEAD untouched: falling back to
 /// an unsigned commit would leave the user believing they had signed it.
+/// The refusal when HEAD is not what the caller believed it was.
+///
+/// `InvalidArgument` rather than a variant of its own: the frontend has no
+/// special remedy for this beyond showing the sentence, and a new `AppError`
+/// variant costs the TS union plus `appErrorDetail` prose in the same commit.
+fn stale_head(actual: &str, expected: &str) -> AppError {
+    let short = |s: &str| s.chars().take(7).collect::<String>();
+    AppError::InvalidArgument(format!(
+        "HEAD has moved since that commit was chosen — it is now {}, not {}. Nothing was changed.",
+        short(actual),
+        short(expected),
+    ))
+}
+
 fn commit_signed(
     repo: &Repository,
     sig: &git2::Signature<'_>,
@@ -5126,6 +5140,118 @@ impl GitBackend for Libgit2Backend {
         // DISCARDED because git discards it. Reporting a commit that exists as
         // failed would send the user hunting for work that already landed.
         if !opts.no_verify {
+            let _ = hooks::run_hook(&repo_path, "post-commit", &[]);
+        }
+
+        Ok(CommitResult { oid, message })
+    }
+
+    fn amend_head_message(
+        &self,
+        repo_id: &RepoId,
+        expected_oid: &str,
+        message: &str,
+        no_verify: bool,
+    ) -> AppResult<CommitResult> {
+        use crate::git::hooks;
+        use crate::git::signature::default_signature;
+
+        /// Run one hook and turn a refusal into the error the frontend renders.
+        /// Mirrors `commit`'s own `gate`.
+        fn gate(workdir: &std::path::Path, name: &str, args: &[&str]) -> AppResult<()> {
+            let out = hooks::run_hook(workdir, name, args)?;
+            if out.rejected() {
+                return Err(AppError::HookRejected(crate::error::HookRejection {
+                    hook: name.to_string(),
+                    output: out.output,
+                }));
+            }
+            Ok(())
+        }
+
+        // Refused HERE, before any hook runs, exactly as `commit` does: every
+        // caller of this method is a caller that meant to write history, and a
+        // refusal must not have run anybody's hook.
+        if message.trim().is_empty() {
+            return Err(AppError::InvalidArgument(
+                "the commit message is empty".to_string(),
+            ));
+        }
+
+        let repo_path = self.repo_path(repo_id)?;
+
+        // An ADVISORY early check, so a reword that is already doomed does not
+        // run the user's `commit-msg` hook first. It is not the authoritative
+        // one — that happens under the write lock below, because anything
+        // checked out here can change before the amend. Both exist on purpose.
+        let head_now = self.with_repo_read(repo_id, |repo| {
+            let head = repo.head().map_err(|_| AppError::Unborn)?;
+            Ok(head.peel_to_commit().map_err(|_| AppError::Unborn)?.id().to_string())
+        })?;
+        if head_now != expected_oid {
+            return Err(stale_head(&head_now, expected_oid));
+        }
+
+        // `pre-commit` is deliberately NOT run: `tree: None` below means this op
+        // cannot change the tree, so a hook that lints content has nothing to
+        // inspect. A documented deviation from `git commit --amend --only`,
+        // which runs it. The MESSAGE hooks do run — a `commit-msg` that enforces
+        // a format is exactly what should fire on a reword.
+        let message = if no_verify {
+            message.to_string()
+        } else {
+            let git_dir = self.with_repo_read(repo_id, |repo| Ok(repo.path().to_path_buf()))?;
+            let msg_path = git_dir.join("COMMIT_EDITMSG");
+            std::fs::write(&msg_path, message).map_err(|e| AppError::Io(e.to_string()))?;
+            let msg_arg = msg_path
+                .to_str()
+                .ok_or_else(|| AppError::InvalidPath(msg_path.display().to_string()))?;
+
+            // Source is always `message`, with no third argument — the same
+            // pair `commit` passes, because we too supply the text rather than
+            // taking it from a commit.
+            gate(&repo_path, "prepare-commit-msg", &[msg_arg, "message"])?;
+            gate(&repo_path, "commit-msg", &[msg_arg])?;
+
+            // Re-read: either hook may have rewritten the file, and what it left
+            // there is what git would commit.
+            std::fs::read_to_string(&msg_path).map_err(|e| AppError::Io(e.to_string()))?
+        };
+
+        // ONE acquisition for verify-and-mutate. Splitting these is the stash
+        // TOCTOU shape: HEAD could move between the check and the amend, and the
+        // hooks above have just given it time to.
+        let oid = self.with_repo(repo_id, |repo| {
+            let head_ref = repo.head().map_err(|_| AppError::Unborn)?;
+            let head = head_ref.peel_to_commit().map_err(|_| AppError::Unborn)?;
+            let actual = head.id().to_string();
+            if actual != expected_oid {
+                return Err(stale_head(&actual, expected_oid));
+            }
+
+            let sig = default_signature(repo)?;
+
+            // Through the ONE signing chain, so a signed commit stays signed and
+            // a signing failure creates nothing. The rebase engine's own Reword
+            // arm does not do this and drops the signature — a pre-existing gap,
+            // recorded in docs/dev/backend.md.
+            if crate::git::signing::config_wants_signing(repo) {
+                let tree = head.tree()?;
+                return commit_signed(repo, &sig, &message, &tree, Some(&head_ref), true);
+            }
+
+            // `tree: None` reuses the original tree — this is the message-only
+            // part. `author: None` preserves the author; only the committer is
+            // refreshed, which is what git's `--amend` does.
+            let new_oid =
+                head.amend(Some("HEAD"), None, Some(&sig), None, Some(&message), None)?;
+            Ok(new_oid.to_string())
+        })?;
+
+        // `post-commit` runs after the ref moved and its exit code is DISCARDED,
+        // because git discards it. A commit that exists must not be reported as
+        // failed.
+        if !no_verify {
             let _ = hooks::run_hook(&repo_path, "post-commit", &[]);
         }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -626,6 +626,33 @@ pub trait GitBackend: Send + Sync {
     // === commit ===
     fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult>;
 
+    /// Replace HEAD's commit message and nothing else.
+    ///
+    /// `git commit --amend --only -m <msg>`: `tree: None` on `Commit::amend`
+    /// reuses the commit's ORIGINAL tree, so the index is never read. That is
+    /// the difference from `commit` with `amend: true`, which writes the index
+    /// tree and would fold staged changes into the commit being reworded — and
+    /// it is what lets this run against a dirty worktree, which the rebase
+    /// engine refuses outright. Rewording the commit you are sitting on is the
+    /// common case, so it does not go through a replay.
+    ///
+    /// `expected_oid` is what the caller believed HEAD was. HEAD can move
+    /// between a context menu opening and its click landing, so the check and
+    /// the amend happen under ONE lock acquisition; a mismatch refuses with
+    /// `InvalidArgument` and writes nothing.
+    ///
+    /// The author is preserved and only the committer is refreshed, as git does.
+    /// The MESSAGE hooks run (`prepare-commit-msg`, `commit-msg`) but
+    /// `pre-commit` does not: the tree cannot change here, so a hook that lints
+    /// content has nothing to inspect. `no_verify` skips them all.
+    fn amend_head_message(
+        &self,
+        repo_id: &RepoId,
+        expected_oid: &str,
+        message: &str,
+        no_verify: bool,
+    ) -> AppResult<CommitResult>;
+
     /// The repository's `commit.template` and comment prefix (#252).
     ///
     /// A read, not a commit step: the composer asks once per repository and

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -379,6 +379,7 @@ pub fn run() {
             commands::commits::commits_between,
             commands::commits::ahead_behind,
             commands::commits::commit,
+            commands::commits::amend_head_message,
             commands::commits::file_history,
             commands::commits::verify_commit,
             commands::commits::commit_notes,

--- a/src-tauri/tests/amend_message.rs
+++ b/src-tauri/tests/amend_message.rs
@@ -337,6 +337,63 @@ fn a_stale_oid_is_refused_before_any_hook_runs() {
     );
 }
 
+/// HEAD moving DURING the hook window is the case the advisory early check
+/// cannot catch, and the only case the under-lock check exists for.
+///
+/// Measured, not assumed: deleting the under-lock check leaves every other test
+/// in this file green, because the early check absorbs them all. THIS is the
+/// test that fails — without the second check the amend lands on whatever HEAD
+/// became, silently rewording a commit the user never chose.
+///
+/// The `commit-msg` hook makes its own commit, which moves HEAD inside exactly
+/// the window between the two checks. Hooks run outside the per-repo lock (they
+/// must, or a hook shelling out to git would deadlock against us), which is what
+/// makes that window real rather than theoretical.
+#[test]
+fn a_head_move_during_the_hook_window_is_refused() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let workdir = tr.path().display().to_string();
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        // `--no-verify` AND a one-shot marker: the hook's own commit would
+        // otherwise re-run this same hook, which forks until the OS refuses.
+        &format!(
+            "#!/bin/sh\n\
+             [ -f '{workdir}/.hook-fired' ] && exit 0\n\
+             : > '{workdir}/.hook-fired'\n\
+             cd '{workdir}' || exit 0\n\
+             : > moved.txt\n\
+             git add moved.txt\n\
+             git -c user.name=Hook -c user.email=hook@example.com commit -q --no-verify -m 'moved by the hook'\n"
+        ),
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let chosen_oid = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let err = backend
+        .amend_head_message(&handle.id, &chosen_oid, "reworded", false)
+        .expect_err("HEAD moved mid-flight, so the reword must be refused");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    // The hook's commit is still HEAD and was NOT reworded — the op declined
+    // rather than rewriting a commit nobody chose.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(
+        head.message().unwrap().trim(),
+        "moved by the hook",
+        "the hook's own commit must be left exactly as it was"
+    );
+    assert_ne!(head.id().to_string(), chosen_oid);
+}
+
 /// Write an executable hook into the repo's `.git/hooks`.
 fn write_hook(root: &std::path::Path, name: &str, body: &str) {
     let dir = root.join(".git").join("hooks");

--- a/src-tauri/tests/amend_message.rs
+++ b/src-tauri/tests/amend_message.rs
@@ -1,0 +1,351 @@
+//! `amend_head_message` — replace HEAD's commit message and nothing else.
+//!
+//! The distinguishing property, asserted from several angles below, is that this
+//! op does NOT read the index. `commit(amend: true)` writes the index tree and
+//! would fold staged changes into the commit being reworded; this one passes
+//! `tree: None` to `Commit::amend`, which reuses the original tree. That is what
+//! makes it usable with a dirty worktree — the case the rebase engine refuses,
+//! and the case rewording HEAD almost always is.
+
+mod support;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+/// The whole point of the op: the message changes, the tree does not.
+#[test]
+fn amend_changes_the_message_and_keeps_the_tree() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let before = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_before = before.tree_id();
+    let author_before = before.author().when().seconds();
+    let author_name_before = before.author().name().unwrap().to_string();
+
+    let out = backend
+        .amend_head_message(&handle.id, &before.id().to_string(), "reworded", false)
+        .expect("amend");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "reworded");
+    assert_eq!(after.tree_id(), tree_before, "tree must be untouched");
+    assert_ne!(after.id(), before.id(), "a reworded commit is a new object");
+    assert_eq!(out.oid, after.id().to_string());
+    assert_eq!(out.message, "reworded");
+    assert_eq!(after.parent_count(), before.parent_count());
+
+    // Author is PRESERVED and only the committer is refreshed, which is what
+    // git's own `--amend` does. Note this deliberately differs from
+    // `commit(amend: true)`, which passes the current signature as the author
+    // too.
+    assert_eq!(after.author().when().seconds(), author_before);
+    assert_eq!(after.author().name().unwrap(), author_name_before);
+}
+
+/// The reason the op takes `expected_oid` at all: HEAD can move between a
+/// context menu opening and its click landing.
+#[test]
+fn amend_refuses_when_head_has_moved() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let stale = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    tr.add_commit("other.txt", "x\n", "a second commit");
+
+    let err = backend
+        .amend_head_message(&handle.id, &stale, "reworded", false)
+        .expect_err("must refuse a stale oid");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    // And it changed nothing.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.message().unwrap(), "a second commit");
+}
+
+/// A dirty worktree is exactly the case the rebase engine cannot serve
+/// (`rebase_start_with_progress` bails on any wt/index modification), so this op
+/// must serve it — and must leave the dirt alone.
+#[test]
+fn amend_works_with_a_dirty_worktree_and_does_not_consume_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello, edited\n");
+    write_file(tr.path(), "untracked.txt", "new\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_before = head.tree_id();
+
+    backend
+        .amend_head_message(&handle.id, &head.id().to_string(), "reworded", false)
+        .expect("amend with a dirty worktree");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "reworded");
+    assert_eq!(after.tree_id(), tree_before, "the edit must NOT be committed");
+    assert_eq!(
+        support::fs::read_file(tr.path(), "README.md"),
+        "hello, edited\n",
+        "the working tree must be left as it was"
+    );
+    assert_eq!(
+        support::fs::read_file(tr.path(), "untracked.txt"),
+        "new\n",
+        "an untracked file must survive too"
+    );
+}
+
+/// The index is the other half of that guarantee, and the sharper half: this is
+/// the assertion that fails if the op is ever reimplemented on top of
+/// `commit(amend: true)`.
+#[test]
+fn amend_ignores_staged_changes() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "staged.txt", "staged\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("staged.txt")).unwrap();
+        index.write().unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+
+    backend
+        .amend_head_message(&handle.id, &head.id().to_string(), "reworded", false)
+        .expect("amend");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.tree_id(), head.tree_id());
+    assert!(
+        after.tree().unwrap().get_name("staged.txt").is_none(),
+        "the staged file must not be in the reworded commit"
+    );
+
+    // Still staged afterwards — the reword neither consumed nor cleared it.
+    let idx = tr.repo.index().unwrap();
+    assert!(
+        idx.get_path(std::path::Path::new("staged.txt"), 0).is_some(),
+        "the file must still be staged after the reword"
+    );
+}
+
+/// An empty message is refused on this side of the IPC boundary, as `commit`
+/// does — every caller of this method is a caller that meant to write history.
+#[test]
+fn amend_refuses_an_empty_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let err = backend
+        .amend_head_message(&handle.id, &head, "   \n ", false)
+        .expect_err("must refuse a whitespace-only message");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "initial", "nothing may change");
+}
+
+/// An unborn HEAD has no commit to reword.
+#[test]
+fn amend_refuses_on_an_unborn_head() {
+    let tr = TempRepo::fresh();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .amend_head_message(&handle.id, &"0".repeat(40), "x", false)
+        .expect_err("must refuse on an unborn HEAD");
+    assert!(matches!(err, AppError::Unborn), "got {err:?}");
+}
+
+/// The reflog says what git says for an amend, so `Mod+Z` and the reflog screen
+/// both describe it recognisably.
+#[test]
+fn amend_leaves_a_reflog_entry() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    backend
+        .amend_head_message(&handle.id, &head, "reworded", false)
+        .expect("amend");
+
+    let entries = backend.read_reflog(&handle.id).expect("reflog");
+    assert!(
+        entries.iter().any(|e| e.message.contains("reworded")),
+        "expected a reflog entry naming the new message, got {:?}",
+        entries.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+/// `commit-msg` gets to refuse a reword — that hook validates message format,
+/// which is exactly what a reword changes.
+#[test]
+fn a_commit_msg_hook_can_refuse_the_reword() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(tr.path(), "commit-msg", "#!/bin/sh\necho 'bad subject'\nexit 1\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let err = backend
+        .amend_head_message(&handle.id, &head, "nope", false)
+        .expect_err("the hook must be able to refuse");
+    assert!(matches!(err, AppError::HookRejected(_)), "got {err:?}");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(
+        after.message().unwrap(),
+        "initial",
+        "a refused reword must create nothing"
+    );
+}
+
+/// A `commit-msg` hook that REWRITES the message is honoured, as in `commit`.
+#[test]
+fn a_commit_msg_hook_can_rewrite_the_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        "#!/bin/sh\nprintf 'rewritten by the hook\\n' > \"$1\"\n",
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let out = backend
+        .amend_head_message(&handle.id, &head, "what I typed", false)
+        .expect("amend");
+
+    assert_eq!(out.message, "rewritten by the hook\n");
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "rewritten by the hook\n");
+}
+
+/// `pre-commit` is deliberately NOT run: this op cannot change the tree, so a
+/// hook that lints content has nothing to inspect. A documented deviation from
+/// `git commit --amend --only`, which runs it.
+#[test]
+fn pre_commit_does_not_run_because_the_tree_cannot_change() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let marker = tr.path().join("pre-commit-ran");
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    backend
+        .amend_head_message(&handle.id, &head, "reworded", false)
+        .expect("amend");
+
+    assert!(
+        !marker.exists(),
+        "pre-commit must not run for a message-only amend"
+    );
+}
+
+/// `no_verify` skips the message hooks, matching `commit`'s own option.
+#[test]
+fn no_verify_skips_the_message_hooks() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(tr.path(), "commit-msg", "#!/bin/sh\nexit 1\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    backend
+        .amend_head_message(&handle.id, &head, "reworded", true)
+        .expect("no_verify must skip the refusing hook");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.message().unwrap(), "reworded");
+}
+
+/// A refused reword must not have run the message hook at all — the stale-oid
+/// check happens before them, so nobody's hook fires for an operation that was
+/// always going to be refused.
+#[test]
+fn a_stale_oid_is_refused_before_any_hook_runs() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let marker = tr.path().join("commit-msg-ran");
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let stale = "0".repeat(40);
+
+    backend
+        .amend_head_message(&handle.id, &stale, "reworded", false)
+        .expect_err("must refuse");
+
+    assert!(
+        !marker.exists(),
+        "no hook may run for a reword that is refused outright"
+    );
+}
+
+/// Write an executable hook into the repo's `.git/hooks`.
+fn write_hook(root: &std::path::Path, name: &str, body: &str) {
+    let dir = root.join(".git").join("hooks");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}

--- a/src-tauri/tests/signing.rs
+++ b/src-tauri/tests/signing.rs
@@ -381,3 +381,69 @@ fn a_signing_failure_fails_the_commit_instead_of_committing_unsigned() {
     let head_after = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
     assert_eq!(head_before, head_after, "HEAD must not move: {err:?}");
 }
+
+// ─── reword ──────────────────────────────────────────────────────────────────
+
+/// A reword goes through the ONE signing chain, so a repository that signs its
+/// commits does not quietly get an unsigned one back.
+///
+/// This is the property the rebase engine's own `Reword` arm does NOT have — it
+/// calls `Commit::amend` directly and drops the signature. Recorded in
+/// `docs/dev/backend.md`; the gap predates this test.
+#[test]
+fn a_reworded_commit_keeps_a_signature() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping signed reword test");
+        return;
+    };
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_bool("commit.gpgsign", true).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let out = backend
+        .amend_head_message(&handle.id, &head, "reworded and signed", false)
+        .expect("signed reword");
+
+    // Same trap as commit_signed: it writes the object but does not move HEAD.
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(after.id().to_string(), out.oid, "the reword must be HEAD");
+    assert_eq!(after.message().unwrap(), "reworded and signed");
+    let header = after
+        .header_field_bytes("gpgsig")
+        .expect("a reworded commit must carry a gpgsig header");
+    assert!(!header.is_empty(), "signature must not be empty");
+}
+
+/// And a signing failure creates nothing, rather than leaving an unsigned
+/// commit the user believes is signed.
+#[test]
+fn a_reword_whose_signing_fails_changes_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("gpg.ssh.program", "definitely-not-a-real-program").unwrap();
+        c.set_str("user.signingkey", "/nonexistent/key").unwrap();
+        c.set_bool("commit.gpgsign", true).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let before = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
+
+    let err = backend
+        .amend_head_message(&handle.id, &before.to_string(), "should fail", false)
+        .expect_err("a signing failure must fail the reword");
+
+    let after = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(before, after.id(), "HEAD must not move: {err:?}");
+    assert_eq!(after.message().unwrap(), "initial");
+}

--- a/src/design/context-menu.rewrite.test.tsx
+++ b/src/design/context-menu.rewrite.test.tsx
@@ -1,0 +1,248 @@
+// The three history-rewriting entries added for Rider parity, and the retrofit
+// that put Squash and Fixup behind the same published-commit warning.
+//
+// What is asserted here is ENABLEMENT and the reason in the label — the flows
+// themselves are covered in features/commits/rewriteFlows.test.tsx. A disabled
+// entry in this codebase says why it is disabled in its own label, so the label
+// text is the contract, not decoration.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { commitMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { WithDialogs, acceptDialog, dialogBody, resetDialogs } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo } from "@/lib/types";
+
+const HEAD_SHA = "a".repeat(40); // tip of main
+const B = "b".repeat(40);
+const MERGE = "e".repeat(40); // an OLDER merge, in HEAD's ancestry
+const SIDE = "5".repeat(40); // the merge's second parent
+const C = "c".repeat(40);
+const ROOT = "d".repeat(40);
+const OFF_BRANCH = "f".repeat(40); // reachable in the log, not from HEAD
+
+const mk = (
+  oid: string,
+  summary: string,
+  parents: string[],
+  body: string | null = null,
+): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+// Newest-first. HEAD_SHA → B → MERGE(→ C, SIDE) → C → ROOT, plus a commit on
+// another branch that History's all-branch walk also returns.
+const COMMITS = [
+  mk(HEAD_SHA, "commit A", [B]),
+  mk(OFF_BRANCH, "commit on another branch", [C]),
+  mk(B, "commit B", [MERGE], "why B"),
+  mk(MERGE, "Merge branch 'side'", [C, SIDE]),
+  mk(SIDE, "side work", [C]),
+  mk(C, "commit C", [ROOT]),
+  mk(ROOT, "commit root", []),
+];
+
+const DONE = { inProgress: false, nextIndex: 2, total: 2, pauseReason: null };
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+/** Point HEAD at `oid` and rebuild nothing else. */
+function headAt(oid: string) {
+  useRepoStore.setState({
+    headInfo: { branch: "main", headOid: oid },
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+        tip: oid,
+        tipTime: 0,
+        isDefault: true,
+      },
+    ],
+  } as never);
+}
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    error: null,
+    hookRejection: null,
+    noSignature: false,
+    loading: false,
+  } as never);
+  headAt(HEAD_SHA);
+  useNavStore.setState({ intent: null });
+  mockInvoke("rebase_start", () => DONE);
+  mockInvoke("amend_head_message", () => ({ oid: "new1234", message: "x" }));
+  mockInvoke("reset", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: COMMITS, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => DONE);
+  // Not published, unless a case says otherwise.
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 3, mergeBase: C }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Edit commit message", () => {
+  it("is offered for a commit on this branch", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /^Edit commit message/);
+    expect(item.disabled).toBeFalsy();
+    expect(item.label).toBe("Edit commit message…");
+  });
+
+  it("is offered for HEAD even when HEAD is a merge — an amend keeps its parents", () => {
+    headAt(MERGE);
+    const item = labeled(commitMenuItems({ sha: MERGE }), /^Edit commit message/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is refused for an OLDER merge commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: MERGE }), /^Edit commit message/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/merge commit/);
+  });
+
+  it("is refused for a commit that is not on this branch, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: OFF_BRANCH }), /^Edit commit message/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/not on this branch/);
+  });
+
+  it("is refused for the root commit unless it is HEAD", () => {
+    const item = labeled(commitMenuItems({ sha: ROOT }), /^Edit commit message/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/root commit/);
+  });
+});
+
+describe("Undo this commit", () => {
+  it("is offered for HEAD", () => {
+    const item = labeled(commitMenuItems({ sha: HEAD_SHA }), /^Undo this commit/);
+    expect(item.disabled).toBeFalsy();
+    expect(item.label).toBe("Undo this commit…");
+  });
+
+  it("is refused for any other commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /^Undo this commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/only the last commit/);
+  });
+
+  it("is refused for a root commit sitting at HEAD", () => {
+    headAt(ROOT);
+    const item = labeled(commitMenuItems({ sha: ROOT }), /^Undo this commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/root commit/);
+  });
+});
+
+describe("Drop this commit", () => {
+  it("is offered for a non-merge commit on this branch, and is danger-styled", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /^Drop this commit/);
+    expect(item.disabled).toBeFalsy();
+    expect(item.danger).toBe(true);
+  });
+
+  it("is refused for a merge commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: MERGE }), /^Drop this commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/merge commit/);
+  });
+
+  it("is refused for the root commit", () => {
+    const item = labeled(commitMenuItems({ sha: ROOT }), /^Drop this commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/root commit/);
+  });
+
+  it("is refused for a commit not on this branch", () => {
+    const item = labeled(commitMenuItems({ sha: OFF_BRANCH }), /^Drop this commit/);
+    expect(item.disabled).toBe(true);
+  });
+});
+
+describe("the published-commit warning is shared by all five rewrite entries", () => {
+  beforeEach(() => {
+    // behind === 0 → the commit is contained in origin/main.
+    mockInvoke("ahead_behind", () => ({ ahead: 4, behind: 0, mergeBase: C }));
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+  });
+
+  it("warns in the fixup confirm", async () => {
+    void labeled(commitMenuItems({ sha: B }), /^Fixup this commit/).onClick?.();
+    await waitFor(() => expect(dialogBody()).toMatch(/already on origin\/main/));
+  });
+
+  it("warns inside the squash PROMPT, not a second dialog in front of it", async () => {
+    void labeled(commitMenuItems({ sha: B }), /^Squash this commit/).onClick?.();
+    // The prompt is the FIRST and only dialog: an input is present, and the
+    // warning is in its body.
+    await screen.findByTestId("dialog-input");
+    expect(dialogBody()).toMatch(/already on origin\/main/);
+  });
+
+  it("warns in the drop confirm", async () => {
+    void labeled(commitMenuItems({ sha: B }), /^Drop this commit/).onClick?.();
+    await waitFor(() => expect(dialogBody()).toMatch(/already on origin\/main/));
+  });
+
+  it("warns in the undo confirm", async () => {
+    void labeled(commitMenuItems({ sha: HEAD_SHA }), /^Undo this commit/).onClick?.();
+    await waitFor(() => expect(dialogBody()).toMatch(/already on origin\/main/));
+  });
+
+  it("warns in the reword confirm, after the message prompt", async () => {
+    void labeled(commitMenuItems({ sha: HEAD_SHA }), /^Edit commit message/).onClick?.();
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("a new subject");
+    await waitFor(() => expect(dialogBody()).toMatch(/already on origin\/main/));
+  });
+});
+
+describe("a declined fixup confirm", () => {
+  it("starts no rebase", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    void labeled(commitMenuItems({ sha: B }), /^Fixup this commit/).onClick?.();
+    const cancel = await screen.findByTestId("dialog-cancel");
+    cancel.click();
+    await waitFor(() =>
+      expect(getInvokeCalls().filter((c) => c.cmd === "rebase_start")).toHaveLength(0),
+    );
+  });
+});

--- a/src/design/context-menu.squash.test.tsx
+++ b/src/design/context-menu.squash.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { commitMenuItems, commitMultiMenuItems, type ContextMenuItem } from "./context-menu";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { WithDialogs, acceptDialog, resetDialogs } from "@/test/dialog";
+import { WithDialogs, acceptDialog, dismissDialog, resetDialogs } from "@/test/dialog";
 import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
 import type { CommitInfo, RebaseStep } from "@/lib/types";
 
@@ -164,16 +164,47 @@ describe("right-click Squash into parent", () => {
 });
 
 describe("right-click Fixup into parent", () => {
-  it("runs in place with no prompt and no plan screen", async () => {
+  // Fixup now goes through the SHARED rewrite confirm, so it says the same
+  // thing about a published commit as reword, drop and undo do. What has not
+  // changed is the rest of this test's original point: no MESSAGE prompt (a
+  // fixup keeps the parent's message by definition) and no detour through the
+  // Rebase plan screen.
+  it("runs in place behind one confirm, with no message prompt and no plan screen", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
     const item = labeled(
       commitMenuItems({ sha: B, subject: "commit B" }),
       /Fixup this commit into its parent/,
     );
-    await item.onClick?.();
+    void item.onClick?.();
+
+    // A confirm, not a prompt: there is nothing to type.
+    await screen.findByTestId("dialog-confirm");
+    expect(screen.queryByTestId("dialog-input")).toBeNull();
+    await acceptDialog();
 
     await waitFor(() => expect(rebaseStarts().length).toBe(1));
     const plan = rebaseStarts()[0].args.plan as RebaseStep[];
     expect(plan.find((s) => s.oid === B)?.action).toBe("Fixup");
     expect(useNavStore.getState().intent).toBeNull();
+  });
+
+  it("starts nothing when that confirm is declined", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    void labeled(
+      commitMenuItems({ sha: B, subject: "commit B" }),
+      /Fixup this commit into its parent/,
+    ).onClick?.();
+
+    await screen.findByTestId("dialog-cancel");
+    await dismissDialog();
+    expect(rebaseStarts()).toHaveLength(0);
   });
 });

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -11,6 +11,15 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
+import { rewordCommit } from "@/features/commits/rewordCommit";
+import { dropCommit } from "@/features/commits/dropCommit";
+import { undoCommit } from "@/features/commits/undoCommit";
+import {
+  confirmRewrite,
+  isPublished,
+  rewriteWarning,
+  type RewriteCtx,
+} from "@/features/commits/rewriteWarning";
 import type {
   ActionContext,
   BranchInfo,
@@ -490,6 +499,10 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
   const onBranch = !!self;
   const isMerge = (self?.parents.length ?? 0) > 1;
   const baseOid = self?.parents[0] ?? null;
+  // Which commit HEAD is sitting on. The reword and undo entries branch on it:
+  // rewording HEAD is an in-place amend that needs no replay (and so tolerates
+  // a dirty worktree), and undoing a commit only means anything for HEAD.
+  const isHead = !!commit?.sha && commit.sha === (useRepoStore.getState().headInfo?.headOid ?? null);
   return [
     { __menuTitle: `commit ${sha.slice(0, 7)}` },
     // ABOVE the detached-HEAD entry (#179): when a branch is here, checking it
@@ -616,6 +629,39 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       ],
     },
     {
+      icon: "edit",
+      // A merge is refused only on the REBASE path. buildRebasePlan emits Drop
+      // for a merge, so rewording an older one would flatten history — but
+      // amending HEAD's own message keeps its parents, so a merge sitting at
+      // HEAD is fine. The restriction follows the mechanism, not the commit
+      // shape.
+      label: !onBranch
+        ? "Edit commit message — not on this branch"
+        : isMerge && !isHead
+          ? "Edit commit message — merge commit"
+          : !isHead && !baseOid
+            ? "Edit commit message — root commit"
+            : "Edit commit message…",
+      disabled: !onBranch || (isMerge && !isHead) || (!isHead && !baseOid),
+      onClick: () => {
+        if (!commit?.sha) return;
+        void rewordCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+    {
+      icon: "undo",
+      label: !isHead
+        ? "Undo this commit — only the last commit can be undone"
+        : !baseOid
+          ? "Undo this commit — root commit"
+          : "Undo this commit…",
+      disabled: !isHead || !baseOid,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void undoCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+    {
       icon: "fix",
       label: !onBranch
         ? "Fixup into parent — not on this branch"
@@ -625,6 +671,22 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       disabled: !onBranch || isMerge || !baseOid,
       onClick: async () => {
         if (!commit?.sha || isMerge || !baseOid) return;
+        // Through the SHARED rewrite confirm (#published-commit warning), so
+        // fixup says the same thing about a pushed commit as reword, drop and
+        // undo do. Five entries that rewrite history must not split into two
+        // behaviours.
+        const ctx = rewriteCtx(commits);
+        if (
+          !(await confirmRewrite({
+            title: `Fixup ${sha.slice(0, 7)} into its parent?`,
+            body: "The two commits become one, keeping the parent's message. Every commit after them is replayed with a new id.",
+            confirmLabel: "Fixup",
+            repoId: ctx.repoId,
+            oid: commit.sha,
+            upstream: ctx.upstream,
+          }))
+        )
+          return;
         const plan = buildRebasePlan(commits, baseOid, {
           kind: "fixup",
           targetOid: commit.sha,
@@ -646,9 +708,19 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       onClick: async () => {
         if (!commit?.sha || isMerge || !baseOid) return;
         const target = commit.sha;
+        // The published-commit warning goes in THIS prompt's body rather than a
+        // confirm in front of it: squash already asks a question, and a second
+        // modal stacked over the first cannot be dismissed predictably (see the
+        // queue note in dialog.tsx). Same sentence, one dialog.
+        const ctx = rewriteCtx(commits);
+        const warning = rewriteWarning(
+          ctx.upstream,
+          await isPublished(ctx.repoId, target, ctx.upstream),
+        );
+        const intro = "Message for the combined commit — the parent's, then this one's.";
         const msg = await pgPrompt({
           title: "Squash into parent",
-          body: "Message for the combined commit — the parent's, then this one's.",
+          body: warning ? `${intro}\n\n${warning}` : intro,
           // The parent is the older of the two, so its message leads.
           initialValue: combinedSquashMessage([baseOid, target], byOid(commits)),
           confirmLabel: "Squash",
@@ -665,6 +737,25 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
         const outcome = await runRebasePlanNow(plan);
         if (outcome === "done") pgFlash("squashed into parent");
         else if (outcome === "paused") pgFlash("squash paused — see the Conflicts screen");
+      },
+    },
+    {
+      icon: "trash",
+      // A merge is refused for the same reason fixup and squash refuse one:
+      // buildRebasePlan emits Drop for a merge to mean "flatten this branch",
+      // which is not what a reader clicking "drop this commit" is asking for.
+      label: !onBranch
+        ? "Drop this commit — not on this branch"
+        : isMerge
+          ? "Drop this commit — merge commit"
+          : !baseOid
+            ? "Drop this commit — root commit"
+            : "Drop this commit…",
+      danger: true,
+      disabled: !onBranch || isMerge || !baseOid,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void dropCommit({ oid: commit.sha }, rewriteCtx(commits));
       },
     },
     { divider: true },
@@ -727,6 +818,23 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
 /** Oid → commit, for the squash prompts' prefilled messages. */
 function byOid(commits: CommitInfo[]): Map<string, CommitInfo> {
   return new Map(commits.map((c) => [c.oid, c]));
+}
+
+/**
+ * The store reads the rewrite flows need, gathered at menu-BUILD time.
+ *
+ * Synchronous, which is all menu building may be — it runs on every right-click.
+ * The one asynchronous thing a rewrite needs, the published-commit check, is
+ * made by the flow inside `onClick`.
+ */
+function rewriteCtx(commits: CommitInfo[]): RewriteCtx {
+  const s = useRepoStore.getState();
+  return {
+    commits,
+    repoId: s.current?.id ?? "",
+    upstream: currentBranch(s.branches)?.upstream ?? null,
+    headOid: s.headInfo?.headOid ?? null,
+  };
 }
 
 /**

--- a/src/features/commits/buildRebasePlan.merge.test.ts
+++ b/src/features/commits/buildRebasePlan.merge.test.ts
@@ -54,4 +54,32 @@ describe("buildRebasePlan with merges in range", () => {
     const plan = buildRebasePlan(linear, A, { kind: "edit-from" });
     expect(plan!.map((s) => s.action)).toEqual(["Pick"]);
   });
+
+  it("a merge is dropped even when it is the reword target", () => {
+    // The menu refuses this, but the builder must not produce it either: the
+    // backend accepts no action on a merge except MainlinePick, and a Reword
+    // step on one would be rejected mid-replay, after earlier picks had already
+    // been committed.
+    //
+    // THIS is the test that catches the merge check being reordered below the
+    // reword arm — verified by planting that reordering, which failed this
+    // assertion and only this one.
+    const plan = buildRebasePlan(log, A, { kind: "reword", targetOid: M, message: "x" });
+    expect(plan!.find((s) => s.oid === M)!.action).toBe("Drop");
+    expect(plan!.find((s) => s.oid === M)!.message).toBeNull();
+  });
+
+  it("still drops a merge the reword only replays over", () => {
+    const plan = buildRebasePlan(log, A, { kind: "reword", targetOid: C, message: "x" });
+    expect(plan!.map((s) => [s.oid, s.action])).toEqual([
+      [F, "Pick"],
+      [C, "Reword"],
+      [M, "Drop"],
+    ]);
+  });
+
+  it("a merge stays dropped when it is the drop target", () => {
+    const plan = buildRebasePlan(log, A, { kind: "drop", targetOid: M });
+    expect(plan!.find((s) => s.oid === M)!.action).toBe("Drop");
+  });
 });

--- a/src/features/commits/buildRebasePlan.test.ts
+++ b/src/features/commits/buildRebasePlan.test.ts
@@ -59,4 +59,53 @@ describe("buildRebasePlan", () => {
       { oid: "d", action: "Squash", message: "all" },
     ]);
   });
+
+  it("marks only the target Reword and carries its message", () => {
+    // Base is the target's parent, so the target is INSIDE the plan.
+    expect(
+      buildRebasePlan(commits, "b", { kind: "reword", targetOid: "c", message: "new subject" }),
+    ).toEqual([
+      { oid: "c", action: "Reword", message: "new subject" },
+      { oid: "d", action: "Pick", message: null },
+    ]);
+  });
+
+  it("rewords the newest commit as a one-step plan", () => {
+    expect(
+      buildRebasePlan(commits, "c", { kind: "reword", targetOid: "d", message: "tip" }),
+    ).toEqual([{ oid: "d", action: "Reword", message: "tip" }]);
+  });
+
+  it("carries no message on commits the reword replays over", () => {
+    const plan = buildRebasePlan(commits, "a", {
+      kind: "reword",
+      targetOid: "b",
+      message: "new",
+    });
+    expect(plan?.filter((s) => s.action === "Pick").every((s) => s.message === null)).toBe(
+      true,
+    );
+  });
+
+  it("returns null for a reword whose base is outside the loaded range", () => {
+    expect(
+      buildRebasePlan(commits, "zzz", { kind: "reword", targetOid: "c", message: "x" }),
+    ).toBeNull();
+  });
+
+  it("marks only the target Drop and leaves newer commits picked", () => {
+    expect(buildRebasePlan(commits, "b", { kind: "drop", targetOid: "c" })).toEqual([
+      { oid: "c", action: "Drop", message: null },
+      { oid: "d", action: "Pick", message: null },
+    ]);
+  });
+
+  it("carries no message on the dropped step", () => {
+    const plan = buildRebasePlan(commits, "b", { kind: "drop", targetOid: "c" });
+    expect(plan?.[0].message).toBeNull();
+  });
+
+  it("returns null for a drop whose base is outside the loaded range", () => {
+    expect(buildRebasePlan(commits, "zzz", { kind: "drop", targetOid: "c" })).toBeNull();
+  });
 });

--- a/src/features/commits/buildRebasePlan.ts
+++ b/src/features/commits/buildRebasePlan.ts
@@ -9,6 +9,12 @@ import type { CommitInfo, RebaseStep, RebaseAction } from "@/lib/types";
  *   - "edit-from": every commit is a plain pick (equivalent to `rebase -i fromOid^`).
  *   - { kind: "fixup", targetOid }: target becomes "fixup".
  *   - { kind: "squash", targetOid, message }: target becomes "squash" with a custom message.
+ *   - { kind: "reword", targetOid, message }: target becomes "Reword" carrying
+ *     the new message. Pass the target's FIRST PARENT as `fromOid` so the
+ *     target is inside the plan — a reword whose base is the target itself
+ *     replays everything after it and rewords nothing.
+ *   - { kind: "drop", targetOid }: target becomes "Drop"; everything newer stays
+ *     a pick and replays onto the target's parent.
  *   - { kind: "squash-range", oids, message }: collapse a contiguous selection
  *     into one commit — the oldest selected oid stays "pick", every other
  *     selected oid becomes "squash" carrying `message`; commits outside the
@@ -30,6 +36,8 @@ export function buildRebasePlan(
   mode:
     | { kind: "edit-from" }
     | { kind: "fixup"; targetOid: string }
+    | { kind: "reword"; targetOid: string; message: string }
+    | { kind: "drop"; targetOid: string }
     | { kind: "squash"; targetOid: string; message: string }
     | { kind: "squash-range"; oids: string[]; message: string },
 ): RebaseStep[] | null {
@@ -54,6 +62,11 @@ export function buildRebasePlan(
       action = "Drop";
     } else if (mode.kind === "fixup" && c.oid === mode.targetOid) {
       action = "Fixup";
+    } else if (mode.kind === "reword" && c.oid === mode.targetOid) {
+      action = "Reword";
+      message = mode.message;
+    } else if (mode.kind === "drop" && c.oid === mode.targetOid) {
+      action = "Drop";
     } else if (mode.kind === "squash" && c.oid === mode.targetOid) {
       action = "Squash";
       message = mode.message;

--- a/src/features/commits/commitMessageText.test.ts
+++ b/src/features/commits/commitMessageText.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { fullCommitMessage } from "./commitMessageText";
+
+describe("fullCommitMessage", () => {
+  it("joins summary and body with a blank line", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: "Why: y" })).toBe(
+      "feat: x\n\nWhy: y",
+    );
+  });
+
+  it("is the summary alone when there is no body", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: null })).toBe("feat: x");
+  });
+
+  it("treats a whitespace-only body as no body", () => {
+    expect(fullCommitMessage({ summary: "feat: x", body: "  \n\n " })).toBe("feat: x");
+  });
+
+  it("trims trailing whitespace off the body but keeps its internal blank lines", () => {
+    expect(fullCommitMessage({ summary: "s", body: "one\n\ntwo\n\n" })).toBe(
+      "s\n\none\n\ntwo",
+    );
+  });
+});

--- a/src/features/commits/commitMessageText.ts
+++ b/src/features/commits/commitMessageText.ts
@@ -1,0 +1,21 @@
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * One commit's message as editable text: `summary`, then its body after a blank
+ * line. The same starting point `git rebase -i` hands you in an editor, minus
+ * the comment lines.
+ *
+ * The single owner of that rendering — `combinedSquashMessage` calls it per
+ * commit and the reword prompt calls it for one, so a change to how a message
+ * is reassembled cannot land in one of those places only.
+ *
+ * A whitespace-only body is treated as absent rather than rendered as trailing
+ * blanks: the value goes straight into a prompt the user then edits, and git's
+ * own cleanup would strip them anyway.
+ */
+export function fullCommitMessage(
+  commit: Pick<CommitInfo, "summary" | "body">,
+): string {
+  const body = commit.body?.trim();
+  return body ? `${commit.summary}\n\n${body}` : commit.summary;
+}

--- a/src/features/commits/dropCommit.ts
+++ b/src/features/commits/dropCommit.ts
@@ -1,0 +1,43 @@
+import { pgFlash } from "@/design";
+import { buildRebasePlan } from "./buildRebasePlan";
+import { runRebasePlanNow } from "./runRebasePlan";
+import { confirmRewrite, type RewriteCtx } from "./rewriteWarning";
+
+/**
+ * Remove one commit from history, replaying everything after it.
+ *
+ * Danger-confirmed, and the confirm names the alternative: unlike a revert,
+ * nothing afterwards records that this commit ever existed. That is the whole
+ * difference between the two entries, and it is not obvious from either label.
+ */
+export async function dropCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  const baseOid = self?.parents[0] ?? null;
+  // No parent means a root commit: there is no base to replay onto.
+  if (!self || !baseOid) return;
+
+  if (
+    !(await confirmRewrite({
+      title: `Drop ${target.oid.slice(0, 7)}?`,
+      body: `"${self.summary}" is removed from history and every commit after it is replayed with a new id. Nothing records that it existed — use Revert instead to undo its changes with a new commit.`,
+      confirmLabel: "Drop",
+      danger: true,
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  const plan = buildRebasePlan(ctx.commits, baseOid, {
+    kind: "drop",
+    targetOid: target.oid,
+  });
+  if (!plan) return;
+  const outcome = await runRebasePlanNow(plan);
+  if (outcome === "done") pgFlash("commit dropped");
+  else if (outcome === "paused") pgFlash("drop paused — see the Conflicts screen");
+}

--- a/src/features/commits/rewordCommit.ts
+++ b/src/features/commits/rewordCommit.ts
@@ -1,0 +1,86 @@
+import { pgFlash, pgPrompt } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { buildRebasePlan } from "./buildRebasePlan";
+import { fullCommitMessage } from "./commitMessageText";
+import { runRebasePlanNow } from "./runRebasePlan";
+import { confirmRewrite, type RewriteCtx } from "./rewriteWarning";
+
+/**
+ * Edit one commit's message.
+ *
+ * TWO paths, and the split is not an optimisation:
+ *
+ * - **HEAD** gets a message-only amend. The rebase engine refuses a dirty
+ *   worktree, and rewording the commit you are sitting on — usually while you
+ *   have uncommitted work — is by far the most common reword. Nothing is
+ *   replayed, so no other commit changes id.
+ * - **An older commit** gets a one-target `Reword` plan through the rebase
+ *   engine, which is what already runs squash and fixup from this menu.
+ *
+ * The prompt is the same surface squash already uses. It does NOT open a second
+ * commit-message composer beside `features/commits/message/` — that surface owns
+ * composing a NEW commit's message, with its co-authors and trailers; this edits
+ * one existing message in place.
+ */
+export async function rewordCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  if (!self) return;
+
+  const short = target.oid.slice(0, 7);
+  const existing = fullCommitMessage(self);
+  const next = await pgPrompt({
+    title: "Edit commit message",
+    body: `Rewriting ${short}.`,
+    initialValue: existing,
+    confirmLabel: "Save",
+    requireValue: true,
+    multiline: 8,
+  });
+  if (next === null) return;
+
+  // An unchanged message must NOT rewrite the commit. Every descendant would
+  // get a new id for nothing, and on a published commit it would demand a
+  // force-push for nothing.
+  if (next === existing) return;
+
+  const isHead = ctx.headOid === target.oid;
+  const baseOid = self.parents[0] ?? null;
+
+  if (
+    !(await confirmRewrite({
+      title: `Reword ${short}?`,
+      body: isHead
+        ? "The commit keeps its changes, author and date; only the message and the commit id change."
+        : "Every commit after this one is replayed, so they all get new ids.",
+      confirmLabel: "Reword",
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  if (isHead) {
+    if (await useRepoStore.getState().amendMessage(target.oid, next)) {
+      pgFlash("message updated");
+    }
+    return;
+  }
+
+  // A root commit cannot be reworded through a rebase — there is no base to
+  // replay onto. The menu disables that case; this is the guard for any other
+  // caller.
+  if (!baseOid) return;
+  const plan = buildRebasePlan(ctx.commits, baseOid, {
+    kind: "reword",
+    targetOid: target.oid,
+    message: next,
+  });
+  if (!plan) return;
+  const outcome = await runRebasePlanNow(plan);
+  if (outcome === "done") pgFlash("message updated");
+  else if (outcome === "paused") pgFlash("reword paused — see the Conflicts screen");
+}

--- a/src/features/commits/rewriteFlows.test.tsx
+++ b/src/features/commits/rewriteFlows.test.tsx
@@ -1,0 +1,257 @@
+// The three history-rewriting flows behind the History context menu.
+//
+// One file rather than three: they share the log fixture, the dialog host and
+// the refresh mocks, and the behaviour worth pinning is how they DIFFER from
+// each other — which reads better side by side.
+//
+// Dialogs are rendered for real (the house pattern, `src/test/dialog.tsx`)
+// rather than mocked: pgConfirm/pgPrompt resolve false/null with no host
+// mounted, so a mocked-out dialog would make every one of these pass while
+// asserting nothing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { rewordCommit } from "./rewordCommit";
+import { dropCommit } from "./dropCommit";
+import { undoCommit } from "./undoCommit";
+import type { RewriteCtx } from "./rewriteWarning";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { WithDialogs, acceptDialog, dismissDialog, dialogBody, resetDialogs } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStep } from "@/lib/types";
+
+const A = "a".repeat(40); // tip
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const ROOT = "d".repeat(40);
+
+const mk = (
+  oid: string,
+  summary: string,
+  parents: string[],
+  body: string | null = null,
+): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+/** Newest-first, as the log is: A → B → C → ROOT. */
+const COMMITS = [
+  mk(A, "commit A", [B]),
+  mk(B, "commit B", [C], "why B"),
+  mk(C, "commit C", [ROOT]),
+  mk(ROOT, "commit root", []),
+];
+
+const DONE = { inProgress: false, nextIndex: 2, total: 2, pauseReason: null };
+
+const ctx = (over: Partial<RewriteCtx> = {}): RewriteCtx => ({
+  commits: COMMITS,
+  repoId: "r1",
+  upstream: null,
+  headOid: A,
+  ...over,
+});
+
+/**
+ * Wait for a dialog to actually be on screen, then accept it.
+ *
+ * Every flow `await`s the published-commit check before opening its confirm, so
+ * accepting immediately races the dialog into existence and silently accepts
+ * nothing.
+ */
+async function acceptWhenOpen(value?: string) {
+  await screen.findByTestId("dialog-confirm");
+  await acceptDialog(value);
+}
+
+/** Same race, for the decline path. */
+async function dismissWhenOpen() {
+  await screen.findByTestId("dialog-cancel");
+  await dismissDialog();
+}
+
+const rebaseStarts = () => getInvokeCalls().filter((c) => c.cmd === "rebase_start");
+const amends = () => getInvokeCalls().filter((c) => c.cmd === "amend_head_message");
+const resets = () => getInvokeCalls().filter((c) => c.cmd === "reset");
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    branches: [],
+    error: null,
+    hookRejection: null,
+    noSignature: false,
+    loading: false,
+  } as never);
+  mockInvoke("rebase_start", () => DONE);
+  mockInvoke("amend_head_message", () => ({ oid: "new1234", message: "reworded" }));
+  mockInvoke("reset", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: COMMITS, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => DONE);
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 5, mergeBase: C }));
+  render(
+    <WithDialogs>
+      <div />
+    </WithDialogs>,
+  );
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("rewordCommit", () => {
+  it("prefills the prompt with the commit's full existing message", async () => {
+    void rewordCommit({ oid: B }, ctx());
+    const input = (await screen.findByTestId("dialog-input")) as HTMLTextAreaElement;
+    expect(input.value).toBe("commit B\n\nwhy B");
+  });
+
+  it("amends in place when the target is HEAD, with no rebase at all", async () => {
+    void rewordCommit({ oid: A }, ctx({ headOid: A }));
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("a new subject");
+    await acceptDialog(); // the rewrite confirm
+
+    await waitFor(() => expect(amends().length).toBe(1));
+    expect(amends()[0].args).toMatchObject({ expectedOid: A, message: "a new subject" });
+    expect(rebaseStarts()).toHaveLength(0);
+  });
+
+  it("runs a one-target Reword plan for an older commit", async () => {
+    void rewordCommit({ oid: B }, ctx({ headOid: A }));
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("reworded B");
+    await acceptDialog();
+
+    await waitFor(() => expect(rebaseStarts().length).toBe(1));
+    expect(rebaseStarts()[0].args.plan as RebaseStep[]).toEqual([
+      { oid: B, action: "Reword", message: "reworded B" },
+      { oid: A, action: "Pick", message: null },
+    ]);
+    expect(amends()).toHaveLength(0);
+  });
+
+  it("does nothing when the message comes back unchanged", async () => {
+    void rewordCommit({ oid: B }, ctx());
+    await screen.findByTestId("dialog-input");
+    // Accept without editing: the prefill IS the existing message.
+    await acceptDialog();
+
+    expect(amends()).toHaveLength(0);
+    expect(rebaseStarts()).toHaveLength(0);
+  });
+
+  it("does nothing when the prompt is dismissed", async () => {
+    void rewordCommit({ oid: A }, ctx());
+    await screen.findByTestId("dialog-input");
+    await dismissDialog();
+
+    expect(amends()).toHaveLength(0);
+    expect(rebaseStarts()).toHaveLength(0);
+  });
+
+  it("does nothing when the rewrite confirm is declined", async () => {
+    void rewordCommit({ oid: A }, ctx());
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("a new subject");
+    await dismissDialog();
+
+    expect(amends()).toHaveLength(0);
+  });
+
+  it("warns in the confirm when the commit is already published", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 4, behind: 0, mergeBase: C }));
+    void rewordCommit({ oid: A }, ctx({ upstream: "origin/main" }));
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("a new subject");
+
+    await waitFor(() => expect(dialogBody()).toMatch(/already on origin\/main/));
+    expect(dialogBody()).toMatch(/has to be forced/);
+  });
+
+  it("stays quiet when the commit is not published yet", async () => {
+    void rewordCommit({ oid: A }, ctx({ upstream: "origin/main" }));
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("a new subject");
+
+    await waitFor(() => expect(dialogBody()).toBeTruthy());
+    expect(dialogBody()).not.toMatch(/origin\/main/);
+  });
+
+  it("does nothing for a commit the log does not hold", async () => {
+    await rewordCommit({ oid: "f".repeat(40) }, ctx());
+    expect(screen.queryByTestId("dialog-input")).toBeNull();
+    expect(amends()).toHaveLength(0);
+  });
+});
+
+describe("dropCommit", () => {
+  it("runs a plan that drops the target and picks everything newer", async () => {
+    void dropCommit({ oid: B }, ctx());
+    await acceptWhenOpen();
+
+    await waitFor(() => expect(rebaseStarts().length).toBe(1));
+    expect(rebaseStarts()[0].args.plan as RebaseStep[]).toEqual([
+      { oid: B, action: "Drop", message: null },
+      { oid: A, action: "Pick", message: null },
+    ]);
+  });
+
+  it("names Revert as the non-destructive alternative", async () => {
+    void dropCommit({ oid: B }, ctx());
+    await waitFor(() => expect(dialogBody()).toMatch(/use Revert instead/));
+  });
+
+  it("does nothing when the confirm is declined", async () => {
+    void dropCommit({ oid: B }, ctx());
+    await dismissWhenOpen();
+    expect(rebaseStarts()).toHaveLength(0);
+  });
+
+  it("does nothing for a root commit — there is no base to replay onto", async () => {
+    await dropCommit({ oid: ROOT }, ctx());
+    expect(rebaseStarts()).toHaveLength(0);
+  });
+});
+
+describe("undoCommit", () => {
+  it("soft-resets to the parent, leaving the work staged", async () => {
+    void undoCommit({ oid: A }, ctx({ headOid: A }));
+    await acceptWhenOpen();
+
+    await waitFor(() => expect(resets().length).toBe(1));
+    expect(resets()[0].args).toMatchObject({ target: B, mode: "Soft" });
+  });
+
+  it("says the changes are kept, so the entry is not read as a discard", async () => {
+    void undoCommit({ oid: A }, ctx({ headOid: A }));
+    await waitFor(() => expect(dialogBody()).toMatch(/stay in your working tree/));
+  });
+
+  it("does nothing for a commit that is not HEAD", async () => {
+    await undoCommit({ oid: B }, ctx({ headOid: A }));
+    expect(resets()).toHaveLength(0);
+  });
+
+  it("does nothing for a root commit at HEAD — there is no parent to reset to", async () => {
+    await undoCommit({ oid: ROOT }, ctx({ headOid: ROOT }));
+    expect(resets()).toHaveLength(0);
+  });
+});

--- a/src/features/commits/rewriteWarning.test.ts
+++ b/src/features/commits/rewriteWarning.test.ts
@@ -1,0 +1,69 @@
+// The published-commit warning shared by every history-rewriting menu entry.
+//
+// `isPublished`'s argument order is the part worth pinning: getting it backwards
+// inverts the warning silently, so it would fire on exactly the commits that are
+// safe to rewrite and stay quiet on the ones that are not.
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { isPublished, rewriteWarning } from "./rewriteWarning";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+describe("rewriteWarning", () => {
+  it("names the upstream and the force-push when the commit is published", () => {
+    expect(rewriteWarning("origin/main", true)).toBe(
+      "This commit is already on origin/main. Rewriting it means your next push has to be forced.",
+    );
+  });
+
+  it("is silent for an unpublished commit", () => {
+    expect(rewriteWarning("origin/main", false)).toBeNull();
+  });
+
+  it("is silent when the branch tracks nothing — there is nothing to force", () => {
+    expect(rewriteWarning(null, true)).toBeNull();
+  });
+});
+
+describe("isPublished", () => {
+  const aheadBehindCall = () => getInvokeCalls().find((c) => c.cmd === "ahead_behind");
+
+  beforeEach(() => {
+    // `behind` is "on a, not on b" (pinned by ref_compare.rs), so a commit is
+    // published exactly when nothing on it is missing from the upstream.
+    mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 0, mergeBase: null }));
+  });
+
+  it("asks about the commit against the upstream, in that order", async () => {
+    await isPublished("r1", "abc1234", "origin/main");
+    expect(aheadBehindCall()?.args).toMatchObject({
+      repoId: "r1",
+      a: "abc1234",
+      b: "origin/main",
+    });
+  });
+
+  it("is true when the commit is contained in the upstream", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 3, behind: 0, mergeBase: "abc" }));
+    expect(await isPublished("r1", "abc1234", "origin/main")).toBe(true);
+  });
+
+  it("is false when the commit is not in the upstream yet", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 2, mergeBase: "abc" }));
+    expect(await isPublished("r1", "abc1234", "origin/main")).toBe(false);
+  });
+
+  it("does not ask at all when the branch tracks nothing", async () => {
+    expect(await isPublished("r1", "abc1234", null)).toBe(false);
+    expect(aheadBehindCall()).toBeUndefined();
+  });
+
+  it("is false, not a throw, when the upstream cannot be resolved", async () => {
+    // A deleted remote branch or a stale config. A warning is a courtesy, and
+    // failing to compute one must never block the operation the user asked for.
+    mockInvoke("ahead_behind", () => {
+      throw { kind: "InvalidRef", message: "no such ref" };
+    });
+    expect(await isPublished("r1", "abc1234", "origin/gone")).toBe(false);
+  });
+});

--- a/src/features/commits/rewriteWarning.ts
+++ b/src/features/commits/rewriteWarning.ts
@@ -1,0 +1,91 @@
+import { pgConfirm } from "@/design";
+import { aheadBehind } from "@/lib/tauri";
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * Everything a rewrite flow reads, gathered by the CALLER.
+ *
+ * Shared vocabulary rather than any one flow's own type, so the menu's three
+ * call sites are identical. Keeping the store reads at the call site — where
+ * menu building already reads the store synchronously — is what lets the flows
+ * be unit tested without a store.
+ */
+export interface RewriteCtx {
+  /** HEAD's ancestry, newest first — what a rebase plan is defined over. */
+  commits: CommitInfo[];
+  repoId: string;
+  /** The current branch's upstream, for the published-commit warning. */
+  upstream: string | null;
+  headOid: string | null;
+}
+
+/**
+ * Is this commit already contained in the branch's upstream?
+ *
+ * `aheadBehind(repoId, a, b).behind` is "on `a`, not on `b`" (pinned by
+ * `ref_compare.rs::ahead_behind_counts_a_diverged_pair_both_ways`), so zero
+ * means the commit holds nothing the upstream is missing — it is published.
+ * Getting that order backwards inverts the warning silently, which is why the
+ * order has its own test.
+ *
+ * One IPC call, made from an `onClick` and never while building a menu: menu
+ * building runs on every right-click and must stay synchronous.
+ *
+ * A branch that tracks nothing is not published and is not asked about. An
+ * unresolvable upstream — a deleted remote branch, a stale config — answers
+ * "false" rather than throwing: a warning is a courtesy, and failing to compute
+ * one must never block the operation the user actually asked for.
+ */
+export async function isPublished(
+  repoId: string,
+  oid: string,
+  upstream: string | null,
+): Promise<boolean> {
+  if (!upstream) return false;
+  try {
+    const ab = await aheadBehind(repoId, oid, upstream);
+    return ab.behind === 0;
+  } catch {
+    return false;
+  }
+}
+
+/** The sentence a rewrite confirm gains when the commit is already pushed. */
+export function rewriteWarning(
+  upstream: string | null,
+  published: boolean,
+): string | null {
+  if (!upstream || !published) return null;
+  return `This commit is already on ${upstream}. Rewriting it means your next push has to be forced.`;
+}
+
+/**
+ * The one confirm every history-rewriting menu entry goes through, so all five
+ * of them — reword, drop, undo, squash, fixup — say the same thing about a
+ * published commit. Five entries that rewrite history splitting into two
+ * behaviours is the inconsistency this shared helper exists to prevent.
+ *
+ * **No force-push is offered.** A network write behind a menu item that does not
+ * mention pushing is a surprise, and force-with-lease is its own design
+ * question.
+ */
+export async function confirmRewrite(opts: {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  danger?: boolean;
+  repoId: string;
+  oid: string;
+  upstream: string | null;
+}): Promise<boolean> {
+  const warning = rewriteWarning(
+    opts.upstream,
+    await isPublished(opts.repoId, opts.oid, opts.upstream),
+  );
+  return pgConfirm({
+    title: opts.title,
+    body: warning ? `${opts.body}\n\n${warning}` : opts.body,
+    confirmLabel: opts.confirmLabel,
+    danger: opts.danger,
+  });
+}

--- a/src/features/commits/squashMessage.ts
+++ b/src/features/commits/squashMessage.ts
@@ -1,4 +1,5 @@
 import type { CommitInfo } from "@/lib/types";
+import { fullCommitMessage } from "./commitMessageText";
 
 /**
  * Default message for a squash: every squashed commit's own message, oldest
@@ -17,8 +18,7 @@ export function combinedSquashMessage(
   for (const oid of oids) {
     const c = byOid.get(oid);
     if (!c) continue;
-    const body = c.body?.trim();
-    parts.push(body ? `${c.summary}\n\n${body}` : c.summary);
+    parts.push(fullCommitMessage(c));
   }
   return parts.join("\n\n");
 }

--- a/src/features/commits/undoCommit.ts
+++ b/src/features/commits/undoCommit.ts
@@ -1,0 +1,42 @@
+import { pgFlash } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { confirmRewrite, type RewriteCtx } from "./rewriteWarning";
+
+/**
+ * Undo the last commit, keeping its changes staged — `reset --soft HEAD^`.
+ *
+ * HEAD only, which is the only commit this means anything for: undoing an older
+ * commit is a drop or a revert, and both have their own entry.
+ *
+ * It earns a named entry over the reset submenu because reaching it there means
+ * right-clicking a DIFFERENT commit — the parent — and picking "Soft". This
+ * names the intent instead of the mechanism.
+ *
+ * No new backend op: the reset already exists, and it is already undoable.
+ */
+export async function undoCommit(
+  target: { oid: string },
+  ctx: RewriteCtx,
+): Promise<void> {
+  if (ctx.headOid !== target.oid) return;
+  const self = ctx.commits.find((c) => c.oid === target.oid);
+  const parent = self?.parents[0] ?? null;
+  // A root commit has no parent to reset to; unmaking it would mean an unborn
+  // HEAD, which is not what this entry offers.
+  if (!self || !parent) return;
+
+  if (
+    !(await confirmRewrite({
+      title: `Undo ${target.oid.slice(0, 7)}?`,
+      body: `"${self.summary}" stops being a commit. Its changes stay in your working tree, staged and ready to commit again.`,
+      confirmLabel: "Undo commit",
+      repoId: ctx.repoId,
+      oid: target.oid,
+      upstream: ctx.upstream,
+    }))
+  )
+    return;
+
+  await useRepoStore.getState().reset(parent, "Soft");
+  pgFlash("commit undone — changes are staged");
+}

--- a/src/features/repo/amendMessage.test.ts
+++ b/src/features/repo/amendMessage.test.ts
@@ -1,0 +1,103 @@
+// amendMessage — reword HEAD in place, message only.
+//
+// The three failure shapes matter as much as the success one: a hook refusal
+// and a missing identity are questions the commit panel can answer in place,
+// so they land in their own per-repo fields rather than the error banner.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useRepoStore } from "./useRepoStore";
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+
+/** Everything refreshAll() fans out to — return empties so it resolves. */
+function mockRefresh() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+}
+
+const amendCall = () => getInvokeCalls().find((c) => c.cmd === "amend_head_message");
+
+describe("amendMessage", () => {
+  beforeEach(() => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      error: null,
+      hookRejection: null,
+      noSignature: false,
+    } as never);
+    mockRefresh();
+  });
+
+  it("sends the expected oid, so a moved HEAD is refused by the backend", async () => {
+    mockInvoke("amend_head_message", () => ({ oid: "new1234", message: "reworded" }));
+    await useRepoStore.getState().amendMessage("old1234", "reworded");
+    expect(amendCall()?.args).toMatchObject({
+      repoId: "r1",
+      expectedOid: "old1234",
+      message: "reworded",
+    });
+  });
+
+  it("resolves true and refreshes, so the log repaints with the new oid", async () => {
+    mockInvoke("amend_head_message", () => ({ oid: "new1234", message: "reworded" }));
+    const ok = await useRepoStore.getState().amendMessage("old1234", "reworded");
+    expect(ok).toBe(true);
+    expect(getInvokeCalls().some((c) => c.cmd === "get_status")).toBe(true);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("routes a hook refusal to hookRejection, not the error banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "HookRejected", message: { hook: "commit-msg", output: "nope" } };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "bad");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().hookRejection).toMatchObject({ hook: "commit-msg" });
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("puts a missing identity in noSignature, not the error banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "NoSignature" };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "x");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().noSignature).toBe(true);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("reports any other failure in the banner", async () => {
+    mockInvoke("amend_head_message", () => {
+      throw { kind: "InvalidArgument", message: "HEAD has moved" };
+    });
+    const ok = await useRepoStore.getState().amendMessage("old1234", "x");
+    expect(ok).toBe(false);
+    expect(useRepoStore.getState().error?.kind).toBe("InvalidArgument");
+  });
+
+  it("clears a previous refusal before trying again", async () => {
+    useRepoStore.setState({
+      hookRejection: { hook: "commit-msg", output: "old" },
+    } as never);
+    mockInvoke("amend_head_message", () => ({ oid: "new1234", message: "ok" }));
+    await useRepoStore.getState().amendMessage("old1234", "ok");
+    expect(useRepoStore.getState().hookRejection).toBeNull();
+  });
+
+  it("does nothing without an open repository", async () => {
+    useRepoStore.setState({ current: null } as never);
+    const ok = await useRepoStore.getState().amendMessage("old1234", "x");
+    expect(ok).toBe(false);
+    expect(amendCall()).toBeUndefined();
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -46,6 +46,7 @@ import {
   checkoutRef,
   cherryPick,
   commit as commitFn,
+  amendHeadMessage as amendHeadMessageFn,
   continueOperation,
   createBranch,
   createTag,
@@ -372,6 +373,14 @@ interface RepoStoreState extends RepoSlice {
     /** Skip every commit-side hook for this commit only (#232). */
     noVerify?: boolean,
   ) => Promise<CommitResult | null>;
+  /**
+   * Reword HEAD in place, message only. Resolves true when history changed.
+   *
+   * `expectedOid` guards against HEAD moving between the menu opening and the
+   * click landing — see `amendHeadMessage`. Distinct from `commit(amend)`,
+   * which writes the index tree and would fold in staged changes.
+   */
+  amendMessage: (expectedOid: string, message: string) => Promise<boolean>;
   /** Dismiss the hook refusal on display (#232). */
   clearHookRejection: () => void;
   /**
@@ -1405,6 +1414,39 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       }
       setErrorFor(repo.id, e);
       return null;
+    }
+  },
+
+  async amendMessage(expectedOid, message) {
+    const repo = get().current;
+    if (!repo) return false;
+    // Clear the previous refusal first, exactly as `commit` does: a stale block
+    // sitting above a fresh attempt reads as though the new attempt failed too.
+    setFor(repo.id, { hookRejection: null, noSignature: false });
+    const before = headSnapshot();
+    try {
+      await amendHeadMessageFn(repo.id, expectedOid, message);
+      await get().refreshAll();
+      // Undoable like any other history rewrite: an amend REPLACES the tip, so
+      // before/after already describes putting the original commit back, with
+      // no special case needed.
+      noteUndo(repo.id, "commit", "reword", before);
+      return true;
+    } catch (e) {
+      // Same three surfaces as `commit`, for the same three reasons — a hook
+      // refusal needs somewhere that scrolls, and a missing identity is a
+      // question the panel answers in place rather than a failure to report.
+      if (isAppError(e) && e.kind === "HookRejected") {
+        await get().refreshAll();
+        setFor(repo.id, { hookRejection: e.message as HookRejection });
+        return false;
+      }
+      if (isNoSignatureError(e)) {
+        setFor(repo.id, { noSignature: true });
+        return false;
+      }
+      setErrorFor(repo.id, e);
+      return false;
     }
   },
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -549,6 +549,34 @@ export async function commit(
 }
 
 /**
+ * Replace HEAD's commit message and nothing else — the reword path for the
+ * commit you are sitting on.
+ *
+ * Message-only by construction: the backend reuses the commit's original tree
+ * and never reads the index, so this works with a dirty worktree and cannot
+ * fold staged changes into the commit being reworded. `commit(amend: true)` is
+ * NOT an alternative — it writes the index tree.
+ *
+ * `expectedOid` is what the caller believed HEAD was. A mismatch is refused
+ * rather than rewording whatever is there now: HEAD can move between a context
+ * menu opening and its click landing.
+ */
+export async function amendHeadMessage(
+  repoId: string,
+  expectedOid: string,
+  message: string,
+  /** Skip the message hooks for this reword only (matches `commit`). */
+  noVerify = false,
+): Promise<CommitResult> {
+  return invoke<CommitResult>("amend_head_message", {
+    repoId,
+    expectedOid,
+    message,
+    noVerify,
+  });
+}
+
+/**
  * Signature status of ONE commit (#61 D6).
  *
  * Lazy and per-selection by design: a badge on every log row would mean a


### PR DESCRIPTION
Brings three of Rider's commit context-menu entries to History: **Edit commit
message…**, **Undo this commit…** and **Drop this commit…**, behind a warning
shared with Squash and Fixup that names the force-push when the commit is
already published.

First of five PRs from a spec that audits our commit menu against Rider's. The
spec is in this PR (`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`),
along with this PR's plan; the remaining four cover *Show repository at
revision* + *Go to parent/child commit*, *View in browser*, *Create patch…* and
*Push all up to here…*.

## Rewording HEAD does not use the rebase engine, and that is the point

`RebaseAction::Reword` has worked end to end since the Rebase screen shipped —
no menu could reach it. But `rebase_start_with_progress` refuses **any** worktree
or index modification, so a one-step Reword plan would fail for anyone with
uncommitted work, which is most reword attempts.

So HEAD gets a new op, `amend_head_message`. `Commit::amend` with `tree: None`
reuses the commit's original tree, which makes it message-only: the index is
never read. `commit(amend: true)` is not an alternative — it writes the index
tree (`fresh_index(repo)?; index.write_tree()?`) and would silently fold staged
changes into the commit being reworded. An **older** commit still goes through
the engine, via a new `buildRebasePlan` mode.

The op preserves the author and refreshes only the committer, as git does, and
goes through the one signing chain so a signed commit stays signed and a signing
failure creates nothing. `pre-commit` deliberately does not run — the tree cannot
change here — while the message hooks do; that deviation from `git commit --amend
--only` is documented.

## Two findings worth a reviewer's attention

**My Rust tests did not pin the TOCTOU guard until I made them.** Deleting the
authoritative HEAD check inside the write lock left all 12 tests green, because
the advisory early check absorbed every case. The test that closes the real
window is `a_head_move_during_the_hook_window_is_refused`: a `commit-msg` hook
that makes its own commit, moving HEAD between the two checks — hooks run outside
the per-repo lock, which is what makes the window real. Re-planting the removal
now fails that test and only that test. (The hook needs `--no-verify` and a
one-shot marker, or it forks until the OS refuses.)

**Splitting `context-menu.tsx` was planned and then rejected.** `commitMenuItems`
cannot move without also extracting the `ContextMenuItem` type,
`customActionItems` and `headBranch`, all shared with the file builders, or the
two modules import each other — a restructure of the type every menu builder
depends on, for a file this work only passes through. Each flow got its own
`features/commits/` module instead, which is where `buildRebasePlan`,
`runRebasePlan` and `squashMessage` already live. The reasoning is in the spec.

## One shipped behaviour changed

Right-click **Fixup** previously ran with no dialog at all. It now goes through
the shared rewrite confirm, so all five history-rewriting entries say the same
thing about a published commit. `pgConfirm` resolves false with no host mounted,
so its existing test needed updating; its original point — no message prompt, no
Rebase-screen detour — is kept and now asserted explicitly.

Squash puts the warning in its **prompt body** rather than a confirm in front of
it: squash already asks a question, and a second modal over the first cannot be
dismissed predictably.

## Known gap, recorded and not fixed here

The rebase engine's own `Reword` arm calls `Commit::amend` directly and therefore
**drops a signature**. That affects every reword of an older commit and every
`Reword` step run from the Rebase screen, so it predates this work and belongs to
its own change with its own tests. Recorded in `docs/dev/backend.md`.

## Verification

- `cargo test` — 92 test binaries, zero failures. 13 new in `tests/amend_message.rs`,
  2 new in `tests/signing.rs` (the signed-reword pair runs for real; `ssh-keygen`
  is present, so it was not skipped).
- `pnpm test` — 370 files, 3739 tests passed.
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `pnpm test:e2e:docker` on `history-ops.e2e.ts` — **8 passing**, including two
  new reword tests. The dirty-worktree one asserts unstaged, untracked and staged
  changes all survive unconsumed, and that the staged file is absent from the
  reworded commit's tree.

Guard tests were verified to bite rather than trusted: renaming the
`architecture.md` command entry failed the docs gate, and reordering the merge
check in `buildRebasePlan` failed exactly one merge test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
