### PR TITLE
feat(commits): create patch files from the History menu

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -414,7 +414,18 @@ commands/        Thin Tauri handlers, one file per area:
 │                the rebase engine refuses, making a one-step Reword plan
 │                useless for the most common reword of all. Takes the oid the
 │                caller believed was HEAD and refuses a mismatch, checked
-│                under the SAME lock as the amend), file_history,
+│                under the SAME lock as the amend), format_patch (mailbox
+│                patches via `git format-patch`, which libgit2 has no
+│                equivalent for — so it shells out through proc::git. ONE
+│                invocation per commit carrying an explicit --start-number,
+│                because separate invocations each number from 0001 and
+│                overwrite one another. Every oid is resolved and every merge
+│                refused BEFORE anything is written: format-patch skips a merge
+│                silently, so a partial export would hand back a shorter list
+│                with nothing naming the commit that vanished. NOTE it passes
+│                no `--` before the revision — that separator introduces
+│                PATHSPECS, so `-- <oid>` selects nothing; safe because the oid
+│                is a resolved 40-hex id, not user text), file_history,
 │                verify_commit (SELECTED commit
 │                only, never per row), commit_notes, which is lazy for the
 │                same reason (#253 — the log walk is the hot path, so notes are

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -1541,6 +1541,38 @@ affects every reword of an older commit and every `Reword` step run from the
 Rebase screen, so it predates this op and belongs to its own change with its own
 tests.
 
+## `format_patch` — mailbox patches, and the `--` that must NOT be there
+
+libgit2 has no `format-patch`, so this shells out through `proc::git`. Mailbox
+format rather than a plain diff, because the files carry author, date and
+message and `git am` reconstructs the commit; `tests/format_patch.rs` proves
+that round-trip against a second repository.
+
+- **One invocation per commit, with an explicit `--start-number`.** Left to
+  itself every invocation numbers from `0001` and the files overwrite one
+  another, so a three-commit export leaves one file — silently. Measured:
+  removing the flag fails `numbers_a_multi_commit_export_as_a_series` and only
+  that test. In particular the *order* test still passes without it, because two
+  commits with different subjects produce two different filenames even when both
+  are numbered `0001` — a fixture whose subjects happen to differ hides the bug,
+  which is why the numbering test uses `linear_history` and counts files.
+- **No `--` before the revision, and this is the one place the usual rule is
+  actively wrong.** This codebase ends option parsing with `--` before every
+  user-supplied value; but `--` introduces **pathspecs**, so `-- <oid>` asks for
+  commits touching a *file* named like that oid, selects nothing, and writes no
+  files. (That was the first implementation, and the tests caught it.) Safe
+  without the separator because the oid is `commit.id().to_string()` from a
+  resolution done first — 40 hex characters, which cannot begin with a dash.
+- **Everything is resolved and every merge refused BEFORE anything is written.**
+  `format-patch` skips a merge silently, so a partial export would hand back a
+  shorter list with nothing naming the commit that vanished. A merge anywhere in
+  the selection refuses the whole export: a series with a hole is not a series.
+- The output directory comes from the OS folder picker, so it is a place the
+  user chose, and is used as given. No new Tauri permission —
+  `dialog:allow-open` is already granted and is the same call Clone / Init /
+  Worktree make. A *save-file* picker would be wrong: `format-patch` names its
+  own files and one request can produce several.
+
 ## Stacked branches: `--update-refs` is implemented, not passed through (#240)
 
 Our rebase is our **own replay** — `rebase_start_with_progress` detaches at the

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -199,6 +199,31 @@ pub async fn amend_head_message(
     .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Export commits as mailbox-format patch files into `out_dir`.
+///
+/// `git format-patch`, so the files carry author, date and message and `git am`
+/// reconstructs each commit — not a plain diff, which would only carry the
+/// changes. `oids` is OLDEST-FIRST; the numbering follows that order.
+///
+/// The directory comes from the user through the OS folder picker, so it is
+/// already a place they chose. It is used as given: this writes where they
+/// pointed, and refusing paths outside some notion of "allowed" would break the
+/// only reason anyone exports a patch.
+#[tauri::command]
+pub async fn format_patch(
+    state: State<'_, AppState>,
+    repo_id: String,
+    oids: Vec<String>,
+    out_dir: String,
+) -> AppResult<Vec<String>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let dir = std::path::PathBuf::from(out_dir);
+    tokio::task::spawn_blocking(move || backend.format_patch(&repo_id, &oids, &dir))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// The repository's `commit.template` + comment prefix (#252).
 ///
 /// Called once per commit-screen visit. A configured template that cannot be

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -274,6 +274,15 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
 
+    fn format_patch(
+        &self,
+        _repo_id: &RepoId,
+        _oids: &[String],
+        _out_dir: &std::path::Path,
+    ) -> AppResult<Vec<String>> {
+        Err(AppError::NotImplemented)
+    }
+
     fn commit_template(
         &self,
         _repo_id: &RepoId,

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -5258,6 +5258,94 @@ impl GitBackend for Libgit2Backend {
         Ok(CommitResult { oid, message })
     }
 
+    fn format_patch(
+        &self,
+        repo_id: &RepoId,
+        oids: &[String],
+        out_dir: &std::path::Path,
+    ) -> AppResult<Vec<String>> {
+        if oids.is_empty() {
+            return Err(AppError::InvalidArgument(
+                "no commits were given to export".to_string(),
+            ));
+        }
+
+        // Resolve every oid AND refuse a merge before writing anything. A
+        // partial export is worse than none: `format-patch` skips a merge
+        // silently, so the caller would get a shorter list than it asked for
+        // with nothing saying which commit vanished.
+        let full: Vec<String> = self.with_repo_read(repo_id, |repo| {
+            let mut out = Vec::with_capacity(oids.len());
+            for oid in oids {
+                let commit = repo
+                    .revparse_single(oid)
+                    .map_err(|_| AppError::InvalidRef(oid.clone()))?
+                    .peel_to_commit()
+                    .map_err(|_| AppError::InvalidRef(oid.clone()))?;
+                if commit.parent_count() > 1 {
+                    return Err(AppError::InvalidArgument(format!(
+                        "{} is a merge commit, which has no patch to export",
+                        &oid[..7.min(oid.len())]
+                    )));
+                }
+                out.push(commit.id().to_string());
+            }
+            Ok(out)
+        })?;
+
+        let repo_path = self.repo_path(repo_id)?;
+        let dir = out_dir
+            .to_str()
+            .ok_or_else(|| AppError::InvalidPath(out_dir.display().to_string()))?;
+
+        let mut written = Vec::with_capacity(full.len());
+        for (i, oid) in full.iter().enumerate() {
+            // ONE invocation per commit with an explicit --start-number. Left to
+            // git, each invocation numbers from 0001 and the files overwrite one
+            // another; `-1` keeps each to its own commit rather than a range.
+            //
+            // NO `--` before the oid, deliberately, and this is the one place
+            // where this codebase's usual "end option parsing with `--`" rule
+            // would be actively wrong: `--` separates revisions from PATHSPECS,
+            // so `-- <oid>` asks git to export commits touching a *file* named
+            // like that oid — which selects nothing and writes no files.
+            //
+            // Safe without it because `oid` is not user text: it is
+            // `commit.id().to_string()` from the resolution above, so it is 40
+            // hex characters and cannot begin with a dash.
+            let out = crate::proc::git(&repo_path)
+                .args([
+                    "format-patch",
+                    "-1",
+                    "--start-number",
+                    &(i + 1).to_string(),
+                    "-o",
+                    dir,
+                    oid,
+                ])
+                .output()
+                .map_err(|e| AppError::Io(e.to_string()))?;
+            if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                return Err(AppError::Git(format!("git format-patch: {stderr}")));
+            }
+            // format-patch prints each path it wrote, one per line.
+            for line in String::from_utf8_lossy(&out.stdout).lines() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    written.push(line.to_string());
+                }
+            }
+        }
+
+        if written.is_empty() {
+            return Err(AppError::Git(
+                "git format-patch wrote no files".to_string(),
+            ));
+        }
+        Ok(written)
+    }
+
     fn commit_template(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -653,6 +653,29 @@ pub trait GitBackend: Send + Sync {
         no_verify: bool,
     ) -> AppResult<CommitResult>;
 
+    /// Write one mailbox-format patch file per commit into `out_dir`, returning
+    /// the paths written in the order they were created.
+    ///
+    /// `git format-patch`, which libgit2 has no equivalent for — so this shells
+    /// out through `proc::git`. Mailbox format rather than a plain diff on
+    /// purpose: it carries the author, the date and the full message, so
+    /// `git am` reconstructs the commit rather than just its changes.
+    ///
+    /// `oids` is expected OLDEST-FIRST, and each commit gets its own invocation
+    /// with an explicit `--start-number`. Separate invocations would each
+    /// restart numbering at `0001` and overwrite one another, which is the whole
+    /// reason the numbering is passed rather than left to git.
+    ///
+    /// A merge commit has no patch: `format-patch` skips one silently, so a
+    /// merge among `oids` is refused up front instead of producing a short list
+    /// the caller cannot account for.
+    fn format_patch(
+        &self,
+        repo_id: &RepoId,
+        oids: &[String],
+        out_dir: &Path,
+    ) -> AppResult<Vec<String>>;
+
     /// The repository's `commit.template` and comment prefix (#252).
     ///
     /// A read, not a commit step: the composer asks once per repository and

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -380,6 +380,7 @@ pub fn run() {
             commands::commits::ahead_behind,
             commands::commits::commit,
             commands::commits::amend_head_message,
+            commands::commits::format_patch,
             commands::commits::file_history,
             commands::commits::verify_commit,
             commands::commits::commit_notes,

--- a/src-tauri/tests/format_patch.rs
+++ b/src-tauri/tests/format_patch.rs
@@ -50,6 +50,13 @@ fn exports_one_commit_as_a_mailbox_patch() {
 
 /// THE case `--start-number` exists for. Without it each invocation writes
 /// `0001-…` and later commits clobber earlier ones.
+///
+/// Measured: removing `--start-number` fails THIS test and only this one. In
+/// particular `the_series_order_matches_the_oids_given` below still passes
+/// without it, because two commits with different subjects produce two
+/// different filenames even when both are numbered `0001` — so a fixture whose
+/// commits happen to sort correctly hides the bug. This one uses
+/// `linear_history`, whose subjects are uniform, and counts the files.
 #[test]
 fn numbers_a_multi_commit_export_as_a_series() {
     let tr = TempRepo::with_initial_commit("hello\n");

--- a/src-tauri/tests/format_patch.rs
+++ b/src-tauri/tests/format_patch.rs
@@ -1,0 +1,211 @@
+//! `format_patch` — export commits as mailbox-format patch files.
+//!
+//! The numbering is the part most likely to be silently wrong: each commit gets
+//! its OWN `git format-patch` invocation, and left to itself every invocation
+//! numbers from `0001` and the files overwrite one another. `--start-number` is
+//! what makes a multi-commit export come out as a readable series.
+
+mod support;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+
+use support::{linear_history, TempRepo};
+
+/// Sorted file names in `dir`, so assertions do not depend on readdir order.
+fn names(dir: &std::path::Path) -> Vec<String> {
+    let mut v: Vec<String> = std::fs::read_dir(dir)
+        .expect("read out dir")
+        .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn exports_one_commit_as_a_mailbox_patch() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    tr.add_commit("a.txt", "alpha\n", "feat: add a.txt");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    let out = tempfile::tempdir().unwrap();
+
+    let written = backend
+        .format_patch(&handle.id, &[head], out.path())
+        .expect("format-patch");
+
+    assert_eq!(written.len(), 1, "one commit, one file: {written:?}");
+    assert_eq!(names(out.path()), vec!["0001-feat-add-a.txt.patch".to_string()]);
+
+    // MAILBOX format, which is the whole reason this is not a plain diff: the
+    // author, the date and the subject travel with the change so `git am` can
+    // reconstruct the commit.
+    let body = std::fs::read_to_string(&written[0]).unwrap();
+    assert!(body.starts_with("From "), "not a mailbox patch:\n{body}");
+    assert!(body.contains("From: Test User <test@example.com>"));
+    assert!(body.contains("Subject: [PATCH] feat: add a.txt"));
+    assert!(body.contains("Date: "));
+    assert!(body.contains("+alpha"));
+}
+
+/// THE case `--start-number` exists for. Without it each invocation writes
+/// `0001-…` and later commits clobber earlier ones.
+#[test]
+fn numbers_a_multi_commit_export_as_a_series() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let oids = linear_history(&tr, 3); // newest-first, per the helper
+    let oldest_first: Vec<String> = oids.iter().rev().cloned().collect();
+    let (backend, handle) = tr.open_with_backend();
+    let out = tempfile::tempdir().unwrap();
+
+    let written = backend
+        .format_patch(&handle.id, &oldest_first, out.path())
+        .expect("format-patch");
+
+    assert_eq!(written.len(), 3, "one file per commit: {written:?}");
+    let files = names(out.path());
+    assert_eq!(files.len(), 3, "three DISTINCT files, not one overwritten: {files:?}");
+    assert!(files[0].starts_with("0001-"), "{files:?}");
+    assert!(files[1].starts_with("0002-"), "{files:?}");
+    assert!(files[2].starts_with("0003-"), "{files:?}");
+}
+
+/// And the numbering follows the order given, oldest first — a series read in
+/// file order must replay in ancestry order.
+#[test]
+fn the_series_order_matches_the_oids_given() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    tr.add_commit("one.txt", "1\n", "feat: first");
+    tr.add_commit("two.txt", "2\n", "feat: second");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let parent = head.parent(0).unwrap();
+    let out = tempfile::tempdir().unwrap();
+
+    backend
+        .format_patch(
+            &handle.id,
+            &[parent.id().to_string(), head.id().to_string()],
+            out.path(),
+        )
+        .expect("format-patch");
+
+    let files = names(out.path());
+    assert!(files[0].contains("first"), "0001 should be the older commit: {files:?}");
+    assert!(files[1].contains("second"), "0002 should be the newer commit: {files:?}");
+}
+
+/// A merge is refused UP FRONT, and nothing is written — `format-patch` skips a
+/// merge silently, so exporting a selection containing one would hand back a
+/// shorter list with nothing saying which commit vanished.
+#[test]
+fn a_merge_commit_is_refused_and_nothing_is_written() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let h = support::merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let out = tempfile::tempdir().unwrap();
+
+    let err = backend
+        .format_patch(&handle.id, &[h.m.clone()], out.path())
+        .expect_err("a merge has no patch to export");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert!(names(out.path()).is_empty());
+}
+
+/// And a merge ANYWHERE in the selection refuses the whole export, rather than
+/// quietly writing the others: a series with a hole in it is not a series.
+#[test]
+fn a_merge_among_several_refuses_the_whole_export() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let h = support::merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let out = tempfile::tempdir().unwrap();
+
+    let err = backend
+        .format_patch(&handle.id, &[h.c.clone(), h.m.clone()], out.path())
+        .expect_err("must refuse the whole export");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert!(
+        names(out.path()).is_empty(),
+        "the non-merge commit must NOT have been written: {:?}",
+        names(out.path())
+    );
+}
+
+#[test]
+fn an_empty_selection_is_refused() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let out = tempfile::tempdir().unwrap();
+
+    let err = backend
+        .format_patch(&handle.id, &[], out.path())
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert!(names(out.path()).is_empty());
+}
+
+#[test]
+fn an_unknown_oid_is_refused_and_nothing_is_written() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    tr.add_commit("a.txt", "alpha\n", "feat: add a.txt");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    let out = tempfile::tempdir().unwrap();
+
+    // The good oid comes FIRST, so a per-commit loop with no up-front
+    // resolution would already have written 0001 before hitting the bad one.
+    let err = backend
+        .format_patch(&handle.id, &[head, "0".repeat(40)], out.path())
+        .expect_err("must refuse an unknown oid");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+    assert!(
+        names(out.path()).is_empty(),
+        "a refused export must write nothing: {:?}",
+        names(out.path())
+    );
+}
+
+/// The root commit has no parent and still exports — git handles it, and a
+/// first-commit patch is a legitimate thing to send.
+#[test]
+fn the_root_commit_exports() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let root = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    let out = tempfile::tempdir().unwrap();
+
+    let written = backend
+        .format_patch(&handle.id, &[root], out.path())
+        .expect("the root commit should export");
+    assert_eq!(written.len(), 1);
+    assert!(std::fs::read_to_string(&written[0]).unwrap().contains("README"));
+}
+
+/// The exported patch actually applies — the point of mailbox format.
+#[test]
+fn the_exported_patch_can_be_applied_to_a_fresh_clone_of_the_parent() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    tr.add_commit("a.txt", "alpha\n", "feat: add a.txt");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    let written = backend
+        .format_patch(&handle.id, &[head.id().to_string()], out.path())
+        .expect("format-patch");
+
+    // A second repo at the parent commit, then `git am` the patch.
+    let other = TempRepo::with_initial_commit("hello\n");
+    let applied = support::git_in(other.path(), &["am", &written[0]]);
+    let _ = applied;
+    let subject = support::git_in(other.path(), &["log", "-1", "--pretty=%s"]);
+    assert!(
+        subject.contains("feat: add a.txt"),
+        "git am should have reconstructed the commit, got {subject:?}"
+    );
+    assert_eq!(
+        support::fs::read_file(other.path(), "a.txt"),
+        "alpha\n",
+        "and its content"
+    );
+}

