### PR TITLE
feat(commits): push history up to one commit from the History menu

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -466,6 +466,19 @@ commands/        Thin Tauri handlers, one file per area:
 ├── branches.rs  list_branches/tags/stashes/remotes,
 │                checkout/create/delete/rename_branch, set_upstream,
 │                fetch, fetch_all, pull, push,
+│                push_commit (publish history only UP TO one commit —
+│                `git push <remote> <oid>:refs/heads/<branch>`. A REFSPEC push,
+│                which is what makes "up to here" expressible: an ordinary push
+│                sends whatever the branch points at. FAST-FORWARD ONLY by
+│                construction — no force variant exists on this path, so a push
+│                that would discard remote commits is refused by the remote and
+│                surfaces like any other network error, and `--force-with-lease`
+│                on a PARTIAL push is deliberately out of scope. No `-u` either:
+│                the branch's upstream is what decided the destination, so
+│                re-pointing it here would be circular. Both halves of the
+│                refspec are validated before it is built — validate_sha on the
+│                oid, validate_ref_name on the branch — so neither can smuggle
+│                in an option or a second refspec),
 │                unshallow (#255 — `git fetch --unshallow`, on the one runner;
 │                answers false instead of relaying git's refusal when the
 │                repository is already complete),

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -885,6 +885,33 @@ Two entries that read the repository and change nothing, so neither goes near
 - **Selection moves scroll by INDEX** through `useWindowedList`, never
   `scrollIntoView`: the target row is usually unmounted (#68 G10).
 
+## "Push all up to here" — publishing part of a branch
+
+- **The confirm names the real effect: "Pushes 3 of your 7 commits".** The
+  label cannot say how much of the branch it covers, and someone who reads
+  "push all up to here" as "push everything" has published work they meant to
+  hold back. Both counts come from `ahead_behind` against the upstream — one
+  against the commit, one against `HEAD` — and when either cannot be read the
+  sentence **omits the numbers** rather than inventing them. A wrong count here
+  is worse than no count.
+- **Two gates, each preventing a different surprise.** A commit outside HEAD's
+  ancestry is refused, because pushing it would publish a foreign branch's
+  history to this branch's ref; a branch with no upstream is refused, because
+  there is no destination to infer and a guessed `origin/<branch>` publishes to
+  a remote nobody chose. Both say which in the label.
+- **`pushTarget()` splits the upstream, and strips only the leading
+  `<remote>/`.** A branch may itself contain slashes (`release/2026/09`), so
+  splitting on every `/` truncates it. Remote resolution reuses
+  `remoteOfUpstream`, which picks the LONGEST matching remote name — that
+  matters when one remote's name is a prefix of another's.
+- **Fast-forward only.** No force is offered anywhere on this path; a push that
+  would discard remote commits is refused by the remote and lands in
+  `PGErrorBanner` like any other network failure.
+- Being a long-running op that can raise a credential challenge, it joins
+  `RepoActivity` through `withAuthRetry` with `{ key, label }` — never a
+  `finally` at the call site, which would clear the label while the password
+  dialog was still open.
+
 ## "View in browser" on a commit
 
 - **The flow lives in `features/forge/openCommitInBrowser.ts`, not in the menu**,

--- a/e2e/specs/remote.e2e.ts
+++ b/e2e/specs/remote.e2e.ts
@@ -219,4 +219,41 @@ describe("remote operations", () => {
 
     expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
   });
+
+  // "Push all up to here": a REFSPEC push, so the remote lands on the commit
+  // that was chosen rather than on the branch tip. The whole point is that it
+  // is PARTIAL, so the fixture needs two unpushed commits and the assertion has
+  // to distinguish the middle one from HEAD.
+  it("pushes history up to one commit, leaving the rest local", async () => {
+    pair = remoteRepo(); // origin/main == main, upstream set
+    pair.repo.commitFile("first.txt", "1\n", "feat: first unpushed");
+    const middle = pair.repo.git("rev-parse", "HEAD").trim();
+    pair.repo.commitFile("second.txt", "2\n", "feat: second unpushed");
+    const tip = pair.repo.git("rev-parse", "HEAD").trim();
+    expect(middle).not.toBe(tip);
+
+    await openRepo(pair.repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await $('[data-testid="commit-row"]*=feat: first unpushed').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "the middle commit's row never appeared",
+    });
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: first unpushed" });
+    await jsClickMenuItem("Push all up to here…");
+
+    // Repo truth on the BARE remote is the acceptance, waited on because there
+    // is no UI signal for "the remote moved" — the activity label clears on
+    // completion either way.
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === middle,
+      { timeout: 30_000, timeoutMsg: "origin/main never advanced to the chosen commit" },
+    );
+
+    // PARTIAL: the remote has the middle commit and NOT the tip, and the local
+    // branch is untouched.
+    expect(pair.bareGit("rev-parse", "main").trim()).toBe(middle);
+    expect(pair.repo.git("rev-parse", "HEAD").trim()).toBe(tip);
+    expect(pair.repo.git("log", "--pretty=%s")).toContain("feat: second unpushed");
+  });
 });

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -497,6 +497,70 @@ fn push_args(
     args
 }
 
