### PR TITLE
feat(commits): browse at a revision, and navigate the commit graph

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -845,6 +845,46 @@ therefore belongs in `features/`, not `design/`.
   `MAX_BARREN_PAGES`, or it walks the whole repository. New client-side log
   filters inherit that trap.
 
+## Navigating from the History menu
+
+Two entries that read the repository and change nothing, so neither goes near
+`confirmRewrite`.
+
+- **`browse-rev` is routed by `AppShell` but consumed by `RepoBrowser`.** The
+  shell only calls `enterScreen("repo")` and deliberately does NOT clear the
+  intent; the browser reads it on mount, sets the same `rev` its toolbar picker
+  writes, and clears it there. That keeps one source of truth for "what am I
+  browsing" instead of a shell-owned copy. A new kind with no `case` in the
+  shell sets an intent and navigates nowhere with **nothing failing** — not
+  tsc, not the unit tests, not e2e (#133) — which is why
+  `AppShell.navroutes.test.tsx` types `EXPECTED` as a mapped type over
+  `NavIntent["kind"]`: a new kind will not compile until it has a sample and a
+  destination.
+- **`Show repository at this revision` ignores ancestry**, unlike every rewrite
+  entry. Browsing a tree reads nothing and writes nothing, so a commit on any
+  branch is fair game.
+- **`Go to parent / child commit` takes a CALLBACK (`onGoTo`)** because
+  History's selection is local component state (`History.tsx`'s
+  `useState<Selection>`), which a builder in `src/design/` cannot reach — the
+  same shape and the same reason as `PGErrorBanner`'s `onReport`. With no
+  callback the two entries are **omitted entirely** rather than rendered dead,
+  because this menu is also used outside History.
+- **The builder History passes must be a `useCallback`, never an inline arrow.**
+  An arrow changes identity every render, cascades through `onRowContext` into
+  every row and kills `PGCommitRow`'s memo. That is #68 G9, and it has regressed
+  once already — the comment beside `onCommitMulti` records the first time.
+- **One target is inline, several give a submenu.** A merge has two parents and
+  a branch point two children; picking one silently would be a guess presented
+  as a fact.
+- **The child entry blames the LOADED LOG, not the repository.** `s.commits` is
+  a prefix of history, so `commitChildren` returning nothing means "none
+  loaded" — the label says exactly that, and a test asserts it does not say "no
+  child exists". A parent outside the window stays *enabled*, because its oid is
+  genuine even unloaded; `goToCommit` then flashes rather than no-opping when it
+  cannot reach the row.
+- **Selection moves scroll by INDEX** through `useWindowedList`, never
+  `scrollIntoView`: the target row is usually unmounted (#68 G10).
+
 ## Rewriting one commit from the History menu
 
 Five entries in `commitMenuItems` rewrite history — *Edit commit message*,

--- a/docs/superpowers/plans/2026-09-08-commit-menu-parity-pr2-navigation-entries.md
+++ b/docs/superpowers/plans/2026-09-08-commit-menu-parity-pr2-navigation-entries.md
@@ -1,0 +1,534 @@
+# Commit menu parity — PR2: the navigation entries
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add *Show repository at this revision* and *Go to parent / child
+commit* to the History commit context menu.
+
+**Architecture:** Both are pure frontend. `RepoBrowser` already browses at a
+revision and only lacks an entry point, so that one is a new `NavIntent` routed
+in `AppShell`. Parent/child navigation moves History's selection, which is local
+component state a `src/design/` menu builder cannot reach — so
+`commitMenuItems` takes an optional callback, the shape `PGErrorBanner`'s
+`onReport` already uses.
+
+**Tech Stack:** React 19 / TypeScript, Zustand, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md` §5, §6.
+
+**Stacked on PR1** (`feat/commit-menu-parity`), because both PRs edit the same
+region of `commitMenuItems`. Rebase onto `main` once PR1 lands.
+
+## Global Constraints
+
+Same as PR1's plan; the ones that bite here:
+
+- **Node 22 + pnpm** by absolute path — `~/Library/pnpm/pnpm`,
+  `~/.cargo/bin/cargo`. The worktree guard refuses CLAUDE.md's
+  `export PATH="$HOME/…"` line and refuses compound commands containing a `git`
+  token.
+- **A new `NavIntent` kind MUST be routed in `AppShell`** — compile-enforced by
+  `assertNever` (`src/AppShell.tsx:132`) and pinned by
+  `AppShell.navroutes.test.tsx`. A kind with no `case` sets an intent and
+  navigates nowhere, and *nothing* fails: not tsc, not unit tests, not e2e
+  (that was #133).
+- **The log is PAGED.** `s.commits` is a prefix of history, never the answer to
+  a containment question. A child that is not loaded must produce a disabled
+  entry naming why, never a wrong jump.
+- **Menu building stays synchronous.** No `await` outside `onClick`.
+- **Scroll by offset, never `scrollIntoView`** — History's list is windowed and
+  the target row is usually unmounted.
+- No new backend op, no new command, so no `architecture.md` command entry is
+  required this time. `docs/dev/frontend.md` still gets the navigation model
+  note.
+
+---
+
+### Task 1: `commitChildren` — the reverse-parent lookup
+
+**Files:**
+- Create: `src/features/commits/commitChildren.ts`
+- Create: `src/features/commits/commitChildren.test.ts`
+
+**Interfaces:**
+- Produces: `commitChildren(commits: CommitInfo[], oid: string): CommitInfo[]`
+  — every loaded commit listing `oid` among its parents, newest-first (input
+  order preserved).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/features/commits/commitChildren.test.ts
+import { describe, expect, it } from "vitest";
+import { commitChildren } from "./commitChildren";
+import type { CommitInfo } from "@/lib/types";
+
+const mk = (oid: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary: `commit ${oid}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+describe("commitChildren", () => {
+  it("finds the one commit whose parent it is", () => {
+    const log = [mk("c", ["b"]), mk("b", ["a"]), mk("a", [])];
+    expect(commitChildren(log, "b").map((c) => c.oid)).toEqual(["c"]);
+  });
+
+  it("finds several children at a branch point, newest first", () => {
+    // Both `c` and `side` were committed on top of `b`.
+    const log = [mk("c", ["b"]), mk("side", ["b"]), mk("b", ["a"]), mk("a", [])];
+    expect(commitChildren(log, "b").map((c) => c.oid)).toEqual(["c", "side"]);
+  });
+
+  it("counts a merge that lists the commit as its SECOND parent", () => {
+    const log = [mk("m", ["c", "side"]), mk("c", ["b"]), mk("side", ["b"])];
+    expect(commitChildren(log, "side").map((c) => c.oid)).toEqual(["m"]);
+  });
+
+  it("is empty for the newest loaded commit", () => {
+    const log = [mk("c", ["b"]), mk("b", ["a"])];
+    expect(commitChildren(log, "c")).toEqual([]);
+  });
+
+  it("is empty for an oid the log does not hold", () => {
+    expect(commitChildren([mk("c", ["b"])], "zzz")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/commitChildren.test.ts`
+Expected: FAIL — cannot resolve `./commitChildren`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/features/commits/commitChildren.ts
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * The loaded commits that list `oid` among their parents — this commit's
+ * children, newest first.
+ *
+ * **A commit can have several children** (a branch point), and a merge counts as
+ * a child of BOTH its parents, so every parent slot is searched rather than just
+ * the first.
+ *
+ * **The answer is only as complete as the loaded log**, which is a PREFIX of
+ * history: an empty result means "no child in what is loaded", never "no child
+ * exists". Callers must say that rather than treat it as a fact about the
+ * repository — the menu disables the entry with a label naming the reason.
+ */
+export function commitChildren(commits: CommitInfo[], oid: string): CommitInfo[] {
+  if (!oid) return [];
+  return commits.filter((c) => c.parents.includes(oid));
+}
+```
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/commits/commitChildren.test.ts`
+Expected: PASS, all five.
+
+- [ ] **Step 5: Commit**
+
+```
+feat(commits): find a commit's children in the loaded log
+```
+
+---
+
+### Task 2: the `browse-rev` NavIntent
+
+**Files:**
+- Modify: `src/features/nav/useNavStore.ts` (the `NavIntent` union)
+- Modify: `src/AppShell.tsx` (the routing switch)
+- Modify: `src/screens/RepoBrowser.tsx` (consume it; `rev` is local state at ~line 202)
+- Modify: `src/AppShell.navroutes.test.tsx`
+- Create: `src/screens/RepoBrowser.browseRev.test.tsx`
+
+**Interfaces:**
+- Produces: `{ kind: "browse-rev"; rev: string; label: string }` — `rev` is a
+  full oid; `label` is what the header shows (`<short> — <subject>`).
+
+- [ ] **Step 1: Read the two files that constrain this**
+
+`AppShell.navroutes.test.tsx` — how it enumerates kinds and what its allow-list
+means. `RepoBrowser.tsx` around `const [rev, setRev]` (line ~202), the
+`setRev(null)` repo-switch reset (~242), and the toolbar's `setRev(r)` (~1022):
+the intent must set the same state that toolbar picker sets, not a parallel one.
+
+- [ ] **Step 2: Write the failing routing test**
+
+Add to `src/AppShell.navroutes.test.tsx`, following the file's existing shape:
+
+```ts
+it("routes browse-rev to the repo browser", () => {
+  // A kind with no case in AppShell sets an intent and navigates NOWHERE, and
+  // nothing else fails — that is #133, and this test is the guard.
+  useNavStore.getState().setIntent({
+    kind: "browse-rev",
+    rev: "a".repeat(40),
+    label: "aaaaaaa — commit A",
+  });
+  // ...assert the screen became "repo", exactly as the sibling cases do.
+});
+```
+
+- [ ] **Step 3: Run and confirm it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/AppShell.navroutes.test.tsx`
+Expected: FAIL — the kind is not in the union, so this does not compile.
+
+- [ ] **Step 4: Add the union member**
+
+In `src/features/nav/useNavStore.ts`, beside `{ kind: "commit-self"; oid: string }`:
+
+```ts
+  /**
+   * Browse the whole tree as it was at one revision (#Rider parity). The
+   * RepoBrowser already does this — `listFilesAtRev` / `readFileContentAtRev`
+   * and a "Browsing {rev}" header — and had no entry point but its own toolbar.
+   */
+  | { kind: "browse-rev"; rev: string; label: string }
+```
+
+- [ ] **Step 5: Route it in `AppShell`**
+
+Add a `case` beside `commit-self`'s. It must set the RepoBrowser's `rev` before
+or as it enters the screen; read how `open-settings` passes a page through
+`useSettingsStore` and mirror that shape rather than inventing a third
+mechanism. If RepoBrowser's `rev` has to leave local state to receive this,
+prefer a `useNavStore` field the screen reads on mount over lifting `rev` into
+`useRepoStore` — `rev` is per-window view state, not per-repo data, and
+`RepoSlice` is for state a tab switch must carry.
+
+- [ ] **Step 6: Consume it in `RepoBrowser`**
+
+Set `rev` from the intent and clear the intent. Keep the existing
+`setRev(null)`-on-repo-switch behaviour intact: browsing a revision of the
+previous repository must not survive a tab switch (the comment at ~line 239
+already says so).
+
+- [ ] **Step 7: Write the RepoBrowser test**
+
+```ts
+// src/screens/RepoBrowser.browseRev.test.tsx
+it("browses at the revision the intent names", async () => {
+  mockInvoke("list_files_at_rev", () => [{ path: "a.txt", /* …the real shape */ }]);
+  useNavStore.getState().setIntent({
+    kind: "browse-rev",
+    rev: REV,
+    label: "aaaaaaa — commit A",
+  });
+  render(<RepoBrowser />);
+  // The header names the revision, and the file list came from the AT-REV call.
+  expect(await screen.findByText(/Browsing/)).toBeTruthy();
+  expect(getInvokeCalls().find((c) => c.cmd === "list_files_at_rev")?.args).toMatchObject({
+    rev: REV,
+  });
+});
+```
+
+Check the real command name and argument shape in `src/lib/tauri.ts` first
+(`listFilesAtRev`) and match them; do not trust the name above.
+
+- [ ] **Step 8: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/AppShell.navroutes.test.tsx src/screens/RepoBrowser.browseRev.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```
+feat(commits): browse the repository at a commit's revision
+```
+
+---
+
+### Task 3: `onGoTo` — the callback that lets the menu move History's selection
+
+**Files:**
+- Modify: `src/design/context-menu.tsx` (`commitMenuItems` signature + entries)
+- Modify: `src/screens/History.tsx` (pass the callback; `sel` is at line 135)
+- Create: `src/design/context-menu.goto.test.tsx`
+
+**Interfaces:**
+- Produces: `commitMenuItems(commit, opts?: { onGoTo?: (oid: string) => void })`
+  — the second parameter is OPTIONAL and every existing call site keeps working
+  unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("Go to parent / child commit", () => {
+  it("omits both entries entirely when no onGoTo is supplied", () => {
+    // The menu is used outside History too; a dead entry there is worse than
+    // no entry.
+    const labels = commitMenuItems({ sha: B }).map((i) => i.label);
+    expect(labels.some((l) => typeof l === "string" && /Go to parent/.test(l))).toBe(false);
+    expect(labels.some((l) => typeof l === "string" && /Go to child/.test(l))).toBe(false);
+  });
+
+  it("goes to the first parent inline", async () => {
+    const onGoTo = vi.fn();
+    await labeled(commitMenuItems({ sha: B }, { onGoTo }), /^Go to parent commit/).onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(C); // B's first parent
+  });
+
+  it("offers a submenu of every parent for a merge", () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: MERGE }, { onGoTo }), /^Go to parent commit/);
+    expect(item.submenu).toHaveLength(2);
+    expect(item.submenu?.[0].label).toMatch(/^ccccccc/);
+  });
+
+  it("is refused for the root commit, and says why", () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: ROOT }, { onGoTo }), /^Go to parent commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/root commit/);
+  });
+
+  it("goes to the one child inline", async () => {
+    const onGoTo = vi.fn();
+    await labeled(commitMenuItems({ sha: B }, { onGoTo }), /^Go to child commit/).onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(HEAD_SHA);
+  });
+
+  it("offers a submenu when a commit has several children", () => {
+    const onGoTo = vi.fn();
+    // MERGE and SIDE both list C as a parent.
+    const item = labeled(commitMenuItems({ sha: C }, { onGoTo }), /^Go to child commit/);
+    expect(item.submenu?.length).toBeGreaterThan(1);
+  });
+
+  // THE paged-log case. Not "no child exists" — "no child is loaded".
+  it("is refused when no child is in the loaded log, and says so", () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: HEAD_SHA }, { onGoTo }), /^Go to child commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/loaded log/);
+    expect(item.label).not.toMatch(/no child exists/);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/context-menu.goto.test.tsx`
+Expected: FAIL — no such entries, and the second parameter does not exist.
+
+- [ ] **Step 3: Widen the signature**
+
+```ts
+export function commitMenuItems(
+  commit: { sha?: string; subject?: string } | null,
+  opts?: {
+    /**
+     * Move the caller's selection to `oid`. History owns its selection as LOCAL
+     * component state, which a builder in `src/design/` cannot reach — the same
+     * reason `PGErrorBanner` takes an `onReport`.
+     *
+     * Absent means the caller has no selection to move, and the parent/child
+     * entries are omitted rather than rendered dead.
+     */
+    onGoTo?: (oid: string) => void;
+  },
+): ContextMenuItem[] {
+```
+
+- [ ] **Step 4: Add the entries**
+
+Place them after the bisect submenu's divider, per the spec's menu order. Use
+`commitChildren(commits, sha)` from Task 1 and `self.parents`. Shape:
+
+```ts
+    ...(opts?.onGoTo ? gotoItems(commit?.sha ?? null, commits, opts.onGoTo) : []),
+```
+
+with a private helper beside `bisectSubmenu`:
+
+```ts
+/**
+ * "Go to parent / child commit" — Rider has these on Left/Right; we ship them
+ * menu-only (the chord model is single-stroke and Left/Right are list
+ * expand/collapse).
+ *
+ * One target → an inline entry. Several → a submenu, because a merge has two
+ * parents and a branch point has two children, and picking silently would be a
+ * guess. None → a disabled entry that says WHY, and for a child the honest
+ * reason is the paged log, not the repository.
+ */
+function gotoItems(
+  sha: string | null,
+  commits: CommitInfo[],
+  onGoTo: (oid: string) => void,
+): ContextMenuItem[] {
+  const self = sha ? (commits.find((c) => c.oid === sha) ?? null) : null;
+  const parents = (self?.parents ?? [])
+    .map((p) => commits.find((c) => c.oid === p) ?? { oid: p, summary: "" })
+    .filter(Boolean);
+  const children = sha ? commitChildren(commits, sha) : [];
+
+  const entry = (
+    verb: "parent" | "child",
+    targets: { oid: string; summary?: string }[],
+    emptyReason: string,
+  ): ContextMenuItem => {
+    if (targets.length === 0) {
+      return { icon: "dot", label: `Go to ${verb} commit — ${emptyReason}`, disabled: true };
+    }
+    if (targets.length === 1) {
+      return {
+        icon: "dot",
+        label: `Go to ${verb} commit`,
+        onClick: () => onGoTo(targets[0].oid),
+      };
+    }
+    return {
+      icon: "dot",
+      label: `Go to ${verb} commit`,
+      submenu: targets.map((t) => ({
+        icon: "dot",
+        label: `${t.oid.slice(0, 7)} — ${t.summary ?? ""}`.trim(),
+        onClick: () => onGoTo(t.oid),
+      })),
+    };
+  };
+
+  return [
+    entry("parent", parents, "root commit"),
+    // NOT "no child exists": s.commits is a PREFIX of history.
+    entry("child", children, "none in the loaded log"),
+  ];
+}
+```
+
+Verify `"dot"` is in `IconName` (`src/design/icons.tsx`) — it is used by the
+reset submenu already, but check rather than assume; `test/iconSet.test.ts`
+fails the build for an undeclared literal.
+
+- [ ] **Step 5: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/`
+Expected: PASS, including every pre-existing `context-menu.*` suite. A suite
+asserting a full label list will need the new labels added — but note they only
+appear when `onGoTo` is passed, so most will be unaffected.
+
+- [ ] **Step 6: Commit**
+
+```
+feat(commits): navigate to a commit's parent or child from the menu
+```
+
+---
+
+### Task 4: wire History's selection to `onGoTo`
+
+**Files:**
+- Modify: `src/screens/History.tsx` (`useContextMenu` call at ~line 259; `sel` at 135)
+- Create: `src/screens/History.goto.test.tsx`
+
+- [ ] **Step 1: Read how History selects and scrolls**
+
+`clickSelection` (used at ~line 378), `scrollCommitListTo`'s production
+equivalent, and the windowed-list offset scrolling around line 406
+(`selectedIndex: cursorIdx`). The callback must do what clicking the row does —
+select it AND bring it into view — without `scrollIntoView`, which cannot work
+under windowing.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+it("selects the parent commit when the menu asks to go there", async () => {
+  render(<History />);
+  // Open the menu on the HEAD row and pick "Go to parent commit", then assert
+  // the DETAIL pane switched to the parent — that is the observable effect of
+  // the selection moving, and it does not depend on which row is windowed in.
+});
+```
+
+Drive it the way the sibling History tests drive a context menu; read one first.
+
+- [ ] **Step 3: Pass the callback**
+
+```ts
+  const commitMenu = React.useCallback(
+    (c: { sha: string; subject: string } | null) =>
+      commitMenuItems(c, {
+        onGoTo: (oid) => {
+          setSel((prev) => clickSelection(order, prev, oid, {}));
+          // Scroll by OFFSET — the list is windowed, so the target row is
+          // usually unmounted and `scrollIntoView` has nothing to act on.
+          scrollToOid(oid);
+        },
+      }),
+    [order],
+  );
+```
+
+`scrollToOid` is whatever History's existing offset-scroll helper is called —
+find it rather than adding a second one; `scrollCommitListTo` in the e2e support
+file is the test-side equivalent and names the production concept.
+
+- [ ] **Step 4: Run and confirm green**
+
+Run: `~/Library/pnpm/pnpm vitest run src/screens/History.goto.test.tsx src/screens/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+feat(history): move the selection when the menu navigates
+```
+
+---
+
+### Task 5: docs, gates, e2e
+
+**Files:**
+- Modify: `docs/dev/frontend.md` (the navigation-model section, and the
+  "Rewriting one commit from the History menu" section PR1 added)
+- Modify: `e2e/specs/history-ops.e2e.ts`
+
+- [ ] **Step 1: Document**
+
+The `browse-rev` intent in the navigation model; the `onGoTo` callback and WHY
+it is a callback (History's selection is local state, `src/design/` cannot reach
+it); and the paged-log honesty rule for the child entry.
+
+- [ ] **Step 2: Run every gate**
+
+```
+~/Library/pnpm/pnpm tsc --noEmit
+~/Library/pnpm/pnpm exec tsc -p e2e/tsconfig.json --noEmit
+~/Library/pnpm/pnpm test
+~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+The Rust suite is untouched by this PR but run it anyway — it is cheap and this
+branch is stacked, so a red would otherwise be attributed to PR1.
+
+- [ ] **Step 3: E2E**
+
+Add one spec: right-click a commit → *Show repository at this revision* → the
+browser lists a file that exists at that revision. **`jsClickMenuItem` matches
+the label's `textContent` EXACTLY** — pass the ellipsis if the label has one.
+Rebuild the snapshot first (`full`), since `src/` changed, and run only this
+spec. Read the `N passing` / `N failing` lines; a wrapper exit code of 0 with
+failures inside is a shape that has already happened here.
+
+- [ ] **Step 4: Push, open the PR against PR1's branch**
+
+Base it on `feat/commit-menu-parity` while that is open, and retarget to `main`
+after PR1 merges. `gh pr create` needs `--body-file`; a `--body` with prose is
+refused in this worktree.

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -260,6 +260,37 @@ describe("rewording a commit", () => {
     expect(repo.git("ls-tree", "--name-only", "HEAD")).not.toContain("staged.txt");
   });
 
+  // Reading the tree AS IT WAS, which changes nothing — the other half of what
+  // the commit menu gained. The assertion is that the browser lists a file that
+  // exists at that revision and NOT one added later: that is what proves the
+  // at-rev backend call drove the tree, rather than the working copy.
+  it("browses the repository at a commit's revision", async () => {
+    repo = cherryRepo(); // a.txt at the root commit, b.txt added later
+    await openRepo(repo.path);
+    await switchScreen("history");
+    await scrollCommitListTo("feat: add a.txt");
+    await $('[data-testid="commit-row"]*=feat: add a.txt').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "root-ish row missing",
+    });
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add a.txt" });
+    await jsClickMenuItem("Show repository at this revision");
+
+    // The browser says which revision it is on — a reader must be able to tell
+    // this is not the working tree. Waits on the TESTID, not the copy.
+    await $('[data-testid="browsing-rev"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the repo browser never entered at-rev mode",
+    });
+    // a.txt existed at that commit; b.txt did not.
+    await $('[data-pg-row][data-path="a.txt"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "a.txt was not listed at that revision",
+    });
+    await expect($('[data-pg-row][data-path="b.txt"]')).not.toBeExisting();
+    // Nothing was written.
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
   // The other path: an older commit goes through the rebase engine's Reword
   // action, which replays every commit after it.
   it("rewords an older commit and replays the commits after it", async () => {

--- a/src/AppShell.navroutes.test.tsx
+++ b/src/AppShell.navroutes.test.tsx
@@ -102,6 +102,10 @@ const EXPECTED: { [K in NavIntent["kind"]]: Expectation<K> } = {
     intent: { kind: "file-history", path: "src/a.ts" },
     screen: "fileHistory",
   },
+  "browse-rev": {
+    intent: { kind: "browse-rev", rev: OID, label: "aaaaaaa — commit 0" },
+    screen: "repo",
+  },
   blame: {
     intent: { kind: "blame", path: "src/a.ts" },
     screen: "blame",

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -400,6 +400,13 @@ export function AppShell() {
       case "blame":
         enterDeep("blame");
         break;
+      // The repo browser owns the revision itself — it already has a `rev` and a
+      // toolbar that sets it, so the intent is left in place for the screen to
+      // read on mount rather than lifted into a store here. Do NOT clearIntent:
+      // RepoBrowser clears it once it has consumed the rev.
+      case "browse-rev":
+        enterScreen("repo");
+        break;
       case "rebase-plan":
       // The base-only variant (186). Same destination: the Rebase screen owns
       // the range walk and the plan either way.

--- a/src/design/context-menu.browseRev.test.tsx
+++ b/src/design/context-menu.browseRev.test.tsx
@@ -1,0 +1,81 @@
+// "Show repository at this revision" — the commit menu's entry point into the
+// repo browser's at-rev mode.
+//
+// Two halves, and the routing half is the one that has silently broken before
+// (#133): the menu sets the intent, AppShell routes it, and RepoBrowser turns it
+// into the same `rev` its toolbar picker writes. The unit test here covers the
+// menu's half; AppShell.navroutes.test.tsx covers the routing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { commitMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import type { CommitInfo } from "@/lib/types";
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+
+const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+const COMMITS = [mk(A, "commit A", [B]), mk(B, "commit B", [])];
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    headInfo: { branch: "main", headOid: A },
+    branches: [],
+    loading: false,
+  } as never);
+  useNavStore.setState({ intent: null });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Show repository at this revision", () => {
+  it("fires a browse-rev intent carrying the full oid", async () => {
+    await labeled(commitMenuItems({ sha: B, subject: "commit B" }), /^Show repository/)
+      .onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "browse-rev",
+      rev: B,
+      label: `${B.slice(0, 7)} — commit B`,
+    });
+  });
+
+  it("is offered for a commit that is not on this branch", () => {
+    // Unlike every rewrite entry, browsing a tree reads and changes nothing, so
+    // ancestry is irrelevant — a commit from any branch can be browsed.
+    const OFF = "f".repeat(40);
+    const item = labeled(commitMenuItems({ sha: OFF }), /^Show repository/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is disabled with no commit", () => {
+    const item = labeled(commitMenuItems(null), /^Show repository/);
+    expect(item.disabled).toBe(true);
+  });
+
+  it("sets no intent when there is no commit", async () => {
+    await labeled(commitMenuItems(null), /^Show repository/).onClick?.();
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+});

--- a/src/design/context-menu.goto.test.tsx
+++ b/src/design/context-menu.goto.test.tsx
@@ -1,0 +1,154 @@
+// "Go to parent / child commit" — graph navigation from the commit menu.
+//
+// The interesting cases are the ambiguous ones (a merge has two parents, a
+// branch point two children) and the PAGED-LOG one: an absent child means "none
+// loaded", which is not the same claim as "none exists", and the label has to
+// say which.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { commitMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo } from "@/lib/types";
+
+const HEAD_SHA = "a".repeat(40); // tip; nothing loaded is its child
+const B = "b".repeat(40);
+const MERGE = "e".repeat(40);
+const SIDE = "5".repeat(40);
+const C = "c".repeat(40); // parent of BOTH MERGE and SIDE → two children
+const ROOT = "d".repeat(40);
+
+const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+// Newest-first: HEAD → B → MERGE(C, SIDE) → SIDE → C → ROOT.
+const COMMITS = [
+  mk(HEAD_SHA, "commit A", [B]),
+  mk(B, "commit B", [MERGE]),
+  mk(MERGE, "Merge branch 'side'", [C, SIDE]),
+  mk(SIDE, "side work", [C]),
+  mk(C, "commit C", [ROOT]),
+  mk(ROOT, "commit root", []),
+];
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+const labels = (items: ContextMenuItem[]) =>
+  items.map((i) => i.label).filter((l): l is string => typeof l === "string");
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    headInfo: { branch: "main", headOid: HEAD_SHA },
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        tip: HEAD_SHA,
+        tipTime: 0,
+        isDefault: true,
+      },
+    ],
+    loading: false,
+  } as never);
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 1, mergeBase: C }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Go to parent / child commit", () => {
+  it("omits both entries entirely when no onGoTo is supplied", () => {
+    // The menu is used outside History, which has no selection to move. A dead
+    // entry there is worse than no entry.
+    const l = labels(commitMenuItems({ sha: B }));
+    expect(l.some((s) => /Go to parent/.test(s))).toBe(false);
+    expect(l.some((s) => /Go to child/.test(s))).toBe(false);
+  });
+
+  it("goes to the first parent inline", async () => {
+    const onGoTo = vi.fn();
+    await labeled(commitMenuItems({ sha: B }, { onGoTo }), /^Go to parent commit/).onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(MERGE);
+  });
+
+  it("offers a submenu of every parent for a merge", async () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: MERGE }, { onGoTo }), /^Go to parent commit/);
+    expect(item.submenu).toHaveLength(2);
+    expect(item.submenu?.[0].label).toBe(`${C.slice(0, 7)} — commit C`);
+    expect(item.submenu?.[1].label).toBe(`${SIDE.slice(0, 7)} — side work`);
+    // And it is the submenu that navigates, not the parent row.
+    expect(item.onClick).toBeUndefined();
+    await item.submenu?.[1].onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(SIDE);
+  });
+
+  it("is refused for the root commit, and says why", () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: ROOT }, { onGoTo }), /^Go to parent commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/root commit/);
+  });
+
+  it("goes to the one child inline", async () => {
+    const onGoTo = vi.fn();
+    await labeled(commitMenuItems({ sha: B }, { onGoTo }), /^Go to child commit/).onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(HEAD_SHA);
+  });
+
+  it("offers a submenu when a commit has several children", () => {
+    const onGoTo = vi.fn();
+    // Both MERGE and SIDE list C as a parent.
+    const item = labeled(commitMenuItems({ sha: C }, { onGoTo }), /^Go to child commit/);
+    expect(item.submenu).toHaveLength(2);
+    expect(item.submenu?.map((s) => s.label)).toEqual([
+      `${MERGE.slice(0, 7)} — Merge branch 'side'`,
+      `${SIDE.slice(0, 7)} — side work`,
+    ]);
+  });
+
+  // THE paged-log case. `s.commits` is a prefix of history, so the absence of a
+  // child in it is a fact about the LOG, not about the repository.
+  it("is refused when no child is in the loaded log, and blames the log", () => {
+    const onGoTo = vi.fn();
+    const item = labeled(commitMenuItems({ sha: HEAD_SHA }, { onGoTo }), /^Go to child commit/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/none in the loaded log/);
+    // It must NOT claim the commit has no children.
+    expect(item.label).not.toMatch(/no child exists|has no child/);
+  });
+
+  it("keeps a parent outside the loaded window navigable, without a subject", async () => {
+    const onGoTo = vi.fn();
+    // A log window holding only the tip: its parent is unknown but still a real
+    // oid the selection can move to.
+    useRepoStore.setState({ commits: [mk(HEAD_SHA, "commit A", [B])] } as never);
+    const item = labeled(
+      commitMenuItems({ sha: HEAD_SHA }, { onGoTo }),
+      /^Go to parent commit/,
+    );
+    expect(item.disabled).toBeFalsy();
+    await item.onClick?.();
+    expect(onGoTo).toHaveBeenCalledWith(B);
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -11,6 +11,7 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
+import { commitChildren } from "@/features/commits/commitChildren";
 import { rewordCommit } from "@/features/commits/rewordCommit";
 import { dropCommit } from "@/features/commits/dropCommit";
 import { undoCommit } from "@/features/commits/undoCommit";
@@ -482,7 +483,23 @@ export function diffCopyMenuItems(
   return items;
 }
 
-export function commitMenuItems(commit: { sha?: string; subject?: string } | null): ContextMenuItem[] {
+export function commitMenuItems(
+  commit: { sha?: string; subject?: string } | null,
+  opts?: {
+    /**
+     * Move the caller's selection to `oid` — what "Go to parent / child commit"
+     * does.
+     *
+     * A CALLBACK because History owns its selection as local component state,
+     * which a builder living in `src/design/` cannot reach. Same shape and same
+     * reason as `PGErrorBanner`'s `onReport`.
+     *
+     * Absent means the caller has no selection to move, and both entries are
+     * OMITTED rather than rendered dead — this menu is used outside History too.
+     */
+    onGoTo?: (oid: string) => void;
+  },
+): ContextMenuItem[] {
   const sha = commit?.sha || "—";
   // Ancestry for the rebase entry points, from the full log. The base is the
   // commit's FIRST PARENT — never the next log row, which on a graph is often a
@@ -783,6 +800,12 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       },
     },
     { divider: true },
+    // Graph navigation, next to the inspection group above it rather than the
+    // rewrite group: these two move the SELECTION and change nothing. Both are
+    // absent unless the caller supplied a way to move it.
+    ...(opts?.onGoTo
+      ? [...gotoItems(commit?.sha ?? null, commits, opts.onGoTo), { divider: true }]
+      : []),
     ...bisectSubmenu(commit?.sha ?? null),
     { divider: true },
     {
@@ -949,6 +972,71 @@ function checkoutBranchItems(oid: string | null | undefined): ContextMenuItem[] 
  *
  * Deliberately no keyboard chords anywhere in this group: see the design doc.
  */
+/**
+ * "Go to parent / child commit" — Rider puts these on Left/Right; ours are
+ * menu-only, because `chord.ts` is single-stroke (modifiers plus one base key)
+ * and Left/Right are already list expand/collapse.
+ *
+ * One target → an inline entry. SEVERAL → a submenu, because a merge has two
+ * parents and a branch point has two children, and jumping to one silently
+ * would be a guess dressed as a fact. None → a disabled entry that says why,
+ * and for a child the honest reason is **the loaded log**, not the repository:
+ * `commits` is a prefix of history, so "none loaded" is all this can know.
+ */
+function gotoItems(
+  sha: string | null,
+  commits: CommitInfo[],
+  onGoTo: (oid: string) => void,
+): ContextMenuItem[] {
+  const self = sha ? (commits.find((c) => c.oid === sha) ?? null) : null;
+  // A parent outside the loaded window is still a real, navigable oid — the
+  // caller's selection can move to it and the log will page to reach it — so an
+  // unknown parent keeps its oid and loses only its subject.
+  const parents = (self?.parents ?? []).map((p) => {
+    const known = commits.find((c) => c.oid === p);
+    return { oid: p, summary: known?.summary ?? "" };
+  });
+  const children = sha
+    ? commitChildren(commits, sha).map((c) => ({ oid: c.oid, summary: c.summary }))
+    : [];
+
+  const entry = (
+    verb: "parent" | "child",
+    targets: { oid: string; summary: string }[],
+    emptyReason: string,
+  ): ContextMenuItem => {
+    if (targets.length === 0) {
+      return {
+        icon: "dot",
+        label: `Go to ${verb} commit — ${emptyReason}`,
+        disabled: true,
+      };
+    }
+    if (targets.length === 1) {
+      return {
+        icon: "dot",
+        label: `Go to ${verb} commit`,
+        onClick: () => onGoTo(targets[0].oid),
+      };
+    }
+    return {
+      icon: "dot",
+      label: `Go to ${verb} commit`,
+      submenu: targets.map((t) => ({
+        icon: "dot",
+        label: `${t.oid.slice(0, 7)} — ${t.summary}`.trim(),
+        onClick: () => onGoTo(t.oid),
+      })),
+    };
+  };
+
+  return [
+    entry("parent", parents, "root commit"),
+    // NOT "no child exists" — see the note above.
+    entry("child", children, "none in the loaded log"),
+  ];
+}
+
 function bisectSubmenu(sha: string | null): ContextMenuItem[] {
   const bisect = useRepoStore.getState().bisectStatus;
   const short = sha ? sha.slice(0, 7) : "—";

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -789,6 +789,22 @@ export function commitMenuItems(
         useNavStore.getState().setIntent({ kind: "commit-self", oid: commit.sha });
       },
     },
+    // Neither a diff nor a rewrite: the whole tree AS IT WAS. The repo browser
+    // has done this since it shipped and its only way in was its own toolbar,
+    // so a commit could not reach it.
+    {
+      icon: "folder",
+      label: "Show repository at this revision",
+      disabled: !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha) return;
+        useNavStore.getState().setIntent({
+          kind: "browse-rev",
+          rev: commit.sha,
+          label: `${sha.slice(0, 7)} — ${commit.subject ?? ""}`.trim(),
+        });
+      },
+    },
     // Kept alongside it: a genuinely different question — this commit's tree
     // against the working tree, not against its parent.
     {

--- a/src/features/commits/commitChildren.test.ts
+++ b/src/features/commits/commitChildren.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { commitChildren } from "./commitChildren";
+import type { CommitInfo } from "@/lib/types";
+
+const mk = (oid: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary: `commit ${oid}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+describe("commitChildren", () => {
+  it("finds the one commit whose parent it is", () => {
+    const log = [mk("c", ["b"]), mk("b", ["a"]), mk("a", [])];
+    expect(commitChildren(log, "b").map((c) => c.oid)).toEqual(["c"]);
+  });
+
+  it("finds several children at a branch point, newest first", () => {
+    // Both `c` and `side` were committed on top of `b`.
+    const log = [mk("c", ["b"]), mk("side", ["b"]), mk("b", ["a"]), mk("a", [])];
+    expect(commitChildren(log, "b").map((c) => c.oid)).toEqual(["c", "side"]);
+  });
+
+  it("counts a merge that lists the commit as its SECOND parent", () => {
+    // A merge is a child of both its parents; searching only `parents[0]` would
+    // make the side branch look like it had no children at all.
+    const log = [mk("m", ["c", "side"]), mk("c", ["b"]), mk("side", ["b"])];
+    expect(commitChildren(log, "side").map((c) => c.oid)).toEqual(["m"]);
+  });
+
+  it("is empty for the newest loaded commit", () => {
+    const log = [mk("c", ["b"]), mk("b", ["a"])];
+    expect(commitChildren(log, "c")).toEqual([]);
+  });
+
+  it("is empty for an oid the log does not hold", () => {
+    expect(commitChildren([mk("c", ["b"])], "zzz")).toEqual([]);
+  });
+
+  it("is empty for an empty oid rather than matching a parentless commit", () => {
+    expect(commitChildren([mk("a", [])], "")).toEqual([]);
+  });
+});

--- a/src/features/commits/commitChildren.ts
+++ b/src/features/commits/commitChildren.ts
@@ -1,0 +1,20 @@
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * The loaded commits that list `oid` among their parents — this commit's
+ * children, newest first (input order preserved).
+ *
+ * **A commit can have several children** (a branch point), and a merge is a
+ * child of BOTH its parents — so every parent slot is searched, not just the
+ * first. Searching `parents[0]` alone would make a side branch look childless.
+ *
+ * **The answer is only as complete as the loaded log**, which is a PREFIX of
+ * history (`s.commits`, `PAGE_SIZE = 500`). An empty result means "no child in
+ * what is loaded", never "no child exists". Callers must say that: the menu
+ * disables its entry with a label naming the loaded log as the reason, rather
+ * than asserting something about the repository it cannot know.
+ */
+export function commitChildren(commits: CommitInfo[], oid: string): CommitInfo[] {
+  if (!oid) return [];
+  return commits.filter((c) => c.parents.includes(oid));
+}

--- a/src/features/nav/useNavStore.ts
+++ b/src/features/nav/useNavStore.ts
@@ -25,6 +25,16 @@ export type NavIntent =
   | { kind: "ref-compare"; left: CompareSide; right: CompareSide }
   | { kind: "file-history"; path: string }
   | { kind: "blame"; path: string }
+  /**
+   * Browse the whole tree as it was at one revision — Rider's "Show Repository
+   * at Revision".
+   *
+   * `RepoBrowser` has done this since it shipped (`listFilesAtRev`,
+   * `readFileContentAtRev`, a "Browsing {rev}" header) and its only entry point
+   * was its own toolbar, so a commit could not reach it. `rev` is a full oid;
+   * `label` is what the browser names on screen.
+   */
+  | { kind: "browse-rev"; rev: string; label: string }
   | { kind: "rebase-plan"; plan: RebaseStep[] }
   /**
    * Replay the current branch onto a NEW base, interactively (186) — the

--- a/src/screens/History.goto.test.tsx
+++ b/src/screens/History.goto.test.tsx
@@ -1,0 +1,139 @@
+// History wiring the commit menu's "Go to parent / child commit" to its own
+// selection.
+//
+// The menu builder lives in `src/design/` and cannot reach this screen's
+// selection — it is local component state — so the connection is a callback,
+// and this file is what proves the callback is actually connected. The menu's
+// own half (which oid it asks for, and when it refuses) lives in
+// `src/design/context-menu.goto.test.tsx`.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { resetDialogs } from "@/test/dialog";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo } from "@/lib/types";
+
+const mkCommit = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const D = "d".repeat(40);
+
+const rowFor = (text: string) => {
+  const row = screen
+    .getAllByText(text)
+    .map((el) => el.closest("[data-pg-row]"))
+    .find((el): el is Element => el != null);
+  expect(row, `no row for ${text}`).toBeTruthy();
+  return row! as HTMLElement;
+};
+const isSelected = (text: string) => rowFor(text).hasAttribute("data-selected");
+
+/** Open the row's context menu and click an item by its exact label. */
+function menuItem(label: RegExp): HTMLElement {
+  const menu = document.querySelector("[data-pg-menu]");
+  expect(menu, "no context menu open").toBeTruthy();
+  const found = Array.from(menu!.querySelectorAll("*")).find(
+    (el) => el.children.length === 0 && label.test(el.textContent ?? ""),
+  );
+  expect(found, `no menu item matching ${label}`).toBeTruthy();
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: [
+      mkCommit(A, "commit A", [B]),
+      mkCommit(B, "commit B", [C]),
+      mkCommit(C, "commit C", [D]),
+      mkCommit(D, "commit D", []),
+    ],
+    searchResults: null,
+    searching: false,
+    searchCommits: async () => {},
+    branches: [],
+    headInfo: { branch: "main", headOid: A },
+    status: [],
+    loading: false,
+  } as never);
+  useNavStore.setState({ intent: null });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 1, mergeBase: D }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("History: go to parent / child commit", () => {
+  it("moves the selection to the parent", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit B"));
+    expect(isSelected("commit B")).toBe(true);
+
+    fireEvent.contextMenu(rowFor("commit B"));
+    fireEvent.click(menuItem(/^Go to parent commit$/));
+
+    // B's parent is C.
+    expect(isSelected("commit C")).toBe(true);
+    expect(isSelected("commit B")).toBe(false);
+  });
+
+  it("moves the selection to the child", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit B"));
+
+    fireEvent.contextMenu(rowFor("commit B"));
+    fireEvent.click(menuItem(/^Go to child commit$/));
+
+    // A is the only loaded commit listing B as a parent.
+    expect(isSelected("commit A")).toBe(true);
+    expect(isSelected("commit B")).toBe(false);
+  });
+
+  it("offers the entries at all — the callback is wired, not just declared", () => {
+    // The regression this guards is a real one in shape: commitMenuItems omits
+    // both entries entirely when no onGoTo is passed, so forgetting to wire it
+    // would leave the feature invisible with nothing else failing.
+    render(<HistoryScreen />);
+    fireEvent.contextMenu(rowFor("commit B"));
+    expect(menuItem(/^Go to parent commit$/)).toBeTruthy();
+    expect(menuItem(/^Go to child commit$/)).toBeTruthy();
+  });
+
+  it("says so rather than moving nowhere when the target is off the visible log", () => {
+    // Only the tip is loaded; its parent's oid is real but not in the list.
+    useRepoStore.setState({ commits: [mkCommit(A, "commit A", [B])] } as never);
+    render(<HistoryScreen />);
+    fireEvent.contextMenu(rowFor("commit A"));
+    fireEvent.click(menuItem(/^Go to parent commit$/));
+
+    // The one loaded row keeps the selection, and the flash explains why.
+    expect(isSelected("commit A")).toBe(true);
+    expect(screen.getByText(/not in the visible log/)).toBeInTheDocument();
+  });
+});

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -255,8 +255,8 @@ export function HistoryScreen() {
     () => resolveHeadDecor(headMarks, headWeight),
     [headMarks, headWeight],
   );
-  const { onContextMenu: onCommitContext, menu: commitMenu } =
-    useContextMenu<{ sha: string; subject: string }>(commitMenuItems);
+  // The commit menu is built further down, once `order` and the windowed list
+  // it navigates through exist — see `commitMenuBuilder`.
   // The imported builder directly — an inline arrow here changed onCommitMulti's
   // identity every render, which cascaded through onRowContext into every row
   // and made PGCommitRow's memo dead (#68 G9, regressed).
@@ -378,6 +378,41 @@ export function HistoryScreen() {
     setSel((prev) => clickSelection(order, prev, oid, { range }));
     setLeadOid(oid);
   };
+
+  // "Go to parent / child commit". The menu builder lives in `src/design/` and
+  // cannot reach this screen's selection, which is LOCAL component state — so it
+  // takes this as a callback, the same shape and reason as PGErrorBanner's
+  // onReport.
+  //
+  // Scrolls by INDEX through the windowed list, never scrollIntoView: the target
+  // row is usually unmounted (#68 G10).
+  const goToCommit = React.useCallback(
+    (oid: string) => {
+      const i = order.indexOf(oid);
+      if (i < 0) {
+        // A real oid this screen cannot reach: past the loaded page, or filtered
+        // out of the visible list. Say so rather than no-op silently — the menu
+        // offers an unloaded PARENT deliberately, since its oid is genuine even
+        // when the log has not paged that far.
+        pgFlash("that commit is not in the visible log");
+        return;
+      }
+      setSel((prev) => clickSelection(order, prev, oid, {}));
+      setLeadOid(oid);
+      win.scrollToIndex(i);
+    },
+    [order, win.scrollToIndex],
+  );
+  // A stable builder, NOT an inline arrow: an arrow here changes identity every
+  // render, which cascades through onRowContext into every row and kills
+  // PGCommitRow's memo — #68 G9, which has regressed once already.
+  const commitMenuBuilder = React.useCallback(
+    (c: { sha: string; subject: string } | null) =>
+      commitMenuItems(c, { onGoTo: goToCommit }),
+    [goToCommit],
+  );
+  const { onContextMenu: onCommitContext, menu: commitMenu } =
+    useContextMenu<{ sha: string; subject: string }>(commitMenuBuilder);
 
   // Enter / "View combined diff": one commit → its own diff full-screen
   // (commit-self, matching the inline panel — not commit-vs-HEAD); 2+ →

--- a/src/screens/RepoBrowser.browseRev.test.tsx
+++ b/src/screens/RepoBrowser.browseRev.test.tsx
@@ -89,7 +89,9 @@ describe("browse-rev intent", () => {
     render(<RepoBrowserScreen />);
     await waitFor(() => expect(revCalls().length).toBeGreaterThan(0));
     // A reader must be able to tell they are NOT looking at the working tree.
-    expect(await screen.findByText(/Browsing/)).toBeTruthy();
+    const badge = await screen.findByTestId("browsing-rev");
+    expect(badge.getAttribute("data-rev")).toBe(REV);
+    expect(badge.textContent).toContain("Browsing");
   });
 
   it("clears the intent, so a later repo switch is not re-hijacked by it", async () => {
@@ -108,14 +110,14 @@ describe("browse-rev intent", () => {
   // one would be asserting the default filter, not this feature.)
   it("does not browse at a revision when there is no intent", async () => {
     render(<RepoBrowserScreen />);
-    await waitFor(() => expect(screen.queryByText(/Browsing/)).toBeNull());
+    await waitFor(() => expect(screen.queryByTestId("browsing-rev")).toBeNull());
     expect(revCalls()).toHaveLength(0);
   });
 
   it("ignores an intent meant for another screen, and leaves it standing", async () => {
     useNavStore.getState().setIntent({ kind: "blame", path: "a.txt" });
     render(<RepoBrowserScreen />);
-    await waitFor(() => expect(screen.queryByText(/Browsing/)).toBeNull());
+    await waitFor(() => expect(screen.queryByTestId("browsing-rev")).toBeNull());
     expect(revCalls()).toHaveLength(0);
     // Consuming another screen's intent would strand that navigation.
     expect(useNavStore.getState().intent).toMatchObject({ kind: "blame" });

--- a/src/screens/RepoBrowser.browseRev.test.tsx
+++ b/src/screens/RepoBrowser.browseRev.test.tsx
@@ -1,0 +1,123 @@
+// RepoBrowser consuming a `browse-rev` intent.
+//
+// The half that has silently broken before (#133) is exactly this one: a menu
+// can set an intent, AppShell can route the screen, and the screen can still
+// never read it — with nothing failing. So this asserts the observable
+// consequence: the file list came from the AT-REV backend call, not from the
+// working tree.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { FileStatus, RepoHandle } from "@/lib/types";
+
+const repo: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+const REV = "a".repeat(40);
+
+const atRev = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+});
+
+const revCalls = () => getInvokeCalls().filter((c) => c.cmd === "list_files_at_rev");
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: repo,
+    status: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+  } as never);
+  useNavStore.setState({ intent: null });
+  mockInvoke("list_all_files", () => []);
+  mockInvoke("list_files_at_rev", () => [atRev("only-at-rev.txt")]);
+  mockInvoke("get_diff", (args) => ({
+    path: args.path as string,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("read_file_content", (args) => ({
+    path: args.path as string,
+    text: "content",
+    binary: false,
+    fromHead: false,
+  }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("browse-rev intent", () => {
+  it("browses at the revision the intent names", async () => {
+    useNavStore.getState().setIntent({
+      kind: "browse-rev",
+      rev: REV,
+      label: "aaaaaaa — commit A",
+    });
+    render(<RepoBrowserScreen />);
+
+    // The list came from the at-rev call, with the full oid — not a short one,
+    // and not the working tree.
+    await waitFor(() => expect(revCalls().length).toBeGreaterThan(0));
+    expect(revCalls()[0].args).toMatchObject({ repoId: repo.id, revspec: REV });
+  });
+
+  it("says on screen which revision is being browsed", async () => {
+    useNavStore.getState().setIntent({
+      kind: "browse-rev",
+      rev: REV,
+      label: "aaaaaaa — commit A",
+    });
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(revCalls().length).toBeGreaterThan(0));
+    // A reader must be able to tell they are NOT looking at the working tree.
+    expect(await screen.findByText(/Browsing/)).toBeTruthy();
+  });
+
+  it("clears the intent, so a later repo switch is not re-hijacked by it", async () => {
+    useNavStore.getState().setIntent({
+      kind: "browse-rev",
+      rev: REV,
+      label: "aaaaaaa — commit A",
+    });
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(useNavStore.getState().intent).toBeNull());
+  });
+
+  // Controls. Both assert the NEGATIVE, which is the whole claim: the at-rev
+  // path is entered only by a browse-rev intent. (The screen opens in "changes"
+  // mode, so there is no positive working-tree call to wait on here — asserting
+  // one would be asserting the default filter, not this feature.)
+  it("does not browse at a revision when there is no intent", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(screen.queryByText(/Browsing/)).toBeNull());
+    expect(revCalls()).toHaveLength(0);
+  });
+
+  it("ignores an intent meant for another screen, and leaves it standing", async () => {
+    useNavStore.getState().setIntent({ kind: "blame", path: "a.txt" });
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(screen.queryByText(/Browsing/)).toBeNull());
+    expect(revCalls()).toHaveLength(0);
+    // Consuming another screen's intent would strand that navigation.
+    expect(useNavStore.getState().intent).toMatchObject({ kind: "blame" });
+  });
+});

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -209,6 +209,8 @@ export function RepoBrowserScreen() {
   const [sortMode, setSortMode] = React.useState<SortMode>("asc");
   const [viewMode, setViewMode] = useTreeViewMode("pg-repo-view-mode");
   const setNavIntent = useNavStore((s) => s.setIntent);
+  const intent = useNavStore((s) => s.intent);
+  const clearIntent = useNavStore((s) => s.clearIntent);
   // Three panes in one container: tree | preview (flexible) | inspector (#162).
   // So each fixed pane caps itself against the preview's floor AND the other
   // fixed pane. The tree reserves the inspector's MINIMUM while the inspector
@@ -242,6 +244,19 @@ export function RepoBrowserScreen() {
     setRev(null);
     setSel(emptySelection);
   }, [repo?.id]);
+
+  // "Show repository at this revision" (the commit context menu). AppShell has
+  // already put us on this screen and deliberately left the intent standing —
+  // this is the only place that knows what `rev` means, so consuming it here
+  // keeps the revision in the ONE piece of state the toolbar picker also
+  // writes, rather than growing a second source of truth for what is being
+  // browsed.
+  React.useEffect(() => {
+    if (intent?.kind !== "browse-rev") return;
+    setRev(intent.rev);
+    setSel(emptySelection);
+    clearIntent();
+  }, [intent, clearIntent]);
 
   // Refresh the full file list each time the user picks "All" so the tree
   // reflects newly created / deleted files.

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -974,9 +974,15 @@ export function RepoBrowserScreen() {
         right={
           <>
             {browsingRev ? (
-              <PGBadge tone="muted" icon="history">
-                Browsing {rev}
-              </PGBadge>
+              // The testid, not the prose, is what e2e waits on: "Browsing" is
+              // user-facing copy an edit could redden a required gate over, and
+              // `div*=Browsing` would resolve to whichever innermost div holds
+              // the phrase. PGBadge does not spread rest props, hence the wrapper.
+              <span data-testid="browsing-rev" data-rev={rev}>
+                <PGBadge tone="muted" icon="history">
+                  Browsing {rev}
+                </PGBadge>
+              </span>
             ) : (
               <PGButtonGroup
                 value={filterMode}


### PR DESCRIPTION
Adds **Show repository at this revision** and **Go to parent / child commit**
to the History commit context menu. Second of five PRs from
`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`.

**Stacked on #436** — both PRs edit the same region of `commitMenuItems`, so
this targets `feat/commit-menu-parity` and will be retargeted to `main` once
#436 lands. Review the [own-commits diff](https://github.com/jonassaa/platypusgit/compare/feat/commit-menu-parity...feat/commit-menu-nav)
if the file view looks like it contains #436's work.

No backend changes: no new command, no new op, no `AppError` variant.

## Show repository at this revision

`RepoBrowser` has browsed at a revision since it shipped — `listFilesAtRev`,
`readFileContentAtRev`, a "Browsing {rev}" badge — and its only entry point was
its own toolbar, so no commit could reach it. This is the entry point.

`AppShell` routes the new `browse-rev` intent by entering the repo screen and
**deliberately leaves the intent standing**; `RepoBrowser` consumes it into the
same `rev` state the toolbar picker writes. That keeps one source of truth for
"what am I browsing" rather than a shell-owned copy.

Unlike every rewrite entry, this one is offered for a commit on **any** branch:
browsing a tree reads nothing and writes nothing, so ancestry is irrelevant.

## Go to parent / child commit

`commitMenuItems` takes an optional `onGoTo`. A callback, because History owns
its selection as **local component state** that a builder in `src/design/`
cannot reach — the same shape and the same reason as `PGErrorBanner`'s
`onReport`. With no callback both entries are *omitted*, not disabled, because
this menu is used outside History too.

One target is inline; several give a submenu, since a merge has two parents and
a branch point two children and picking one silently would be a guess presented
as a fact.

**The child entry blames the loaded log, not the repository.** `s.commits` is a
prefix of history, so `commitChildren` returning nothing means "none loaded" —
the label says exactly that, and a test asserts it does *not* say "no child
exists". A parent outside the window stays **enabled**, because its oid is
genuine even unloaded; `goToCommit` then flashes rather than no-opping when it
cannot reach the row.

Selection moves scroll by **index** through the windowed list, never
`scrollIntoView` — the target row is usually unmounted (#68 G10).

## Two traps this had to avoid

**The builder must be a `useCallback`, not an inline arrow.** An arrow changes
identity every render, cascades through `onRowContext` into every row and kills
`PGCommitRow`'s memo. That is #68 G9, it has regressed once already, and the
existing comment beside `onCommitMulti` records the first time.

**A `NavIntent` with no `case` in `AppShell` navigates nowhere with nothing
failing** (#133). Two mechanisms caught it here: `assertNever` at compile time,
and `AppShell.navroutes.test.tsx`'s `EXPECTED` — a mapped type over
`NavIntent["kind"]`, so `browse-rev` could not compile until it had a sample and
a destination.

## Verification

Every claim below was checked by planting the failure, not by reading green:

- Removing `RepoBrowser`'s intent effect reddens 3 tests; the 2 negative
  controls correctly stay green.
- Passing `commitMenuItems(c)` without `onGoTo` reddens all 4 History wiring
  tests — worth having, because the builder *omits* those entries when the
  callback is absent, so forgetting to wire it would leave the feature invisible.

Gates:

- `pnpm test` — 375 files, **3767 tests** passed (3739 before).
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `cargo test` — no failures (untouched by this PR, run because the branch is
  stacked and a red would otherwise be blamed on #436).
- `pnpm test:e2e:docker full` on `history-ops.e2e.ts` — **9 passing**, including
  the new browse-at-revision spec, which asserts `a.txt` is listed at the first
  commit and `b.txt` is not: that is what proves the at-rev call drove the tree
  rather than the working copy.

The e2e wait uses a new `browsing-rev` testid rather than matching the word
"Browsing", per the playbook's wait-on-state rule — copy an edit could change
should not be able to redden a required gate. `PGBadge` does not spread rest
props, so the testid sits on a wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