--- a/src/design/context-menu.patch.test.tsx
+++ b/src/design/context-menu.patch.test.tsx
@@ -1,0 +1,99 @@
+// "Create patch…" enablement on both commit menus.
+//
+// A merge has no patch — `git format-patch` skips one SILENTLY — so the entry
+// has to refuse it rather than letting the user export a series with a hole in
+// it. The flow itself is covered in features/commits/createPatch.test.ts.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { commitMenuItems, commitMultiMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { CommitInfo } from "@/lib/types";
+
+const A = "a".repeat(40);
+const MERGE = "e".repeat(40);
+const SIDE = "5".repeat(40);
+const C = "c".repeat(40);
+const ROOT = "d".repeat(40);
+
+const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+// A → MERGE(C, SIDE) → SIDE → C → ROOT.
+const COMMITS = [
+  mk(A, "commit A", [MERGE]),
+  mk(MERGE, "Merge branch 'side'", [C, SIDE]),
+  mk(SIDE, "side work", [C]),
+  mk(C, "commit C", [ROOT]),
+  mk(ROOT, "commit root", []),
+];
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    headInfo: { branch: "main", headOid: A },
+    branches: [],
+    loading: false,
+  } as never);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Create patch (one commit)", () => {
+  it("is offered for an ordinary commit", () => {
+    const item = labeled(commitMenuItems({ sha: C }), /^Create patch/);
+    expect(item.disabled).toBeFalsy();
+    expect(item.label).toBe("Create patch…");
+  });
+
+  it("is offered for the root commit — a first-commit patch is legitimate", () => {
+    const item = labeled(commitMenuItems({ sha: ROOT }), /^Create patch/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is offered for a commit not on this branch — an export writes nothing", () => {
+    const item = labeled(commitMenuItems({ sha: SIDE }), /^Create patch/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is refused for a merge commit, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: MERGE }), /^Create patch/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/merge commit/);
+  });
+
+  it("is refused with no commit", () => {
+    const item = labeled(commitMenuItems(null), /^Create patch/);
+    expect(item.disabled).toBe(true);
+  });
+});
+
+describe("Create patches (a selection)", () => {
+  it("is offered for a merge-free selection", () => {
+    const item = labeled(commitMultiMenuItems([C, SIDE]), /^Create \d+ patches/);
+    expect(item.disabled).toBeFalsy();
+  });
+
+  it("is refused when the selection contains a merge, and says why", () => {
+    const item = labeled(commitMultiMenuItems([MERGE, A]), /^Create \d+ patches/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/contains a merge/);
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -12,6 +12,7 @@ import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { commitChildren } from "@/features/commits/commitChildren";
+import { createPatch } from "@/features/commits/createPatch";
 import { openCommitInBrowser } from "@/features/forge/openCommitInBrowser";
 import { rewordCommit } from "@/features/commits/rewordCommit";
 import { dropCommit } from "@/features/commits/dropCommit";
@@ -582,6 +583,17 @@ export function commitMenuItems(
       label: "Revert commit",
       onClick: () => {
         if (commit?.sha) useRepoStore.getState().revert(commit.sha);
+      },
+    },
+    {
+      icon: "file",
+      // A merge has no patch — `format-patch` skips one silently, so the
+      // backend refuses it and the entry says so rather than writing nothing.
+      label: isMerge ? "Create patch — merge commit" : "Create patch…",
+      disabled: isMerge || !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha || isMerge) return;
+        void createPatch([commit.sha]);
       },
     },
     {
@@ -1421,6 +1433,21 @@ export function commitMultiMenuItems(oids: string[]): ContextMenuItem[] {
           })
         )
           useRepoStore.getState().cherryPickMany(plan.oids);
+      },
+    },
+    {
+      icon: "file",
+      // `plan.oids` is already oldest→newest, which is the order the series is
+      // numbered in — 0001 must be the oldest commit or the patches replay
+      // backwards. A merge among them is refused whole by the backend, since a
+      // series with a hole in it is not a series.
+      label: plan.hasMerge
+        ? `Create ${n} patches — contains a merge`
+        : `Create ${n} patches…`,
+      disabled: plan.hasMerge,
+      onClick: () => {
+        if (plan.hasMerge) return;
+        void createPatch(plan.oids);
       },
     },
     {

--- a/src/features/commits/createPatch.test.ts
+++ b/src/features/commits/createPatch.test.ts
@@ -1,0 +1,94 @@
+// "Create patch…" — export commits as mailbox patch files.
+//
+// The ordering assertion is the load-bearing one: the backend numbers the
+// series in the order it is given, so a reversed list would produce 0001 for
+// the newest commit and a series that replays backwards.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { createPatch } from "./createPatch";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const A = "a".repeat(40); // newest
+const B = "b".repeat(40);
+const C = "c".repeat(40); // oldest
+
+// The folder picker is a Tauri plugin call, not one of our commands.
+const picked = vi.fn<() => Promise<string | null>>();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: () => picked(),
+}));
+
+const exports = () => getInvokeCalls().filter((c) => c.cmd === "format_patch");
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    error: null,
+  } as never);
+  picked.mockReset();
+  picked.mockResolvedValue("/tmp/patches");
+  mockInvoke("format_patch", () => ["/tmp/patches/0001-one.patch"]);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("createPatch", () => {
+  it("exports to the directory the user picked", async () => {
+    await createPatch([A]);
+    expect(exports()).toHaveLength(1);
+    expect(exports()[0].args).toMatchObject({
+      repoId: "r1",
+      oids: [A],
+      outDir: "/tmp/patches",
+    });
+  });
+
+  it("passes a multi-commit selection through in the order given", async () => {
+    mockInvoke("format_patch", () => [
+      "/tmp/patches/0001-c.patch",
+      "/tmp/patches/0002-b.patch",
+      "/tmp/patches/0003-a.patch",
+    ]);
+    // Oldest-first, as planCommitSelection hands them over. Reversing this
+    // would number the newest commit 0001 and replay the series backwards.
+    await createPatch([C, B, A]);
+    expect(exports()[0].args.oids).toEqual([C, B, A]);
+  });
+
+  it("exports nothing when the picker is dismissed", async () => {
+    picked.mockResolvedValue(null);
+    await createPatch([A]);
+    expect(exports()).toHaveLength(0);
+  });
+
+  it("exports nothing for an empty selection, and does not open a picker", async () => {
+    await createPatch([]);
+    expect(picked).not.toHaveBeenCalled();
+    expect(exports()).toHaveLength(0);
+  });
+
+  it("exports nothing without an open repository", async () => {
+    useRepoStore.setState({ current: null } as never);
+    await createPatch([A]);
+    expect(picked).not.toHaveBeenCalled();
+    expect(exports()).toHaveLength(0);
+  });
+
+  it("reports a refusal in the error banner — the user asked for files and got none", async () => {
+    mockInvoke("format_patch", () => {
+      throw { kind: "InvalidArgument", message: "aaaaaaa is a merge commit" };
+    });
+    await createPatch([A]);
+    expect(useRepoStore.getState().error).toBeTruthy();
+    expect(useRepoStore.getState().error?.kind).toBe("InvalidArgument");
+  });
+
+  it("does not throw on a refusal — a menu click must not crash the screen", async () => {
+    mockInvoke("format_patch", () => {
+      throw { kind: "Io", message: "permission denied" };
+    });
+    await expect(createPatch([A])).resolves.toBeUndefined();
+  });
+});