+/// `git push <remote> <oid>:refs/heads/<branch>` — publish history only up to
+/// one commit.
+///
+/// A REFSPEC push, which is what makes "up to here" expressible: the ordinary
+/// push sends whatever the branch points at, and there is no way to say "stop
+/// at this commit" without naming the source explicitly.
+///
+/// **Fast-forward only, by construction** — no force variant is offered, so the
+/// remote refuses anything that would discard commits and the refusal surfaces
+/// like any other network error. `--force-with-lease` on a partial push is its
+/// own design question and is deliberately out of scope.
+///
+/// No `-u`: this does not establish tracking. The branch's upstream is what
+/// decided where this push goes, so re-pointing it here would be circular.
+fn push_commit_args(remote: &str, oid: &str, branch: &str, no_verify: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec!["push".to_string(), "--progress".to_string()];
+    args.push(remote.to_string());
+    // The FULL destination ref, not a bare branch name: `<oid>:main` would make
+    // git guess, and it guesses differently depending on whether `main` already
+    // exists on the remote.
+    args.push(format!("{oid}:refs/heads/{branch}"));
+    if no_verify {
+        args.push("--no-verify".to_string());
+    }
+    args
+}
+
+/// Push history up to one commit to `branch` on `remote`.
+///
+/// See [`push_commit_args`] for the shape and why there is no force option.
+#[tauri::command]
+pub async fn push_commit(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    repo_id: String,
+    remote: String,
+    oid: String,
+    branch: String,
+    credentials: Option<Credentials>,
+    // Skip `pre-push` for this push only (#232).
+    no_verify: Option<bool>,
+) -> AppResult<()> {
+    // Both halves of the refspec are validated before it is built: the oid must
+    // be hex and the branch must be a name git would accept, so neither can
+    // introduce an option or a second refspec. Secrets travel in env, never
+    // argv, which `run_git_progress` already guarantees.
+    crate::forge::validate_sha(&oid)?;
+    crate::forge::validate_ref_name(&branch)?;
+
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+    let args = push_commit_args(&remote, &oid, &branch, no_verify.unwrap_or(false));
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    run_git_progress(
+        &app,
+        &path,
+        &repo_id,
+        NetOp::Push,
+        &arg_refs,
+        credentials.as_ref(),
+    )
+    .await
+}
+
 #[tauri::command]
 pub async fn push(
     app: AppHandle,
@@ -573,6 +637,51 @@ mod push_args_tests {
                 "--no-verify"
             ]
         );
