### PR TITLE
fix(design): keep an over-tall context menu reachable

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -2075,6 +2075,37 @@ one word (`locked`) with the variable text as a sibling span, `flexShrink: 0`
 on the badge. Screens that are all-path (`Worktrees`) skip the centred
 `maxWidth: 1100` column — the cap ate exactly the width the paths needed.
 
+### A context menu is height-bounded, and that is what keeps it reachable
+
+`menuStyle` carries `maxHeight: calc(100vh - 8px)` + `overflowY: auto`, and both
+are **unconditional**. Without them the off-screen correction degenerates:
+
+```ts
+if (y + r.height + 4 > vh) ny = Math.max(4, vh - r.height - 4);
+```
+
+For a menu taller than the window, `vh - r.height - 4` is negative, `Math.max`
+pins it at `top: 4`, and everything past the bottom edge is **unreachable** —
+no scrollbar, no keyboard route. Bounding the height is also what makes that
+correction honest, because `r.height` can then never exceed the viewport.
+
+This is not hypothetical: the commit menu measures **31 items / 24 rows /
+~734px at its MINIMUM** — one branch at the commit, no custom actions, no tags.
+`checkoutBranchItems` grows with every branch pointing at the commit and
+`customActionItems` with every user-defined command, so the real ceiling is
+open-ended, and the last entry (*View in browser*) is the first thing lost.
+
+Two things follow for anyone adding menu entries:
+
+- **A submenu inherits the bound for free**, because `PGContextMenu` renders
+  submenus by recursing into itself (see below). The *Check out branch* submenu
+  is the one that grows without limit.
+- **Do not make the bound conditional on item count.** A threshold works for
+  whichever menu it was tuned against and silently fails for the next one to
+  grow. `context-menu.overflow.test.tsx` asserts it applies to a 3-item menu as
+  well as a 60-item one, and jsdom does no layout — so those assertions are on
+  the style contract, which is the layer a regression would land in.
+
 ### A submenu is its own portal, and dismissal is a PRESS (#422)
 
 `PGContextMenu` renders each submenu by recursing into itself, and every

