### PR TITLE
feat(commits): view a commit on the forge from the History menu

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -534,7 +534,17 @@ commands/        Thin Tauri handlers, one file per area:
 │                which the issue calls the valuable half of the feature
 ├── forge.rs     forge_detect, forge_sign_in/sign_out/token_status/validate_token,
 │                forge_list_pull_requests, forge_pull_request_checks,
-│                forge_create_pull_request, forge_checkout_pull_request. Owns
+│                forge_create_pull_request, forge_checkout_pull_request,
+│                forge_commit_url (the forge's WEB page for one commit — a pure
+│                build over forge_detect's detection, with NO network call and
+│                NO token, because the url is derivable and asking would be a
+│                round trip to produce a string we already have; that also makes
+│                it work for a forge nobody has signed into. Returns null for
+│                the ordinary "there is no page" cases — no remote, an
+│                unparseable one, or a host that is neither forge — which the
+│                menu renders as a disabled entry, but PROPAGATES a malformed
+│                host or non-hex oid as an error rather than hiding a caller
+│                bug behind a mysteriously disabled item). Owns
 │                ForgeTokens + blocking_forge (redacts tokens from errors).
 │                Every token-using command takes an `account` slot (#233),
 │                absent/null = the pre-#233 slot, and ForgeTokens is keyed

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -885,6 +885,27 @@ Two entries that read the repository and change nothing, so neither goes near
 - **Selection moves scroll by INDEX** through `useWindowedList`, never
   `scrollIntoView`: the target row is usually unmounted (#68 G10).
 
+## "View in browser" on a commit
+
+- **The flow lives in `features/forge/openCommitInBrowser.ts`, not in the menu**,
+  because `src/design/` imports no `@/lib/tauri` — the same boundary that makes
+  `PGErrorBanner` take an `onReport`.
+- **The entry is always enabled and the answer arrives on click.** Whether a
+  page exists is a backend question (which remote, which host, is that host a
+  known forge), and menu building must stay synchronous. Gating on
+  `useForgeStore`'s cached `detection` was considered and rejected: that cache
+  is filled when the Pull requests screen refreshes, so a user who has never
+  opened it would find the entry disabled on an ordinary GitHub repository. A
+  repository with no page flashes a sentence naming the reason instead.
+- **Nothing is sent.** The url is *derived* from the remote with no network call
+  and no token, then handed to the browser through `open_url` —
+  `opener::safe_url`, https-only. No hostname is hard-coded, so
+  `test/privacy.test.ts`'s allow-list is untouched; a test asserts the flow
+  makes exactly two IPC calls and nothing else.
+- A self-hosted instance becomes openable as soon as its host is mapped in
+  Settings, which is the same `hostKinds` map every other forge feature reads —
+  and the flash says so.
+
 ## Rewriting one commit from the History menu
 
 Five entries in `commitMenuItems` rewrite history — *Edit commit message*,

--- a/src-tauri/src/commands/forge.rs
+++ b/src-tauri/src/commands/forge.rs
@@ -137,6 +137,53 @@ pub async fn forge_detect(
     Ok(remote::detect(&remotes, &host_kinds))
 }
 
+/// The forge's web page for one commit, or `null` when there is not one.
+///
+/// A pure URL build over the same detection `forge_detect` uses — **no network
+/// call and no token**, because a commit page is public-or-not on the forge's
+/// side and asking would mean an API round trip to produce a string we can
+/// derive. That also means this works for a repository whose forge the user has
+/// never authenticated against.
+///
+/// `null` rather than an error for the ordinary cases — no remote, an
+/// unparseable remote, or a host that is neither GitHub nor GitLab (a bare
+/// `git://` server has no web UI to open). The menu renders that as a disabled
+/// entry; a self-hosted instance becomes openable as soon as the user maps its
+/// host in Settings, which is the same `host_kinds` map every other forge
+/// feature reads.
+#[tauri::command]
+pub async fn forge_commit_url(
+    state: State<'_, AppState>,
+    repo_id: String,
+    oid: String,
+    host_kinds: HashMap<String, ForgeKind>,
+) -> AppResult<Option<String>> {
+    let backend = state.backend.clone();
+    let id = RepoId(repo_id);
+    let remotes = tokio::task::spawn_blocking(move || backend.remotes(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+    let Some(found) = remote::detect(&remotes, &host_kinds) else {
+        return Ok(None);
+    };
+    let Some(kind) = found.kind else {
+        return Ok(None);
+    };
+    let repo = ForgeRepo {
+        host: found.host,
+        owner: found.owner,
+        name: found.name,
+        kind,
+    };
+    // A malformed host or a non-hex oid is a refusal from the builders, not a
+    // silent `null`: those mean a caller sent something wrong, and hiding it
+    // would leave the entry mysteriously disabled.
+    Ok(Some(match kind {
+        ForgeKind::GitHub => crate::forge::github::commit_url(&repo, &oid)?,
+        ForgeKind::GitLab => crate::forge::gitlab::commit_url(&repo, &oid)?,
+    }))
+}
+
 /// Validate a token against the forge, then store it in one account slot.
 ///
 /// Validation FIRST, deliberately: storing on submit would persist a typo into

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -29,6 +29,28 @@ pub fn api_base(host: &str) -> AppResult<String> {
     Ok(format!("https://{host}/api/v3"))
 }
 
+/// Web page for one commit — `https://<host>/<owner>/<repo>/commit/<sha>`.
+///
+/// The BROWSER url, not an API one, so it is built from the host as it appears
+/// in the remote rather than from [`api_base`]: github.com serves its API on
+/// `api.github.com`, and sending a reader there would show them JSON.
+///
+/// Validated exactly as the API builders are — `validate_host` plus
+/// `validate_sha`, and every path segment percent-encoded — because the owner
+/// and name come from a remote URL the repository controls, and this string is
+/// handed to the user's browser. `opener::safe_url` refuses anything but https
+/// as a second gate.
+pub fn commit_url(repo: &ForgeRepo, sha: &str) -> AppResult<String> {
+    validate_host(&repo.host)?;
+    validate_sha(sha)?;
+    Ok(format!(
+        "https://{}/{}/commit/{}",
+        repo.host,
+        repo_path(repo),
+        encode_segment(sha)
+    ))
+}
+
 /// `owner/repo`, each segment percent-encoded so a crafted remote cannot
 /// traverse the API path.
 fn repo_path(repo: &ForgeRepo) -> String {

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -40,6 +40,42 @@ fn project_id(repo: &ForgeRepo) -> String {
     encode_segment(&format!("{}/{}", repo.owner, repo.name))
 }
 
+/// Web page for one commit — `https://<host>/<namespace>/<repo>/-/commit/<sha>`.
+///
+/// **Deliberately NOT built from [`project_id`].** That encodes the project path
+/// *whole*, slashes included, because GitLab's API takes it as a single `:id`
+/// path parameter. A browser URL needs real `/` separators between namespace
+/// segments, so each segment is encoded on its own — a subgroup path like
+/// `group/sub/repo` has to stay three path segments, and
+/// `group%2Fsub%2Frepo` is not a page. Pinned by
+/// `tests/forge_commit_url.rs::gitlab_keeps_a_subgroup_path_as_real_segments`,
+/// which fails (with two siblings) if this is switched to `project_id`.
+///
+/// The `/-/` infix is GitLab's own separator between the project path and the
+/// route; it is what keeps a project actually named `commit` from colliding.
+///
+/// Validated as the API builders are, because owner and name come from a remote
+/// URL the repository controls and this string is handed to the user's browser;
+/// `opener::safe_url` refuses anything but https as a second gate.
+pub fn commit_url(repo: &ForgeRepo, sha: &str) -> AppResult<String> {
+    validate_host(&repo.host)?;
+    validate_sha(sha)?;
+    let namespace = repo
+        .owner
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(encode_segment)
+        .collect::<Vec<_>>()
+        .join("/");
+    Ok(format!(
+        "https://{}/{}/{}/-/commit/{}",
+        repo.host,
+        namespace,
+        encode_segment(&repo.name),
+        encode_segment(sha)
+    ))
+}
+
 /// Draft state for a title, tolerating an older instance that only reports the
 /// prefix and a newer one that also sets `draft`/`work_in_progress`.
 fn draft_of(v: &serde_json::Value, title: &str) -> bool {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,6 +496,7 @@ pub fn run() {
             commands::watch::watch_stop,
             commands::update::open_url,
             commands::forge::forge_detect,
+            commands::forge::forge_commit_url,
             commands::forge::forge_sign_in,
             commands::forge::forge_sign_out,
             commands::forge::forge_token_status,

--- a/src-tauri/tests/forge_commit_url.rs
+++ b/src-tauri/tests/forge_commit_url.rs
@@ -1,0 +1,155 @@
+//! Forge web URL for one commit. Pure; no network, no repository.
+//!
+//! These strings are handed to the user's browser and are built from an owner
+//! and name that come out of a remote URL the repository controls — so the
+//! validation and the encoding are the point, not decoration.
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::forge::{github, gitlab, ForgeKind, ForgeRepo};
+
+fn repo(host: &str, owner: &str, name: &str, kind: ForgeKind) -> ForgeRepo {
+    ForgeRepo {
+        host: host.into(),
+        owner: owner.into(),
+        name: name.into(),
+        kind,
+    }
+}
+
+const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+#[test]
+fn github_builds_the_commit_page() {
+    let r = repo("github.com", "jonassaa", "platypusgit", ForgeKind::GitHub);
+    assert_eq!(
+        github::commit_url(&r, SHA).unwrap(),
+        format!("https://github.com/jonassaa/platypusgit/commit/{SHA}")
+    );
+}
+
+/// The API lives on `api.github.com`; the WEB page does not. Sending a reader to
+/// the API host would show them JSON.
+#[test]
+fn github_uses_the_remote_host_not_the_api_host() {
+    let r = repo("github.com", "o", "n", ForgeKind::GitHub);
+    let url = github::commit_url(&r, SHA).unwrap();
+    assert!(!url.contains("api."), "web url must not be the API host: {url}");
+}
+
+/// GitHub Enterprise serves both from the same host, with no `/api/v3` on the
+/// web route.
+#[test]
+fn github_enterprise_keeps_its_own_host_and_no_api_path() {
+    let r = repo("git.example.com", "o", "n", ForgeKind::GitHub);
+    assert_eq!(
+        github::commit_url(&r, SHA).unwrap(),
+        format!("https://git.example.com/o/n/commit/{SHA}")
+    );
+}
+
+#[test]
+fn gitlab_builds_the_commit_page_with_its_dash_infix() {
+    let r = repo("gitlab.com", "group", "proj", ForgeKind::GitLab);
+    assert_eq!(
+        gitlab::commit_url(&r, SHA).unwrap(),
+        format!("https://gitlab.com/group/proj/-/commit/{SHA}")
+    );
+}
+
+/// THE case that separates the web builder from GitLab's API `:id`: a subgroup
+/// path must stay several path SEGMENTS. `project_id` percent-encodes the whole
+/// path, slashes included, which is right for the API and wrong here — a URL
+/// containing `group%2Fsub%2Fproj` is not a page.
+#[test]
+fn gitlab_keeps_a_subgroup_path_as_real_segments() {
+    let r = repo("gitlab.com", "group/sub", "proj", ForgeKind::GitLab);
+    let url = gitlab::commit_url(&r, SHA).unwrap();
+    assert_eq!(url, format!("https://gitlab.com/group/sub/proj/-/commit/{SHA}"));
+    assert!(!url.contains("%2F"), "namespace must not be escaped whole: {url}");
+}
+
+#[test]
+fn gitlab_self_hosted_keeps_a_non_standard_https_port() {
+    // The remote parser preserves an HTTPS port on purpose; it is where the
+    // instance is actually served.
+    let r = repo("gitlab.example.com:8443", "o", "n", ForgeKind::GitLab);
+    assert_eq!(
+        gitlab::commit_url(&r, SHA).unwrap(),
+        format!("https://gitlab.example.com:8443/o/n/-/commit/{SHA}")
+    );
+}
+
+// ─── refusals ────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_non_hex_oid_is_refused_by_both() {
+    let gh = repo("github.com", "o", "n", ForgeKind::GitHub);
+    let gl = repo("gitlab.com", "o", "n", ForgeKind::GitLab);
+    for bad in ["not-a-sha", "../../etc/passwd", "HEAD", ""] {
+        assert!(
+            matches!(github::commit_url(&gh, bad), Err(AppError::InvalidArgument(_))),
+            "github accepted {bad:?}"
+        );
+        assert!(
+            matches!(gitlab::commit_url(&gl, bad), Err(AppError::InvalidArgument(_))),
+            "gitlab accepted {bad:?}"
+        );
+    }
+}
+
+#[test]
+fn a_malformed_host_is_refused_by_both() {
+    for bad in ["", ".", "host/../evil", "ho st"] {
+        let gh = repo(bad, "o", "n", ForgeKind::GitHub);
+        let gl = repo(bad, "o", "n", ForgeKind::GitLab);
+        assert!(
+            github::commit_url(&gh, SHA).is_err(),
+            "github accepted host {bad:?}"
+        );
+        assert!(
+            gitlab::commit_url(&gl, SHA).is_err(),
+            "gitlab accepted host {bad:?}"
+        );
+    }
+}
+
+/// A crafted owner or name must not escape its path segment. The remote is
+/// repository-controlled, and the result goes to a browser.
+#[test]
+fn a_crafted_owner_or_name_cannot_traverse_the_path() {
+    for (owner, name) in [("../..", "n"), ("o", "../.."), ("o/../..", "n")] {
+        let gh = repo("github.com", owner, name, ForgeKind::GitHub);
+        let url = github::commit_url(&gh, SHA).unwrap();
+        assert!(
+            !url.contains("/../"),
+            "github url must not contain a traversal: {url}"
+        );
+        let gl = repo("gitlab.com", owner, name, ForgeKind::GitLab);
+        let url = gitlab::commit_url(&gl, SHA).unwrap();
+        assert!(
+            !url.contains("/../"),
+            "gitlab url must not contain a traversal: {url}"
+        );
+    }
+}
+
+/// Every URL these build is https, which is also what `opener::safe_url`
+/// enforces as the second gate.
+#[test]
+fn every_built_url_is_https() {
+    let gh = repo("github.com", "o", "n", ForgeKind::GitHub);
+    let gl = repo("gitlab.com", "o", "n", ForgeKind::GitLab);
+    assert!(github::commit_url(&gh, SHA).unwrap().starts_with("https://"));
+    assert!(gitlab::commit_url(&gl, SHA).unwrap().starts_with("https://"));
+}
+
+/// A short oid is accepted — `validate_sha` allows 7..=64 hex, and a forge
+/// resolves an abbreviated commit id fine.
+#[test]
+fn a_short_but_valid_oid_is_accepted() {
+    let gh = repo("github.com", "o", "n", ForgeKind::GitHub);
+    assert_eq!(
+        github::commit_url(&gh, "0123456").unwrap(),
+        "https://github.com/o/n/commit/0123456"
+    );
+}

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -12,6 +12,7 @@ import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { commitChildren } from "@/features/commits/commitChildren";
+import { openCommitInBrowser } from "@/features/forge/openCommitInBrowser";
 import { rewordCommit } from "@/features/commits/rewordCommit";
 import { dropCommit } from "@/features/commits/dropCommit";
 import { undoCommit } from "@/features/commits/undoCommit";
@@ -838,6 +839,19 @@ export function commitMenuItems(
       onClick: () => {
         navigator.clipboard?.writeText(commit?.subject || "");
         pgFlash("copied subject");
+      },
+    },
+    // Always enabled: whether a forge page exists is a BACKEND question (which
+    // remote, which host, is that host a known forge) and menu building stays
+    // synchronous. See openCommitInBrowser for why gating on the cached forge
+    // detection would be worse.
+    {
+      icon: "external",
+      label: "View in browser",
+      disabled: !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void openCommitInBrowser(commit.sha);
       },
     },
     // The user's own commands, last (#225). Deliberately not on

--- a/src/features/forge/openCommitInBrowser.test.ts
+++ b/src/features/forge/openCommitInBrowser.test.ts
@@ -1,0 +1,83 @@
+// "View in browser" — opening one commit's forge page.
+//
+// Nothing is SENT here: the app derives a url and hands it to the user's
+// browser through `open_url`, the one validated opener path. The assertions
+// below are about which url, and about the honest failure when there is no page.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { openCommitInBrowser } from "./openCommitInBrowser";
+import { useForgeStore } from "./useForgeStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const OID = "0123456789abcdef0123456789abcdef01234567";
+const URL = `https://github.com/o/n/commit/${OID}`;
+
+const opened = () => getInvokeCalls().filter((c) => c.cmd === "open_url");
+const asked = () => getInvokeCalls().filter((c) => c.cmd === "forge_commit_url");
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+  } as never);
+  useForgeStore.setState({ hostKinds: { "git.example.com": "GitHub" } } as never);
+  mockInvoke("forge_commit_url", () => URL);
+  mockInvoke("open_url", () => null);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("openCommitInBrowser", () => {
+  it("opens the url the backend derived, through open_url", async () => {
+    await openCommitInBrowser(OID);
+    expect(opened()).toHaveLength(1);
+    expect(opened()[0].args).toMatchObject({ url: URL });
+  });
+
+  it("passes the oid and the user's host mapping, so self-hosted resolves", async () => {
+    await openCommitInBrowser(OID);
+    expect(asked()[0].args).toMatchObject({
+      repoId: "r1",
+      oid: OID,
+      hostKinds: { "git.example.com": "GitHub" },
+    });
+  });
+
+  it("says so, and opens nothing, when the remote has no forge page", async () => {
+    mockInvoke("forge_commit_url", () => null);
+    await openCommitInBrowser(OID);
+    expect(opened()).toHaveLength(0);
+  });
+
+  it("opens nothing when a refusal comes back from the builders", async () => {
+    mockInvoke("forge_commit_url", () => {
+      throw { kind: "InvalidArgument", message: "not a commit id" };
+    });
+    await openCommitInBrowser(OID);
+    expect(opened()).toHaveLength(0);
+  });
+
+  it("does not throw when a refusal comes back — a menu click must not crash", async () => {
+    mockInvoke("forge_commit_url", () => {
+      throw { kind: "InvalidUrl", message: "bad host" };
+    });
+    await expect(openCommitInBrowser(OID)).resolves.toBeUndefined();
+  });
+
+  it("asks nothing without an open repository", async () => {
+    useRepoStore.setState({ current: null } as never);
+    await openCommitInBrowser(OID);
+    expect(asked()).toHaveLength(0);
+    expect(opened()).toHaveLength(0);
+  });
+
+  // The privacy promise: no request is made from the frontend, and no hostname
+  // is hard-coded. Everything comes back from the backend, derived from the
+  // user's own remote.
+  it("makes no network call of its own — only the two IPC commands", async () => {
+    await openCommitInBrowser(OID);
+    const cmds = getInvokeCalls().map((c) => c.cmd);
+    expect(new Set(cmds)).toEqual(new Set(["forge_commit_url", "open_url"]));
+  });
+});

--- a/src/features/forge/openCommitInBrowser.ts
+++ b/src/features/forge/openCommitInBrowser.ts
@@ -1,0 +1,46 @@
+import { pgFlash } from "@/design";
+import { forgeCommitUrl, openUrl } from "@/lib/tauri";
+import { useForgeStore } from "./useForgeStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+
+/**
+ * Open one commit's page on the forge.
+ *
+ * Lives here rather than in the menu because `src/design/` imports no
+ * `@/lib/tauri` — the same boundary that makes `PGErrorBanner` take an
+ * `onReport` callback.
+ *
+ * **The entry is always enabled, and the answer arrives on click.** Whether a
+ * page exists is a backend question (which remote, which host, is that host a
+ * known forge), and building a menu must stay synchronous. Gating on
+ * `useForgeStore`'s cached `detection` was the alternative and is worse: that
+ * cache is filled when the Pull requests screen refreshes, so a user who has
+ * never opened it would find this entry disabled on a perfectly ordinary GitHub
+ * repository.
+ *
+ * A repository with no forge page therefore flashes instead of opening. That is
+ * the honest trade — a sentence naming the reason, rather than an item whose
+ * disabled state depends on which screen you visited earlier.
+ */
+export async function openCommitInBrowser(oid: string): Promise<void> {
+  const repo = useRepoStore.getState().current;
+  if (!repo) return;
+  try {
+    const url = await forgeCommitUrl(repo.id, oid, useForgeStore.getState().hostKinds);
+    if (!url) {
+      // No remote, an unparseable one, or a host that is neither GitHub nor
+      // GitLab. Self-hosted becomes openable as soon as its host is mapped in
+      // Settings, so the message points there.
+      pgFlash("no forge page for this remote — map its host in Settings");
+      return;
+    }
+    // Through `open_url`, the ONE validated opener path: https-only via
+    // opener::safe_url. Nothing is sent — the app hands a url to the browser.
+    await openUrl(url);
+  } catch (e) {
+    // A malformed host or a non-hex oid propagates as an error from the
+    // builders. Report it where the user is looking rather than in the repo
+    // error banner: they clicked a menu item, they did not run an operation.
+    pgFlash(`could not open the commit page: ${String(e)}`);
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1666,6 +1666,22 @@ export function forgeDetect(
 }
 
 /**
+ * The forge's web page for one commit, or `null` when there is not one.
+ *
+ * No network call and no token — the url is derived from the remote, so this
+ * also answers for a forge the user has never signed into. `null` is the
+ * ordinary "no page exists" answer (no remote, an unparseable one, or a host
+ * that is neither GitHub nor GitLab); the menu renders that as disabled.
+ */
+export function forgeCommitUrl(
+  repoId: string,
+  oid: string,
+  hostKinds: Record<string, ForgeKind>,
+): Promise<string | null> {
+  return invoke<string | null>("forge_commit_url", { repoId, oid, hostKinds });
+}
+
+/**
  * Validate `token` against `host`'s API and then store it, resolving with the
  * identity it belongs to. Validation happens FIRST: storing on submit would
  * persist a typo into the user's keychain.


### PR DESCRIPTION
Adds **View in browser** to the History commit context menu — the commit's page
on GitHub or GitLab. Third of five PRs from
`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`.

**Stacked on #437**, which is stacked on #436. Targets `feat/commit-menu-nav`;
retarget up the chain as each lands. Review the
[own-commits diff](https://github.com/jonassaa/platypusgit/compare/feat/commit-menu-nav...feat/commit-menu-browser).

## No network call, and no token

`forge_commit_url` is a **pure build** over the same detection `forge_detect`
already does. A commit page URL is derivable from the remote, so asking the API
would be a round trip to produce a string we already have — and deriving it
means the entry works for a forge the user has never signed into.

Nothing is sent: the app derives a URL and hands it to the browser through
`open_url`, the one validated opener path (https-only via `opener::safe_url`).
No hostname is hard-coded — the host comes from the user's own remote — so
`test/privacy.test.ts`'s allow-list is untouched, and a test asserts the whole
flow makes exactly two IPC calls and nothing else.

## The GitLab trap

GitLab's `project_id` percent-encodes the project path **whole, slashes
included**, because the API takes it as a single `:id` parameter. A browser URL
needs real separators, so a subgroup path has to stay several path segments —
`group%2Fsub%2Fproj` is not a page.

The web builder therefore encodes each segment on its own. Verified by planting
the `project_id` version, which fails
`gitlab_keeps_a_subgroup_path_as_real_segments` plus two siblings.

Symmetrically for GitHub: the web page is on the **remote** host, not
`api.github.com`. Sending a reader to the API host would show them JSON, and a
test asserts the URL contains no `api.` prefix.

Owner and name come out of a repository-controlled remote and the result goes to
a browser, so both builders run `validate_host` + `validate_sha` and encode
every segment, exactly as the API builders do. Tests cover a non-hex oid, a
malformed host, and a crafted owner/name that must not traverse the path.

## Why the entry is always enabled

Whether a page exists is a backend question — which remote, which host, is that
host a known forge — and building a menu must stay synchronous.

Gating on `useForgeStore`'s cached `detection` was the alternative and is worse:
that cache is filled when the Pull requests screen refreshes, so a user who has
never opened it would find this entry **disabled on an ordinary GitHub
repository**. Instead the entry is always enabled and a repository with no page
flashes a sentence naming the reason, pointing at the Settings host mapping that
makes a self-hosted instance work.

The flow lives in `features/forge/openCommitInBrowser.ts` rather than the menu,
because `src/design/` imports no `@/lib/tauri` — the boundary that makes
`PGErrorBanner` take an `onReport`.

`null` is returned for the ordinary "no page" cases, but a malformed host or
non-hex oid **propagates as an error** rather than becoming a silent `null`:
hiding a caller bug behind a mysteriously disabled item is worse than saying so.

## Verification

- `cargo test` — no failures. 11 new in `tests/forge_commit_url.rs`.
- `pnpm test` — 376 files, **3774 tests** passed (3767 before).
- `pnpm tsc --noEmit` — clean. `test/privacy.test.ts` green.
- **No e2e for this one, deliberately:** the entry's whole effect is to launch
  an external browser, which the container cannot observe and should not be made
  to. The IPC contract is covered by the unit test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