+    }
+
+    // ─── push_commit_args ───────────────────────────────────────────────────
+
+    #[test]
+    fn pushes_a_full_destination_refspec() {
+        // The FULL ref, not a bare name: `<oid>:main` makes git guess, and it
+        // guesses differently depending on whether `main` exists on the remote.
+        assert_eq!(
+            push_commit_args("origin", "abc1234", "main", false),
+            vec!["push", "--progress", "origin", "abc1234:refs/heads/main"]
+        );
+    }
+
+    /// No force flag exists on this path, and no `-u`: fast-forward only, and
+    /// the upstream is what decided where the push goes, so re-pointing it here
+    /// would be circular.
+    #[test]
+    fn carries_no_force_and_no_upstream_flag() {
+        let args = push_commit_args("origin", "abc1234", "main", false);
+        assert!(!args.iter().any(|a| a.starts_with("--force")), "{args:?}");
+        assert!(!args.iter().any(|a| a == "-u"), "{args:?}");
+    }
+
+    #[test]
+    fn no_verify_is_appended_when_asked() {
+        assert_eq!(
+            push_commit_args("origin", "abc1234", "feat/x", true),
+            vec![
+                "push",
+                "--progress",
+                "origin",
+                "abc1234:refs/heads/feat/x",
+                "--no-verify"
+            ]
+        );
+    }
+
+    /// A branch name with slashes stays one refspec — it must not be split or
+    /// re-escaped.
+    #[test]
+    fn a_slashed_branch_name_stays_one_refspec() {
+        let args = push_commit_args("origin", "abc1234", "release/2026/09", false);
+        assert_eq!(args[3], "abc1234:refs/heads/release/2026/09");
+        assert_eq!(args.len(), 4, "no extra argument may appear: {args:?}");
     }
 
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -381,6 +381,7 @@ pub fn run() {
             commands::commits::commit,
             commands::commits::amend_head_message,
             commands::commits::format_patch,
+            commands::branches::push_commit,
             commands::commits::file_history,
             commands::commits::verify_commit,
             commands::commits::commit_notes,

--- a/src/design/context-menu.push.test.tsx
+++ b/src/design/context-menu.push.test.tsx
@@ -1,0 +1,100 @@
+// "Push all up to here…" enablement.
+//
+// Two gates, and each one prevents a different kind of surprise: pushing a
+// commit HEAD cannot reach would publish a foreign branch's history to this
+// branch's ref, and with no upstream there is no destination to infer — a
+// guessed `origin/<branch>` publishes to a remote nobody chose.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { commitMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { CommitInfo } from "@/lib/types";
+
+const HEAD_SHA = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const OFF_BRANCH = "f".repeat(40);
+
+const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+const COMMITS = [
+  mk(HEAD_SHA, "commit A", [B]),
+  mk(OFF_BRANCH, "on another branch", [C]),
+  mk(B, "commit B", [C]),
+  mk(C, "commit C", []),
+];
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+function tracking(upstream: string | null) {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    headInfo: { branch: "main", headOid: HEAD_SHA },
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream,
+        ahead: 0,
+        behind: 0,
+        tip: HEAD_SHA,
+        tipTime: 0,
+        isDefault: true,
+      },
+    ],
+    remotes: [{ name: "origin", url: null }],
+    status: [],
+    loading: false,
+  } as never);
+}
+
+beforeEach(() => tracking("origin/main"));
+afterEach(() => vi.restoreAllMocks());
+
+describe("Push all up to here", () => {
+  it("is offered for a commit on this branch with an upstream", () => {
+    const item = labeled(commitMenuItems({ sha: B }), /^Push all up to here/);
+    expect(item.disabled).toBeFalsy();
+    expect(item.label).toBe("Push all up to here…");
+  });
+
+  it("is refused for a commit not on this branch, and says why", () => {
+    const item = labeled(commitMenuItems({ sha: OFF_BRANCH }), /^Push all up to here/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/not on this branch/);
+  });
+
+  it("is refused when the branch tracks nothing, and says why", () => {
+    tracking(null);
+    const item = labeled(commitMenuItems({ sha: B }), /^Push all up to here/);
+    expect(item.disabled).toBe(true);
+    expect(item.label).toMatch(/tracks nothing/);
+  });
+
+  it("is refused with no commit", () => {
+    const item = labeled(commitMenuItems(null), /^Push all up to here/);
+    expect(item.disabled).toBe(true);
+  });
+
+  it("is offered for HEAD itself — pushing the whole branch is a legitimate case", () => {
+    const item = labeled(commitMenuItems({ sha: HEAD_SHA }), /^Push all up to here/);
+    expect(item.disabled).toBeFalsy();
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -13,6 +13,7 @@ import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { commitChildren } from "@/features/commits/commitChildren";
 import { createPatch } from "@/features/commits/createPatch";
+import { pushTarget, pushUpToHere } from "@/features/commits/pushUpToHere";
 import { openCommitInBrowser } from "@/features/forge/openCommitInBrowser";
 import { rewordCommit } from "@/features/commits/rewordCommit";
 import { dropCommit } from "@/features/commits/dropCommit";
@@ -786,6 +787,23 @@ export function commitMenuItems(
       onClick: () => {
         if (!commit?.sha) return;
         void dropCommit({ oid: commit.sha }, rewriteCtx(commits));
+      },
+    },
+    {
+      icon: "push",
+      // Gated on ancestry AND on an upstream: pushing a commit HEAD cannot
+      // reach would publish a foreign branch's history to this branch's ref,
+      // and with no upstream there is no destination to infer — guessing
+      // `origin/<branch>` would publish to a remote nobody chose.
+      label: !onBranch
+        ? "Push all up to here — not on this branch"
+        : !pushTarget()
+          ? "Push all up to here — this branch tracks nothing"
+          : "Push all up to here…",
+      disabled: !onBranch || !pushTarget() || !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha) return;
+        void pushUpToHere(commit.sha);
       },
     },
     { divider: true },

--- a/src/features/commits/pushUpToHere.test.tsx
+++ b/src/features/commits/pushUpToHere.test.tsx
@@ -1,0 +1,162 @@
+// "Push all up to here…" — publish only part of a branch.
+//
+// The counts in the confirm are the load-bearing part: the entry's own label
+// cannot say how much of the branch it covers, and someone who reads "push all
+// up to here" as "push everything" has published work they meant to hold back.
+// A wrong count is worse than no count, hence the omission case.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { pushTarget, pushUpToHere } from "./pushUpToHere";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { WithDialogs, acceptDialog, dismissDialog, dialogBody, resetDialogs } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const OID = "a".repeat(40);
+
+const pushes = () => getInvokeCalls().filter((c) => c.cmd === "push_commit");
+
+/** Point the store at a branch tracking `upstream`. */
+function tracking(upstream: string | null, remotes = [{ name: "origin", url: null }]) {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream,
+        ahead: 0,
+        behind: 0,
+        tip: OID,
+        tipTime: 0,
+        isDefault: true,
+      },
+    ],
+    remotes,
+    status: [],
+    error: null,
+    activity: {},
+    loading: false,
+  } as never);
+}
+
+async function acceptWhenOpen() {
+  await screen.findByTestId("dialog-confirm");
+  await acceptDialog();
+}
+
+beforeEach(() => {
+  resetDialogs();
+  tracking("origin/main");
+  mockInvoke("push_commit", () => undefined);
+  // ahead(a=upstream, b=rev) = "on b, not on a" — 3 up to the commit, 7 total.
+  mockInvoke("ahead_behind", (args) => ({
+    ahead: args.b === "HEAD" ? 7 : 3,
+    behind: 0,
+    mergeBase: "zzz",
+  }));
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  render(
+    <WithDialogs>
+      <div />
+    </WithDialogs>,
+  );
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("pushTarget", () => {
+  it("splits the upstream into remote and branch", () => {
+    expect(pushTarget()).toEqual({
+      remote: "origin",
+      branch: "main",
+      upstream: "origin/main",
+    });
+  });
+
+  it("keeps a slashed branch name whole", () => {
+    // Splitting on every "/" would truncate this to "release".
+    tracking("origin/release/2026/09");
+    expect(pushTarget()?.branch).toBe("release/2026/09");
+  });
+
+  it("is null when the branch tracks nothing — there is no destination to infer", () => {
+    tracking(null);
+    expect(pushTarget()).toBeNull();
+  });
+
+  it("is null when the upstream names a remote that is gone", () => {
+    tracking("upstream/main", [{ name: "origin", url: null }]);
+    expect(pushTarget()).toBeNull();
+  });
+});
+
+describe("pushUpToHere", () => {
+  it("pushes the oid to the upstream's remote and branch", async () => {
+    void pushUpToHere(OID);
+    await acceptWhenOpen();
+    await waitFor(() => expect(pushes().length).toBe(1));
+    expect(pushes()[0].args).toMatchObject({
+      repoId: "r1",
+      remote: "origin",
+      oid: OID,
+      branch: "main",
+    });
+  });
+
+  it("names how many commits of how many in the confirm", async () => {
+    void pushUpToHere(OID);
+    await waitFor(() => expect(dialogBody()).toMatch(/Pushes 3 of your 7 commits/));
+    expect(dialogBody()).toMatch(/origin\/main/);
+    expect(dialogBody()).toMatch(/rest of your branch stays local/);
+  });
+
+  it("says 'all' when the commit IS the branch tip", async () => {
+    mockInvoke("ahead_behind", () => ({ ahead: 4, behind: 0, mergeBase: "zzz" }));
+    void pushUpToHere(OID);
+    await waitFor(() => expect(dialogBody()).toMatch(/Pushes all 4 commits/));
+  });
+
+  it("omits the numbers rather than inventing them when they cannot be read", async () => {
+    mockInvoke("ahead_behind", () => {
+      throw { kind: "InvalidRef", message: "no such ref" };
+    });
+    void pushUpToHere(OID);
+    await waitFor(() => expect(dialogBody()).toMatch(/Pushes history up to this commit/));
+    expect(dialogBody()).not.toMatch(/\d+ of your/);
+  });
+
+  it("pushes nothing when the confirm is declined", async () => {
+    void pushUpToHere(OID);
+    await screen.findByTestId("dialog-cancel");
+    await dismissDialog();
+    expect(pushes()).toHaveLength(0);
+  });
+
+  it("pushes nothing when the branch tracks nothing", async () => {
+    tracking(null);
+    await pushUpToHere(OID);
+    expect(pushes()).toHaveLength(0);
+  });
+
+  it("sends no force flag — this path is fast-forward only", async () => {
+    void pushUpToHere(OID);
+    await acceptWhenOpen();
+    await waitFor(() => expect(pushes().length).toBe(1));
+    expect(JSON.stringify(pushes()[0].args)).not.toMatch(/force/i);
+  });
+});

--- a/src/features/commits/pushUpToHere.ts
+++ b/src/features/commits/pushUpToHere.ts
@@ -1,0 +1,101 @@
+import { pgConfirm } from "@/design";
+import { aheadBehind } from "@/lib/tauri";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { currentBranch } from "@/lib/derive";
+// The one resolver for "which remote does this upstream name?" — it picks the
+// LONGEST matching remote name, which matters when one remote's name is a
+// prefix of another's.
+import { remoteOfUpstream } from "@/features/branches/fastForward";
+
+/** What "push up to here" needs to know, resolved from the branch's upstream. */
+export interface PushTarget {
+  remote: string;
+  /** The branch NAME on the remote, without the remote prefix. */
+  branch: string;
+  /** `origin/main`, for saying where things are going. */
+  upstream: string;
+}
+
+/**
+ * Where a partial push would go: the current branch's upstream, split.
+ *
+ * `null` when the branch tracks nothing — there is no destination to infer, and
+ * guessing `origin/<branch>` would publish to a remote the user never chose.
+ * The menu disables the entry and says so.
+ */
+export function pushTarget(): PushTarget | null {
+  const s = useRepoStore.getState();
+  const branch = currentBranch(s.branches);
+  const upstream = branch?.upstream ?? null;
+  if (!upstream) return null;
+  const remote = remoteOfUpstream(upstream, s.remotes);
+  if (!remote) return null;
+  // Strip only the leading `<remote>/`: a branch may itself contain slashes
+  // (`release/2026/09`), so splitting on every `/` would truncate it.
+  const prefix = `${remote}/`;
+  const name = upstream.startsWith(prefix) ? upstream.slice(prefix.length) : upstream;
+  if (!name) return null;
+  return { remote, branch: name, upstream };
+}
+
+/**
+ * Push history up to one commit, leaving the rest of the branch unpublished.
+ *
+ * The confirm names the REAL effect — "3 of your 7 commits" — because the
+ * entry's own label cannot: how much of the branch this covers is the whole
+ * question, and a user who reads "push all up to here" as "push everything"
+ * has published work they meant to hold back.
+ *
+ * Fast-forward only. No force is offered anywhere on this path, so a push that
+ * would discard remote commits is refused by the remote and surfaces in the
+ * error banner like any other network failure.
+ */
+export async function pushUpToHere(oid: string): Promise<void> {
+  const repo = useRepoStore.getState().current;
+  const target = pushTarget();
+  if (!repo || !target) return;
+
+  const counts = await commitCounts(repo.id, oid, target.upstream);
+  if (
+    !(await pgConfirm({
+      title: `Push up to ${oid.slice(0, 7)}?`,
+      body: counts
+        ? `${describe(counts.upTo, counts.total)} to ${target.upstream}. The rest of your branch stays local.`
+        : `Pushes history up to this commit to ${target.upstream}. The rest of your branch stays local.`,
+      confirmLabel: "Push",
+    }))
+  )
+    return;
+
+  await useRepoStore.getState().pushCommit(target.remote, oid, target.branch);
+}
+
+/**
+ * How many commits this push would publish, and how many the branch has.
+ *
+ * Both are asked as `ahead` against the upstream — "on b, not on a" — so the
+ * pair describes the same question at two points. `null` when either side
+ * cannot be resolved: the confirm then omits the numbers rather than inventing
+ * them, because a wrong count here is worse than no count.
+ */
+async function commitCounts(
+  repoId: string,
+  oid: string,
+  upstream: string,
+): Promise<{ upTo: number; total: number } | null> {
+  try {
+    const [atCommit, atHead] = await Promise.all([
+      aheadBehind(repoId, upstream, oid),
+      aheadBehind(repoId, upstream, "HEAD"),
+    ]);
+    return { upTo: atCommit.ahead, total: atHead.ahead };
+  } catch {
+    return null;
+  }
+}
+
+function describe(upTo: number, total: number): string {
+  const commits = (n: number) => `${n} commit${n === 1 ? "" : "s"}`;
+  if (upTo === total) return `Pushes all ${commits(total)}`;
+  return `Pushes ${upTo} of your ${commits(total)}`;
+}

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -79,6 +79,7 @@ import {
   pruneRemote,
   pull as pullRemote,
   push as pushRemote,
+  pushCommit as pushCommitFn,
   pushDeleteBranch as pushDeleteBranchFn,
   pushTag as pushTagFn,
   rebaseAbort,
@@ -479,6 +480,20 @@ interface RepoStoreState extends RepoSlice {
     remote: string,
     branch: string,
     force?: PushForce,
+    /** Skip `pre-push` for this push only (#232). */
+    noVerify?: boolean,
+  ) => Promise<void>;
+  /**
+   * Push history only UP TO `oid`, onto `branch` on `remote`.
+   *
+   * Fast-forward only — there is no force variant, so a push that would discard
+   * commits is refused by the remote. Does not set tracking: the branch's
+   * upstream is what decided the destination.
+   */
+  pushCommit: (
+    remote: string,
+    oid: string,
+    branch: string,
     /** Skip `pre-push` for this push only (#232). */
     noVerify?: boolean,
   ) => Promise<void>;
@@ -2134,6 +2149,23 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       },
       (e) => setErrorFor(repo.id, e),
       { key: "push", label: `Pushing ${remote}/${branch}…` },
+    );
+  },
+
+  async pushCommit(remote, oid, branch, noVerify = false) {
+    const repo = get().current;
+    if (!repo) return;
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await pushCommitFn(repo.id, remote, oid, branch, creds, noVerify);
+        setActivity(repo.id, "push", "Refreshing…");
+        await get().refreshAll();
+      },
+      (e) => setErrorFor(repo.id, e),
+      // withAuthRetry OWNS the label. A `finally` at the call site would clear
+      // it while the password dialog was still open.
+      { key: "push", label: `Pushing ${shortOid(oid)} to ${remote}/${branch}…` },
     );
   },
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -909,6 +909,37 @@ export async function pushTag(
   return invoke<void>("push_tag", { repoId, remote, name, credentials });
 }
 