--- a/src/design/context-menu.overflow.test.tsx
+++ b/src/design/context-menu.overflow.test.tsx
@@ -1,0 +1,72 @@
+// A context menu taller than the window must stay REACHABLE.
+//
+// The commit menu is 31 items / ~734px at its MINIMUM — one branch at the
+// commit, no custom actions — so on any window shorter than that it exceeds the
+// viewport. Before this guard the menu had no height bound and no scroll, and
+// the off-screen correction degenerated:
+//
+//     if (y + r.height + 4 > vh) ny = Math.max(4, vh - r.height - 4);
+//
+// With `r.height > vh`, `vh - r.height - 4` is NEGATIVE, `Math.max` pins the
+// menu at `top: 4`, and everything past the bottom edge is unreachable — no
+// scrollbar, no keyboard route, nothing. "View in browser" is the last entry in
+// the commit menu, so it was the first thing lost.
+//
+// jsdom performs no layout, so the assertions here are on the STYLE CONTRACT
+// that makes overflow reachable in a real webview. That is the layer the
+// regression would land in: both properties are unconditional, so there is no
+// threshold for a later change to get wrong.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PGContextMenu, type ContextMenuItem } from "./context-menu";
+
+/** The outside-press listeners attach in a `setTimeout(0)` — let them. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+function menuEl(): HTMLElement {
+  const el = document.querySelector("[data-pg-menu]");
+  if (!el) throw new Error("no context menu rendered");
+  return el as HTMLElement;
+}
+
+/** `n` plain rows, enough to exceed any plausible window height. */
+const manyItems = (n: number): ContextMenuItem[] =>
+  Array.from({ length: n }, (_, i) => ({ label: `Entry ${i}`, onClick: vi.fn() }));
+
+describe("PGContextMenu overflow", () => {
+  it("bounds its height to the viewport", async () => {
+    render(<PGContextMenu x={10} y={10} items={manyItems(60)} onClose={vi.fn()} />);
+    await settle();
+    // Whatever the exact expression, it must be viewport-relative — a fixed
+    // pixel cap would be wrong on a small window and wasteful on a large one.
+    expect(menuEl().style.maxHeight).toMatch(/vh|vb|dvh/);
+  });
+
+  it("makes the overflow scrollable rather than clipped", async () => {
+    render(<PGContextMenu x={10} y={10} items={manyItems(60)} onClose={vi.fn()} />);
+    await settle();
+    // `hidden` would bound the height and still lose the entries — the bug this
+    // guards is unreachability, not spill.
+    expect(menuEl().style.overflowY).toBe("auto");
+  });
+
+  it("applies the bound unconditionally, not past some item count", async () => {
+    // A threshold is the shape a later change gets wrong: it would work for the
+    // commit menu and quietly fail for the next menu to grow.
+    render(<PGContextMenu x={10} y={10} items={manyItems(3)} onClose={vi.fn()} />);
+    await settle();
+    expect(menuEl().style.maxHeight).toMatch(/vh|vb|dvh/);
+    expect(menuEl().style.overflowY).toBe("auto");
+  });
+
+  it("still positions a short menu at the click point", async () => {
+    // The bound must not disturb ordinary placement. jsdom reports a zero-size
+    // rect, so no correction should fire and the menu keeps the given point.
+    render(<PGContextMenu x={42} y={99} items={manyItems(3)} onClose={vi.fn()} />);
+    await settle();
+    expect(menuEl().style.left).toBe("42px");
+    expect(menuEl().style.top).toBe("99px");
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -277,6 +277,19 @@ export function PGContextMenu({
     padding: "4px 0",
     minWidth: 220,
     maxWidth: 320,
+    // A menu can be taller than the window — the commit menu is ~734px at its
+    // MINIMUM (31 items, one branch at the commit, no custom actions). Without
+    // these two the correction below degenerates: `vh - r.height - 4` goes
+    // negative, `Math.max` pins the menu at `top: 4`, and everything past the
+    // bottom edge is unreachable with no scrollbar and no keyboard route.
+    //
+    // Bounding the height is also what keeps that correction honest —
+    // `r.height` can no longer exceed the viewport, so the flip always lands at
+    // a non-negative top. Unconditional on purpose: a threshold would work for
+    // whichever menu it was tuned against and quietly fail for the next one to
+    // grow.
+    maxHeight: "calc(100vh - 8px)",
+    overflowY: "auto",
     fontFamily: "var(--font-sans)",
     fontSize: "var(--fs-12)",
     color: "var(--fg-0)",


### PR DESCRIPTION
A context menu taller than the window was **unreachable past the bottom edge** —
no height bound, no scroll, and the off-screen correction degenerated:

```ts
if (y + r.height + 4 > vh) ny = Math.max(4, vh - r.height - 4);
```

For `r.height > vh` that subtraction is negative, `Math.max` pins the menu at
`top: 4`, and the overflow runs off the screen with no scrollbar and no keyboard
route to it.

## Why it matters now

Measured on `main`: the commit menu is **31 items / 24 rows / ~734px at its
minimum** — one branch at the commit, no custom actions, no tags. The eight
entries added for Rider parity (#436–#440) took it from roughly 518px, so it now
exceeds any window shorter than ~740px. *View in browser* is the last entry, so
it was the first thing lost.

`checkoutBranchItems` grows with every branch pointing at the commit and
`customActionItems` with every user-defined command, so the real ceiling is
open-ended — this is not a "one more entry and we're fine" situation.

Found while answering "why can't I see the new menu entries?". That turned out to
be a stale install (v0.8.0, built two days before the merge), **not** this — but
this is what would have bitten next, on a laptop screen or a resized window.

## The fix

`maxHeight: calc(100vh - 8px)` + `overflowY: auto` on `menuStyle`, both
**unconditional**.

- Bounding the height also makes the existing correction honest: `r.height` can
  no longer exceed the viewport, so the flip always lands at a non-negative top.
- **Submenus inherit it for free**, because `PGContextMenu` renders submenus by
  recursing into itself — which is what covers the unbounded *Check out branch*
  submenu.
- Not conditional on item count: a threshold works for whichever menu it was
  tuned against and silently fails for the next one to grow. One of the four
  tests asserts the bound applies to a 3-item menu as well as a 60-item one.

## Verification

- 4 new assertions in `context-menu.overflow.test.tsx`. jsdom does no layout, so
  they assert the **style contract** — which is the layer a regression would
  land in. A fourth test pins that ordinary placement is undisturbed.
- Written test-first: 3 failed before the change, and **removing both properties
  again fails exactly those 3** while the placement control stays green.
- `pnpm test` — 381 files, **3808 tests** passed (3804 on `main`).
- `pnpm tsc --noEmit` — clean.
- No e2e: the e2e window is a fixed, tall size, so it cannot exercise a short
  viewport, and the behaviour is a CSS bound rather than a flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