--- a/src/features/commits/createPatch.ts
+++ b/src/features/commits/createPatch.ts
@@ -1,0 +1,56 @@
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+
+import { pgFlash } from "@/design";
+import { formatPatch } from "@/lib/tauri";
+import { toAppError } from "@/lib/errors";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+
+/**
+ * Export commits as mailbox-format patch files into a directory the user picks.
+ *
+ * `oids` must be OLDEST-FIRST: the backend numbers the series in the order it
+ * is given, so a reversed list produces `0001` for the newest commit and a
+ * series that replays backwards.
+ *
+ * Lives here rather than in the menu for the usual reason — `src/design/`
+ * imports no `@/lib/tauri`.
+ *
+ * The DIRECTORY picker, not a save-file picker: `format-patch` names its own
+ * files (`0001-subject.patch`), and one commit can become several files, so
+ * there is no single filename to offer. That also means no new Tauri
+ * permission — `dialog:allow-open` is already granted and is the same call
+ * Clone / Init / Worktree already make.
+ */
+export async function createPatch(oids: string[]): Promise<void> {
+  const repo = useRepoStore.getState().current;
+  if (!repo || oids.length === 0) return;
+
+  const picked = await openDialog({
+    directory: true,
+    multiple: false,
+    title: oids.length === 1 ? "Save patch to" : `Save ${oids.length} patches to`,
+  });
+  // A dismissed picker is "no answer", never a choice — the same contract the
+  // pg* dialogs keep.
+  if (typeof picked !== "string") return;
+
+  try {
+    const written = await formatPatch(repo.id, oids, picked);
+    pgFlash(
+      written.length === 1
+        ? `wrote ${fileName(written[0])}`
+        : `wrote ${written.length} patches to ${picked}`,
+    );
+  } catch (e) {
+    // A refusal here is worth a banner rather than a flash: the user asked for
+    // files and got none, and the reason (a merge in the selection, an
+    // unwritable directory) is something they act on.
+    useRepoStore.getState().setError(toAppError(e));
+  }
+}
+
+/** Last path segment, for a message that names the file rather than its path. */
+function fileName(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -577,6 +577,24 @@ export async function amendHeadMessage(
 }
 
 /**
+ * Export commits as mailbox-format patch files into `outDir`, resolving with
+ * the paths written.
+ *
+ * `oids` must be OLDEST-FIRST: the series is numbered in the order given, so a
+ * reversed list numbers the newest commit `0001` and replays backwards.
+ *
+ * Mailbox format (`git format-patch`), not a plain diff — the files carry
+ * author, date and message, so `git am` reconstructs each commit.
+ */
+export async function formatPatch(
+  repoId: string,
+  oids: string[],
+  outDir: string,
+): Promise<string[]> {
+  return invoke<string[]>("format_patch", { repoId, oids, outDir });
+}
+
+/**
  * Signature status of ONE commit (#61 D6).
  *
  * Lazy and per-selection by design: a badge on every log row would mean a


### PR DESCRIPTION
Adds **Create patch…** to the History commit context menu — on a single commit
and on a multi-commit selection. Fourth of five PRs from
`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`.

**Stacked on #438 → #437 → #436.** Targets `feat/commit-menu-browser`; review
the [own-commits diff](https://github.com/jonassaa/platypusgit/compare/feat/commit-menu-browser...feat/commit-menu-patch).

## Mailbox format, not a plain diff

`git format-patch`, so the files carry author, date and full message and
`git am` reconstructs the commit rather than only its changes. Rider's own
Create Patch emits a plain unified diff; this is a deliberate divergence — a
git-native tool should hand you the artifact a maintainer expects to receive,
and a plain diff is already partly served by `diff.copy`. A test proves the
round-trip by applying an exported patch to a second repository and asserting
the subject and content came back.

libgit2 has no `format-patch`, so this shells out through `proc::git`.

## Two things the tests caught

**`--` must NOT be there.** This codebase ends option parsing with `--` before
every user-supplied value, and my first implementation followed that rule here.
But `--` introduces **pathspecs**, so `-- <oid>` asks git for commits touching a
*file* named like that oid: it selects nothing and writes no files. Five tests
failed with "wrote no files" and named the bug. It is safe without the separator
because the oid is `commit.id().to_string()` from a resolution done first — 40
hex characters, which cannot begin with a dash. Documented in
`docs/dev/backend.md` as the one place the usual rule inverts.

**`--start-number` is load-bearing, and only one test proves it.** Each commit
gets its own invocation; left to itself every invocation numbers from `0001` and
the files overwrite one another, so a three-commit export silently leaves one
file. Removing the flag fails `numbers_a_multi_commit_export_as_a_series` and
*only* that one — the order test still passes, because two commits with
different subjects produce two different filenames even when both are numbered
`0001`. A fixture whose subjects happen to differ hides the bug entirely, which
is why the numbering test uses `linear_history` and counts files.

## A merge is refused before anything is written

`format-patch` skips a merge **silently**. So every oid is resolved and every
merge rejected up front: a partial export would hand back a shorter list with
nothing naming the commit that vanished, and a merge anywhere in a selection
refuses the whole export — a series with a hole is not a series. Both menu
entries carry the reason in their label.

## The picker

A **directory** picker, not a save-file one: `format-patch` names its own files
(`0001-subject.patch`) and one request can produce several, so there is no single
filename to offer. That means **no new Tauri permission** — `dialog:allow-open`
is already granted and is the same call Clone, Init and Worktree already make.

The selection entry passes `plan.oids`, which is already oldest-first; the series
is numbered in the order given, so a reversed list would number the newest commit
`0001` and replay backwards. A test pins that.

A refusal lands in the error banner rather than a flash — the user asked for
files and got none, and the reason is something they act on.

## Verification

- `cargo test` — no failures. 9 new in `tests/format_patch.rs`, including the
  `git am` round-trip and the two merge-refusal cases.
- `pnpm test` — 378 files, **3788 tests** passed (3774 before).
- `pnpm tsc --noEmit` — clean.
- **No e2e, deliberately.** The flow opens a native OS folder picker, which
  WebDriver cannot drive here; Clone's spec sidesteps its own picker by typing
  into the text field beside it, and this entry has no such field. Covering it
  would mean new plugin-dialog stubbing infrastructure for one seam that three
  shipped dialogs already exercise. What is untested end-to-end is precisely
  that third-party call; the menu enablement, the flow, and the backend each
  have their own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