+/**
+ * Push history only up to `oid`, onto `branch` on `remote`.
+ *
+ * `git push <remote> <oid>:refs/heads/<branch>` — a refspec push, which is what
+ * makes "up to here" expressible at all: an ordinary push sends whatever the
+ * branch points at.
+ *
+ * **Fast-forward only.** There is no force variant on this path, so the remote
+ * refuses anything that would discard commits and the refusal arrives like any
+ * other network error. It also does not set tracking: the branch's upstream is
+ * what decided where this goes.
+ */
+export async function pushCommit(
+  repoId: string,
+  remote: string,
+  oid: string,
+  branch: string,
+  credentials?: Credentials,
+  /** Skip `pre-push` for this push only (#232). */
+  noVerify = false,
+): Promise<void> {
+  return invoke<void>("push_commit", {
+    repoId,
+    remote,
+    oid,
+    branch,
+    credentials,
+    noVerify,
+  });
+}
+
 /** Delete a branch on the remote (see `pushTag` for the credential contract). */
 export async function pushDeleteBranch(
   repoId: string,


### PR DESCRIPTION
Adds **Push all up to here…** — publish history only as far as one commit,
leaving the rest of the branch local. Last of five PRs from
`docs/superpowers/specs/2026-09-08-commit-menu-parity-spec.md`, and the one that
completes Rider parity for the commit context menu.

**Stacked on #439 → #438 → #437 → #436.** Targets `feat/commit-menu-patch`;
review the [own-commits diff](https://github.com/jonassaa/platypusgit/compare/feat/commit-menu-patch...feat/commit-menu-push).

## A refspec push

`git push <remote> <oid>:refs/heads/<branch>`. That is what makes "up to here"
expressible at all — an ordinary push sends whatever the branch points at, with
no way to say "stop here". The existing `push` command takes a branch *name*, so
this is a new command rather than a flag.

**Fast-forward only, by construction.** No force variant exists on this path, so
a push that would discard remote commits is refused by the remote and surfaces
in `PGErrorBanner` like any other network error. `--force-with-lease` on a
*partial* push is its own design question and is deliberately out of scope.

**No `-u` either:** the branch's upstream is what decided the destination, so
re-pointing it here would be circular.

Both halves of the refspec are validated before it is built — `validate_sha` on
the oid, `validate_ref_name` on the branch — so neither can smuggle in an option
or a second refspec. Secrets travel in env, never argv, which `run_git_progress`
already guarantees, and the op joins `RepoActivity` through `withAuthRetry` with
`{ key, label }` rather than a `finally` at the call site — that would clear the
label while the password dialog was still open.

## Why the confirm carries counts

"Pushes 3 of your 7 commits to origin/main. The rest of your branch stays
local."

The label cannot say how much of the branch it covers, and that is the whole
question: someone who reads "push all up to here" as "push everything" has
published work they meant to hold back. Both numbers come from `ahead_behind`
against the upstream — one against the commit, one against `HEAD`.

When either count cannot be read the sentence **omits the numbers** rather than
inventing them, and a test covers that: a wrong count here is worse than no
count.

## Two gates, each preventing a different surprise

- **A commit outside HEAD's ancestry is refused** — pushing it would publish a
  foreign branch's history to *this* branch's ref.
- **A branch with no upstream is refused** — there is no destination to infer,
  and a guessed `origin/<branch>` publishes to a remote nobody chose.

Both say which in their label.

`pushTarget()` strips only the leading `<remote>/` from the upstream, because a
branch may itself contain slashes (`release/2026/09`) and splitting on every `/`
truncates it. Remote resolution reuses `remoteOfUpstream`, which picks the
longest matching remote name — that matters when one remote's name is a prefix
of another's. Both cases are tested.

## Verification

- `cargo test` — no failures. 4 new `push_commit_args` unit tests, including
  that no force flag and no `-u` can appear, and that a slashed branch name
  stays one refspec.
- `pnpm test` — 380 files, **3804 tests** passed (3788 before).
- `pnpm tsc --noEmit` and the e2e typecheck — clean.
- `pnpm test:e2e:docker full` on `remote.e2e.ts` — **11 passing**, including a
  new spec that pushes to the middle of two unpushed commits against a real
  local bare remote and asserts the remote landed on the **chosen** commit, not
  the tip, with the local branch untouched.

The docs gate caught `push_commit` before I did — `test/docs.test.ts` failed
until the command had a real entry in the backend tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
