### PR TITLE
fix(settings): make theme export work, and revamp theme creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,13 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 - **Never `Command::new` outside `src-tauri/src/proc.rs`** — a guard test
   fails the build. Use the `proc::git*`/`proc::program*` constructors.
   (`docs/dev/backend.md`)
+- **One file save/open path — `lib/userFile.ts`.** A webview is not a browser:
+  WebKitGTK ignores `<a download>`, so every export in the app silently did
+  nothing on Linux (#435). Native `save()`/`open()` over
+  `commands/userfile.rs`; a save returns the PATH so a surface can name the
+  file, and a cancel is `null`, never a throw. No `<a download>`, no file
+  input, no `createObjectURL` in shipped `src/` — `test/fileSave.test.ts` fails
+  the build. (`docs/dev/frontend.md`)
 - **One credential path.** Network git ops go through
   `commands::net::run_git_authenticated`; frontend retries via `useRepoStore`'s
   exported `withAuthRetry`. Never a second auth path. Secrets travel in env,

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -505,6 +505,17 @@ commands/        Thin Tauri handlers, one file per area:
 │                gigabyte-sized IPC message
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
+├── userfile.rs  read_user_file, write_user_file (#435) — the native half of
+│                every export and import. The path is one the USER chose in a
+│                native save/open dialog (src/lib/userFile.ts); the frontend may
+│                never synthesise one, which is why write_user_file refuses to
+│                create parent directories. Reads are capped at
+│                MAX_USER_FILE_BYTES (4 MiB) and a folder is an InvalidPath, so
+│                a mis-picked disk image is a refusal rather than a webview that
+│                swallows a gigabyte. Deliberately not tauri-plugin-fs: two thin
+│                commands match how every other capability here is exposed, and
+│                the plugin's scope config would be a second, parallel answer to
+│                "may the webview touch this path"
 ├── windows.rs   register_window_repos, next_window_label (#256) — thin over
 │                src-tauri/src/windows.rs (same basename, two files).
 │                register_window_repos is called on every tab-strip persist,
@@ -679,8 +690,10 @@ features/            Components + Zustand store colocated per feature:
 │                    useRowReorder, StageDropBar. See frontend.md
 ├── reflog/          useReflogStore, DirtyTreeDialog, ReflogActionDialog
 ├── settings/        useSettingsStore (autoFetch, defaultPullMode, …), headMarks,
-│                    systemAppearance (OS light/dark → themePreference)
-│                    + HeadMarksControl. The searchable, side-menu-navigated
+│                    systemAppearance (OS light/dark → themePreference),
+│                    themeFiles.ts (the side-effecting half of export/import —
+│                    the store keeps the PURE serialisers, same split
+│                    features/report/ makes) + HeadMarksControl. The searchable, side-menu-navigated
 │                    screen lives in four subdirectories:
 │   ├── layout/      SettingsCard / SettingsRow — the one card/row pair every
 │   │                page renders through — plus filterContext (which row ids
@@ -695,8 +708,18 @@ features/            Components + Zustand store colocated per feature:
 │   ├── pages/       The ten pages themselves, one file each, every one
 │   │                exporting a pure `meta` beside its component — see
 │   │                frontend.md's "Settings is a registry" section
-│   └── theme/       ColorEditor + ThemeEditorDialog, split out of the
-│                    Appearance page for size
+│   └── theme/       Everything the Appearance page's theme half is made of
+│                    (#435 revamp): ThemeGallery (the card picker that replaced
+│                    a dropdown of names), ThemePreview (a miniature of the real
+│                    app, painted from themeVars into its OWN subtree — the one
+│                    renderer behind both the cards and the editor's pane),
+│                    ThemeEditorDialog (a PGModal, no props: it reads
+│                    useThemeEditorStore so app.closeOverlay can close it),
+│                    useThemeEditorStore (the draft + the pre-draft theme
+│                    close() restores), ColorEditor (the 18 slots),
+│                    contrast.ts (WCAG ratios for the four pairs that decide
+│                    readability — advisory, never blocking) and deriveTheme.ts
+│                    (base + accent → palette, with the ink recalculated)
 ├── palette/         usePaletteStore (step stack + chips), commands catalog,
 │                    frecency, CommandPalette (⌘P; rows show live keymap chords)
 ├── keymap/          actions.ts (catalog + default runners), presets.ts (rider +
@@ -814,7 +837,12 @@ features/            Components + Zustand store colocated per feature:
 
 lib/                 tauri.ts (typed invoke wrappers — frontend NEVER calls
                      invoke directly), types.ts (mirrors Rust types.rs),
-                     errors.ts (AppError union 1:1 with Rust), derive.ts
+                     errors.ts (AppError union 1:1 with Rust),
+                     userFile.ts (saveTextFile / openTextFile — the ONE way this
+                     app writes a file or reads one back; a webview is not a
+                     browser, so no <a download> and no file input, and
+                     test/fileSave.test.ts fails the build for either),
+                     derive.ts
                      (selectors), syntax/ (Shiki OFF the main thread:
                      tokenizeCore.ts, shiki.ts — the ONE lazy instance,
                      engine-javascript not WASM —, langs.ts (explicit

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -993,6 +993,49 @@ patch text in the format git parses, not a rendering.
 - **Read-only.** Writing needs a ref to pick, a merge strategy for the notes
   tree, and a push story; it is a separate feature, not a missing button.
 
+## Writing a file the user picked (#435)
+
+`commands/userfile.rs` — `read_user_file` and `write_user_file`, the native half
+of every export and import in the app.
+
+**What was wrong.** Theme and settings export wrote their file the way a web
+page would: a `Blob`, an `<a download>` and a synthetic click. WebKitGTK ignores
+the `download` attribute on a blob URL, so on Linux "Export theme" did nothing
+at all — no file, no error, no log line. The report (#435, Ubuntu 26.04) was a
+user clicking a button and watching nothing happen. On top of that, only
+`dialog:allow-open` was granted in `capabilities/default.json`, so even a
+correct save dialog would have been denied at runtime: two independent causes of
+the same silence.
+
+**The trust model.** These commands take an absolute path the **user** chose in
+a native save or open dialog (`@tauri-apps/plugin-dialog`, behind
+`src/lib/userFile.ts`). Nothing in the frontend may synthesise a path for them.
+That is the reason `write_user_file` refuses to create parent directories: a
+dialog's path always has a parent that exists, so a request to invent one is a
+request that did not come from a dialog.
+
+- Reads are capped at `MAX_USER_FILE_BYTES` (4 MiB). A settings bundle with
+  every custom theme is tens of kilobytes; the cap is there because the path
+  comes from a file picker, and a mis-picked disk image should be a refusal
+  rather than a webview swallowing a gigabyte.
+- A directory is `InvalidPath`, not `Io` — "you picked a folder" is a different
+  sentence from "the disk said no".
+- Both wrap their `std::fs` call in `spawn_blocking`. Not for libgit2's reasons:
+  `std::fs` is sync, and blocking a runtime worker on a slow network volume
+  would stall every other command with it.
+- **No new `AppError` variant.** `Io` and `InvalidPath` already existed, so the
+  Rust enum and its TS union stayed as they were and `test/appErrors.test.ts`
+  needed nothing.
+
+**Why not `tauri-plugin-fs`.** Two thin commands match how every other backend
+capability here is exposed, and the plugin's scope configuration would be a
+second, parallel answer to "may the webview touch this path" — one more place
+to keep in step with the first.
+
+`src-tauri/tests/user_file.rs` asserts the boring properties: an exact round
+trip, truncation on rewrite, a missing file as `Io`, a directory and an
+oversized file as `InvalidPath`, a blank path refused, and no silent `mkdir`.
+
 ## Spawning processes (issue 172)
 
 - **Never write `Command::new` outside `src-tauri/src/proc.rs`** —

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1848,6 +1848,64 @@ update checks back on for someone who turned them off.
   a half naming a theme this machine lacks and **re-derives** `activeThemeId`
   from this machine's own appearance: the exported id only records which half
   was on screen where the file was written.
+- **One file save/open path — `lib/userFile.ts`.** `saveTextFile` and
+  `openTextFile` are the only way this app writes a file or reads one back.
+  Export used to be a `Blob`, an `<a download>` and a synthetic click; import a
+  hidden file input. **A webview is not a browser:** WebKitGTK ignores the
+  download attribute, so on Linux every export button did nothing, silently —
+  which is how #435 survived a release. Both are browser affordances in an app
+  that has native dialogs, and `test/fileSave.test.ts` fails the build for
+  either coming back (it greps shipped `src/` for `createObjectURL`, a
+  `.download =` assignment and a file input, and asserts `userFile.ts` is the
+  only module importing the dialog plugin's `save`). Two rules the callers keep:
+  **a save returns the PATH**, so a surface says *Saved to `/home/you/x.json`*
+  rather than guessing at a downloads folder the app never chose; and **a
+  cancelled dialog is `null`, never a throw** — a dismissal is "no answer", the
+  reading `pgConfirm` and `pgPrompt` already give it. `features/settings/
+  themeFiles.ts` is the side-effecting half (dialogs and bytes) over the store's
+  PURE `exportTheme` / `exportSettings`, the same split `features/report/` makes
+  between `report.ts` and `fileReport.ts`. `readSettingsFile` reads WITHOUT
+  applying, because the Backup page asks before replacing every preference.
+- **One theme renderer — `themeVars(theme)`.** It returns every CSS var a theme
+  sets as a plain map; `applyTheme` is one writer of it (to `:root`, plus the
+  `data-theme` stamps, which are the document's IDENTITY and deliberately not in
+  the map). `ThemePreview` writes the same map to its own subtree and reads no
+  `:root` var, which is what lets a light theme's card stay light on a dark
+  page. `themeVars.test.ts` asserts the map is exactly what `applyTheme` writes,
+  so the two cannot drift — a new colour slot lands in one place and every
+  surface gets it. Before the extraction nothing could render a theme except the
+  active one, which is why Settings had never had a swatch or a preview.
+- **The theme picker is a gallery, not a dropdown** (`theme/ThemeGallery.tsx`).
+  Cards carry a real `ThemePreview` and their own Edit / Duplicate / Export /
+  Delete, so an action sits next to the theme it acts on; Import is the only one
+  left on the page, because it belongs to no existing card. It is a `radiogroup`
+  and arrow keys ACTIVATE as they move, so browsing is a live preview rather
+  than a focus walk. Following the system shows TWO galleries, each filtered to
+  its own mode — the rule the old `pairOptions` enforced, because a pairing
+  whose halves share a mode never switches. **The row ids stay
+  `appearance.theme` / `.light` / `.dark`** or `settings.index.test.tsx` fails
+  and Settings search stops finding the picker.
+- **The theme editor's draft lives in a store** (`useThemeEditorStore`), for two
+  reasons. `app.closeOverlay`'s chain in `features/keymap/actions.ts` reads
+  *stores*, because a handler registered from a component runs BEFORE the
+  default runner and would take Escape ahead of the credential prompt — local
+  React state cannot join that chain, which is exactly why the old dialog grew
+  the `window.addEventListener("keydown")` that `design/modal.tsx` names as an
+  anti-pattern. And **closing must RESTORE**: `close()` re-applies the theme
+  that was live on open, so Escape, the backdrop and Cancel are one path; an
+  Escape that only unmounted would leave the abandoned draft painted on the
+  app. `save()` is the one exit that does not restore. The editor's branch sits
+  below the credential prompt's, pinned by a test.
+- **Contrast warnings advise, never block.** `theme/contrast.ts` measures the
+  four pairs that decide whether the app is readable (primary text on the
+  canvas, secondary and muted on a panel, button text on the accent) — not every
+  combination, because a report with twenty findings is one nobody reads. Save
+  is never disabled by a finding: a deliberately low-contrast theme is the
+  user's own call. A user never reads a colour-slot key; each finding carries
+  prose. `deriveTheme` is the guided start (base + accent) and recalculates
+  `accentInk` alone, preferring the base theme's own inks so derived themes stay
+  in the family — it is deliberately not a palette generator, because shifting
+  the greys too produces palettes nobody can predict or correct.
 - **One theme format.** `themePayload()` is the per-theme serialiser behind both
   `exportTheme` and the settings bundle; the bundle adds only `id`, because
   `activeThemeId` has to stay resolvable. `normalizeCustomThemes` is lenient in

--- a/docs/superpowers/plans/2026-09-09-theme-editor-revamp.md
+++ b/docs/superpowers/plans/2026-09-09-theme-editor-revamp.md
@@ -1,0 +1,2628 @@
+# Theme Editor Revamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make theme and settings export/import actually write and read files on
+every platform (#435), and rebuild theme creation around a visual gallery and an
+editor with a live preview, a guided start and contrast warnings.
+
+**Architecture:** A new pair of thin Rust commands (`read_user_file`,
+`write_user_file`) behind one frontend helper (`lib/userFile.ts`) replaces the
+`<a download>` blob click and the hidden `<input type="file">` at all five call
+sites. On the frontend, `themeVars(theme)` is extracted out of `applyTheme` so a
+single `ThemePreview` component can paint any theme into its own subtree —
+serving both the new gallery cards and the editor's preview pane. The editor's
+draft moves from local React state into a small Zustand store so Escape can
+reach it through `app.closeOverlay` and closing can restore the pre-draft theme.
+
+**Tech Stack:** Tauri 2 (Rust) + React 19/TypeScript, Zustand, Vitest
+(projects `unit` in jsdom and `docs` in node), `cargo test`, WebdriverIO e2e.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md`
+
+## Global Constraints
+
+- **Toolchain paths.** This session's Bash tool does not inherit the
+  interactive shell rc, and an isolated worktree refuses
+  `export PATH="$HOME/..."`. Call the binaries directly:
+  `~/Library/pnpm/pnpm` and `~/.cargo/bin/cargo`.
+- **Every IPC-crossing fn returns `AppResult<T>`.** Use the existing
+  `AppError::Io` and `AppError::InvalidPath`. **Add no new `AppError` variant** —
+  the TS union in `src/lib/errors.ts` must stay 1:1 with the Rust enum and
+  `test/appErrors.test.ts` fails the build for a mismatch.
+- **Never call `invoke` directly** from a feature. Add a typed wrapper to
+  `src/lib/tauri.ts` and call that.
+- **Never `Command::new` outside `src-tauri/src/proc.rs`.** Nothing in this plan
+  spawns a process; if you reach for one, you are off-plan.
+- **No native `<select>`/`<option>` in `src/`** — use `PGSelect` from `@/design`.
+  A guard test enforces it.
+- **No `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt` from
+  `@/design`. Every one reads a dismissal as "no answer", never as a choice.
+- **Design system is `src/design/`, imported from `@/design`.** Do not add
+  `src/components/ui/`. Never hardcode the accent hue — CSS vars only.
+- **Icons are `lucide-react` behind `PGIcon`.** `src/design/icons.tsx` is the
+  only file that may import lucide, and every `name` you pass must already be
+  declared in the `IconName` union or `test/iconSet.test.ts` fails the build.
+- **`@/` is the path alias for `src/`.** Use it.
+- **Commit style:** `feat(scope): …` / `fix(scope): …` / `test: …` / `docs: …`,
+  imperative subject under 72 chars, optional body with `**Why:**`, trailing
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+  **Pass the message with `git commit -F <file>`, never `-m`** — the Bash tool
+  evals the command, so a backtick in a `-m` body executes and hangs forever.
+- **New settings copy is user-facing prose.** A user never reads an enum name or
+  a token id in a banner or a hint.
+- **File-size cap:** `MAX_USER_FILE_BYTES = 4 * 1024 * 1024` (4 MiB), used
+  verbatim in Task 1 and cited in the docs in Task 12.
+
+---
+
+### Task 1: Backend file read/write commands
+
+**Files:**
+- Create: `src-tauri/src/commands/userfile.rs`
+- Modify: `src-tauri/src/commands/mod.rs` (add `pub mod userfile;`, alphabetical — between `update` and `watch`)
+- Modify: `src-tauri/src/lib.rs` (add two entries to `tauri::generate_handler![…]`, after the `commands::update::…` block)
+- Test: `src-tauri/tests/user_file.rs`
+
+**Interfaces:**
+- Consumes: `crate::error::{AppError, AppResult}` (both already exist).
+- Produces:
+  - `platypusgit_lib::commands::userfile::write_user_file(path: String, contents: String) -> AppResult<()>` (async)
+  - `platypusgit_lib::commands::userfile::read_user_file(path: String) -> AppResult<String>` (async)
+  - `platypusgit_lib::commands::userfile::MAX_USER_FILE_BYTES: u64`
+  - Tauri command names as seen from the frontend: `write_user_file`, `read_user_file`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/user_file.rs`:
+
+```rust
+//! Reading and writing a file the USER picked in a native dialog (#435).
+//!
+//! Theme and settings export used to write its file with a blob URL and an
+//! `<a download>` click, which WebKitGTK ignores — so on Linux the button did
+//! nothing at all. These commands are the native replacement, and the property
+//! worth asserting is that they are boring: an exact round trip, and a refusal
+//! rather than a surprise for every input that is not a writable file.
+
+use platypusgit_lib::commands::userfile::{read_user_file, write_user_file, MAX_USER_FILE_BYTES};
+use platypusgit_lib::error::AppError;
+
+#[tokio::test]
+async fn round_trips_a_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("my-theme.pgtheme.json");
+    let body = "{\n  \"name\": \"My theme\"\n}\n";
+
+    write_user_file(path.to_string_lossy().to_string(), body.to_string())
+        .await
+        .expect("write should succeed");
+
+    let read = read_user_file(path.to_string_lossy().to_string())
+        .await
+        .expect("read should succeed");
+    assert_eq!(read, body);
+}
+
+#[tokio::test]
+async fn write_truncates_an_existing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("theme.json");
+    let p = path.to_string_lossy().to_string();
+
+    write_user_file(p.clone(), "a-much-longer-first-write".to_string())
+        .await
+        .unwrap();
+    write_user_file(p.clone(), "short".to_string()).await.unwrap();
+
+    assert_eq!(read_user_file(p).await.unwrap(), "short");
+}
+
+#[tokio::test]
+async fn read_reports_a_missing_file_as_io() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nope.json");
+    match read_user_file(path.to_string_lossy().to_string()).await {
+        Err(AppError::Io(_)) => {}
+        other => panic!("expected Io for a missing file, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn read_refuses_a_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    match read_user_file(dir.path().to_string_lossy().to_string()).await {
+        Err(AppError::InvalidPath(_)) => {}
+        other => panic!("expected InvalidPath for a directory, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn read_refuses_an_oversized_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("huge.json");
+    // One byte over the cap is enough: the check is on metadata, so the test
+    // does not need to write a realistic 4 MiB of JSON to prove the refusal.
+    let big = vec![b'x'; (MAX_USER_FILE_BYTES + 1) as usize];
+    std::fs::write(&path, big).unwrap();
+
+    match read_user_file(path.to_string_lossy().to_string()).await {
+        Err(AppError::InvalidPath(m)) => assert!(
+            m.contains("too large"),
+            "the refusal should say why: {m}"
+        ),
+        other => panic!("expected InvalidPath for an oversized file, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_refuses_an_empty_path() {
+    match write_user_file(String::new(), "x".to_string()).await {
+        Err(AppError::InvalidPath(_)) => {}
+        other => panic!("expected InvalidPath for an empty path, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_does_not_create_parent_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("no-such-dir").join("theme.json");
+    match write_user_file(path.to_string_lossy().to_string(), "x".to_string()).await {
+        Err(AppError::Io(_)) => {}
+        other => panic!("expected Io when the parent is missing, got {other:?}"),
+    }
+    assert!(
+        !dir.path().join("no-such-dir").exists(),
+        "a webview string must not be able to mkdir"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml --test user_file`
+Expected: FAIL to compile — `unresolved import platypusgit_lib::commands::userfile`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src-tauri/src/commands/userfile.rs`:
+
+```rust
+//! Reading and writing one file the user picked in a native dialog (#435).
+//!
+//! Export used to be a browser trick: a `Blob`, an `<a download>` and a
+//! synthetic click. WebKitGTK ignores the `download` attribute on a blob URL,
+//! so on Linux "Export theme" did nothing — no file, no error, no log line. A
+//! webview is not a browser, and nothing about `<a download>` is contracted to
+//! work in one, so the fix is a real native path rather than a patch to the
+//! click.
+//!
+//! **The trust model, stated plainly:** these take an absolute path the USER
+//! chose in a native save or open dialog (`@tauri-apps/plugin-dialog`, behind
+//! `src/lib/userFile.ts`). Nothing in the frontend may synthesise a path for
+//! them. That is why `write_user_file` refuses to create parent directories:
+//! a dialog's path always has a parent that exists, so a request to invent one
+//! is a request that did not come from a dialog.
+
+use crate::error::{AppError, AppResult};
+
+/// The largest file `read_user_file` will hand to the webview.
+///
+/// A settings bundle with every custom theme is a few tens of kilobytes. The cap
+/// exists because the path comes from a file picker and a mis-picked disk image
+/// should be a refusal, not a webview that swallows a gigabyte of bytes.
+pub const MAX_USER_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Write `contents` to `path`, creating or truncating it.
+#[tauri::command]
+pub async fn write_user_file(path: String, contents: String) -> AppResult<()> {
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidPath("no file was chosen".into()));
+    }
+    // libgit2 is not involved here, but the reason for spawn_blocking is the
+    // same: std::fs is sync, and blocking the async runtime's worker on a slow
+    // network volume would stall every other command with it.
+    tokio::task::spawn_blocking(move || {
+        std::fs::write(&path, contents.as_bytes())
+            .map_err(|e| AppError::Io(format!("cannot write {path}: {e}")))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("write task failed: {e}")))?
+}
+
+/// Read `path` as UTF-8 text, refusing anything that is not a file we can hand
+/// to the webview whole.
+#[tauri::command]
+pub async fn read_user_file(path: String) -> AppResult<String> {
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidPath("no file was chosen".into()));
+    }
+    tokio::task::spawn_blocking(move || {
+        let meta = std::fs::metadata(&path)
+            .map_err(|e| AppError::Io(format!("cannot read {path}: {e}")))?;
+        if meta.is_dir() {
+            return Err(AppError::InvalidPath(format!("{path} is a folder, not a file")));
+        }
+        if meta.len() > MAX_USER_FILE_BYTES {
+            return Err(AppError::InvalidPath(format!(
+                "{path} is too large to read ({} bytes; the limit is {MAX_USER_FILE_BYTES})",
+                meta.len()
+            )));
+        }
+        std::fs::read_to_string(&path)
+            .map_err(|e| AppError::Io(format!("cannot read {path}: {e}")))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("read task failed: {e}")))?
+}
+```
+
+- [ ] **Step 4: Register the module and the commands**
+
+In `src-tauri/src/commands/mod.rs`, add between `pub mod update;` and `pub mod watch;`:
+
+```rust
+pub mod userfile;
+```
+
+In `src-tauri/src/lib.rs`, inside `tauri::generate_handler![…]`, add after the
+last `commands::update::…` entry:
+
+```rust
+            commands::userfile::read_user_file,
+            commands::userfile::write_user_file,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml --test user_file`
+Expected: PASS, 7 tests.
+
+Then confirm nothing else broke:
+Run: `~/.cargo/bin/cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
+Expected: no errors. (This crate is broadly dirty on warnings already, and CI
+runs no clippy or fmt — do **not** `cargo fmt` a focused diff.)
+
+- [ ] **Step 6: Commit**
+
+Write the message to a file first (backticks in a `-m` body hang the tool):
+
+```bash
+printf '%s\n' 'feat(userfile): read and write a user-picked file natively' '' 'Why: export wrote its file with a blob URL and an <a download> click, which' 'WebKitGTK ignores -- #435 is that click doing nothing on Linux. A webview is' 'not a browser, so the fix is a native path, not a patch to the click.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src-tauri/src/commands/userfile.rs src-tauri/src/commands/mod.rs src-tauri/src/lib.rs src-tauri/tests/user_file.rs
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 2: The frontend file path — `lib/userFile.ts`
+
+**Files:**
+- Create: `src/lib/userFile.ts`
+- Create: `src/lib/userFile.test.ts`
+- Modify: `src/lib/tauri.ts` (two wrappers at the end, beside `revealLogFile`)
+- Modify: `src-tauri/capabilities/default.json` (add `dialog:allow-save`)
+- Modify: `src/test/dialogMock.ts` (make `save()` settable, like `open()`)
+
+**Interfaces:**
+- Consumes: `read_user_file` / `write_user_file` from Task 1.
+- Produces:
+  - `src/lib/tauri.ts`: `readUserFile(path: string): Promise<string>`,
+    `writeUserFile(path: string, contents: string): Promise<void>`
+  - `src/lib/userFile.ts`:
+    - `type FileFilter = { name: string; extensions: string[] }`
+    - `saveTextFile(opts: { defaultName: string; contents: string; filters?: FileFilter[] }): Promise<string | null>`
+    - `openTextFile(opts?: { filters?: FileFilter[] }): Promise<{ path: string; contents: string } | null>`
+    - `THEME_FILE_FILTERS: FileFilter[]`, `SETTINGS_FILE_FILTERS: FileFilter[]`
+  - `src/test/dialogMock.ts`: `mockDialogSave(result: string | null): void`
+
+- [ ] **Step 1: Make the dialog mock's `save()` settable**
+
+`src/test/dialogMock.ts` currently hard-codes `save()` to `null`. Replace its
+body with:
+
+```ts
+// Tauri dialog plugin mock. Each test sets the result `open()` or `save()`
+// should return.
+
+type OpenResult = string | string[] | null;
+
+let openResult: OpenResult = null;
+let saveResult: string | null = null;
+let lastSaveOptions: unknown = null;
+
+export function mockDialogOpen(result: OpenResult): void {
+  openResult = result;
+}
+
+/** The path the native save dialog should pretend the user chose. */
+export function mockDialogSave(result: string | null): void {
+  saveResult = result;
+}
+
+/** What `save()` was last called with, so a test can assert the default name. */
+export function lastDialogSaveOptions(): unknown {
+  return lastSaveOptions;
+}
+
+export function resetDialogMock(): void {
+  openResult = null;
+  saveResult = null;
+  lastSaveOptions = null;
+}
+
+export async function open(): Promise<OpenResult> {
+  return openResult;
+}
+
+export async function save(options?: unknown): Promise<string | null> {
+  lastSaveOptions = options ?? null;
+  return saveResult;
+}
+
+export async function ask(): Promise<boolean> {
+  return false;
+}
+
+export async function confirm(): Promise<boolean> {
+  return false;
+}
+
+export async function message(): Promise<void> {
+  return;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/lib/userFile.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockDialogOpen, mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import {
+  openTextFile,
+  saveTextFile,
+  THEME_FILE_FILTERS,
+} from "./userFile";
+
+describe("saveTextFile", () => {
+  beforeEach(() => {
+    mockDialogSave(null);
+  });
+
+  it("returns null and writes nothing when the user cancels", async () => {
+    mockDialogSave(null);
+    const path = await saveTextFile({
+      defaultName: "my-theme.pgtheme.json",
+      contents: "{}",
+    });
+    expect(path).toBeNull();
+    expect(invokeCalls().some((c) => c.cmd === "write_user_file")).toBe(false);
+  });
+
+  it("writes the contents to the chosen path and returns it", async () => {
+    mockDialogSave("/home/you/my-theme.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    const path = await saveTextFile({
+      defaultName: "my-theme.pgtheme.json",
+      contents: '{"name":"My theme"}',
+      filters: THEME_FILE_FILTERS,
+    });
+
+    expect(path).toBe("/home/you/my-theme.pgtheme.json");
+    const call = invokeCalls().find((c) => c.cmd === "write_user_file");
+    expect(call?.args).toEqual({
+      path: "/home/you/my-theme.pgtheme.json",
+      contents: '{"name":"My theme"}',
+    });
+  });
+});
+
+describe("openTextFile", () => {
+  it("returns null when the user cancels", async () => {
+    mockDialogOpen(null);
+    expect(await openTextFile()).toBeNull();
+  });
+
+  it("reads the chosen file and returns its path and contents", async () => {
+    mockDialogOpen("/home/you/theme.pgtheme.json");
+    mockInvoke("read_user_file", () => '{"name":"From disk"}');
+
+    const got = await openTextFile({ filters: THEME_FILE_FILTERS });
+
+    expect(got).toEqual({
+      path: "/home/you/theme.pgtheme.json",
+      contents: '{"name":"From disk"}',
+    });
+  });
+
+  it("takes the first path when the dialog answers with an array", async () => {
+    // `open()` returns string[] when multiple:true. We never ask for multiple,
+    // but the plugin's type admits it, and reading `[0]` is cheaper than
+    // trusting a cast.
+    mockDialogOpen(["/home/you/a.json", "/home/you/b.json"]);
+    mockInvoke("read_user_file", () => "{}");
+
+    const got = await openTextFile();
+    expect(got?.path).toBe("/home/you/a.json");
+  });
+});
+```
+
+Two things about `src/test/invokeMock.ts`, both verified against the file and
+both easy to get wrong: **`mockInvoke`'s second argument is a HANDLER
+function**, not a value — `mockInvoke("read_user_file", () => json)`, and an
+unregistered command **throws** rather than returning undefined, so every
+command a test exercises needs a handler. The call log accessor is
+`getInvokeCalls()`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/lib/userFile.test.ts`
+Expected: FAIL — cannot resolve `./userFile`.
+
+- [ ] **Step 4: Add the typed invoke wrappers**
+
+At the end of `src/lib/tauri.ts`, after `revealLogFile`:
+
+```ts
+/**
+ * Read a file the user picked in a native open dialog.
+ *
+ * Capped at 4 MiB by the backend, and a folder is a refusal — see
+ * `commands/userfile.rs`. Go through `lib/userFile.ts` rather than calling this
+ * directly: the path has to come from a dialog.
+ */
+export async function readUserFile(path: string): Promise<string> {
+  return invoke<string>("read_user_file", { path });
+}
+
+/** Write a file to the path the user picked in a native save dialog. */
+export async function writeUserFile(path: string, contents: string): Promise<void> {
+  return invoke<void>("write_user_file", { path, contents });
+}
+```
+
+- [ ] **Step 5: Write the implementation**
+
+Create `src/lib/userFile.ts`:
+
+```ts
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+
+import { readUserFile, writeUserFile } from "./tauri";
+
+/**
+ * The ONE way this app puts a file on disk or reads one back (#435).
+ *
+ * Export used to be a `Blob`, an `<a download>` and a synthetic click, and
+ * import a hidden `<input type="file">`. The download attribute is ignored by
+ * WebKitGTK, so on Linux every export button did nothing at all — silently,
+ * with no error to report. Both are browser affordances in an app that has
+ * native dialogs, so both are gone; `test/fileSave.test.ts` fails the build if
+ * either comes back.
+ *
+ * A cancelled dialog resolves to `null`, never a throw: a dismissal is "no
+ * answer", the same reading `pgConfirm` and `pgPrompt` give it. Every save
+ * returns the PATH, because "your settings were exported" is useless without
+ * saying to what.
+ */
+export type FileFilter = { name: string; extensions: string[] };
+
+/** Single-theme files. The double extension is what the app has always written. */
+export const THEME_FILE_FILTERS: FileFilter[] = [
+  { name: "PlatypusGit theme", extensions: ["pgtheme.json", "json"] },
+];
+
+/** Whole-settings bundles (#254). */
+export const SETTINGS_FILE_FILTERS: FileFilter[] = [
+  { name: "PlatypusGit settings", extensions: ["json"] },
+];
+
+/**
+ * Ask where to put a text file, then write it. Resolves to the chosen path, or
+ * `null` when the user cancelled.
+ */
+export async function saveTextFile(opts: {
+  defaultName: string;
+  contents: string;
+  filters?: FileFilter[];
+}): Promise<string | null> {
+  const path = await saveDialog({
+    defaultPath: opts.defaultName,
+    filters: opts.filters,
+  });
+  if (!path) return null;
+  await writeUserFile(path, opts.contents);
+  return path;
+}
+
+/**
+ * Ask for a text file, then read it. Resolves to `null` when the user
+ * cancelled.
+ */
+export async function openTextFile(opts?: {
+  filters?: FileFilter[];
+}): Promise<{ path: string; contents: string } | null> {
+  const picked = await openDialog({
+    multiple: false,
+    directory: false,
+    filters: opts?.filters,
+  });
+  // `open()`'s type admits string[] (multiple: true). We never ask for it, but
+  // reading [0] is cheaper than trusting the cast.
+  const path = Array.isArray(picked) ? picked[0] : picked;
+  if (!path) return null;
+  return { path, contents: await readUserFile(path) };
+}
+```
+
+- [ ] **Step 6: Grant the save permission**
+
+In `src-tauri/capabilities/default.json`, add `"dialog:allow-save"` to
+`permissions`, directly after `"dialog:allow-open"`. Without it the native save
+dialog is denied at runtime and the button fails exactly the way #435 describes
+— which is the failure this whole task exists to end.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/lib/userFile.test.ts`
+Expected: PASS, 5 tests.
+
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+printf '%s\n' 'feat(files): one native save and open path for every export' '' 'Why: a webview is not a browser -- <a download> and <input type=file> are' 'browser affordances this app had no reason to use, and the first of them is' 'silently ignored by WebKitGTK (#435). Every save returns the path so a' 'surface can name the file instead of guessing at a downloads folder.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/lib/userFile.ts src/lib/userFile.test.ts src/lib/tauri.ts src-tauri/capabilities/default.json src/test/dialogMock.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 3: Move theme + settings export onto the native path
+
+**Files:**
+- Create: `src/features/settings/themeFiles.ts`
+- Create: `src/features/settings/themeFiles.test.ts`
+- Modify: `src/features/settings/useSettingsStore.ts` (delete `downloadTheme` and `downloadSettings` — both the interface declarations near lines 1027-1040 and the implementations near lines 1843 and 1904)
+- Modify: `src/features/settings/pages/appearance.tsx` (export/import buttons, drop the `<input type="file">`)
+- Modify: `src/features/settings/pages/backup.tsx` (export/import buttons, drop the `<input type="file">`)
+- Modify: `src/features/settings/useSettingsStore.export.test.ts` (the `downloadSettings` describe block near line 689)
+- Modify: `src/screens/Settings.export.test.tsx` (the file-input import test near line 256, and the `file.text()`→`FileReader` bridge at the top of the file if nothing else needs it)
+
+**Interfaces:**
+- Consumes: `saveTextFile`, `openTextFile`, `THEME_FILE_FILTERS`,
+  `SETTINGS_FILE_FILTERS` from Task 2; `exportTheme(id)`, `exportSettings(opts)`,
+  `importThemeJson(json)`, `importSettings(json)` from the settings store
+  (all unchanged, all still pure).
+- Produces:
+  - `themeFileName(name: string): string` — the slug plus `.pgtheme.json`
+  - `exportThemeToFile(id: string): Promise<string | null>`
+  - `exportThemeDraftToFile(draft: { name: string; mode: "dark" | "light"; colors: ThemeColors }): Promise<string | null>`
+  - `importThemeFromFile(): Promise<ThemeDef | null>`
+  - `exportSettingsToFile(opts?: SettingsExportOptions): Promise<string | null>`
+  - `importSettingsFromFile(): Promise<SettingsImportReport | null>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/themeFiles.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockDialogOpen, mockDialogSave, lastDialogSaveOptions } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { useSettingsStore } from "./useSettingsStore";
+import {
+  exportThemeToFile,
+  importThemeFromFile,
+  themeFileName,
+} from "./themeFiles";
+
+describe("themeFileName", () => {
+  it("slugs the theme name and keeps the double extension", () => {
+    expect(themeFileName("My Cool Theme")).toBe("my-cool-theme.pgtheme.json");
+  });
+
+  it("collapses punctuation and trims the edges", () => {
+    expect(themeFileName("  Dark · Cool!!  ")).toBe("dark-cool.pgtheme.json");
+  });
+
+  it("falls back to a usable name when the slug empties out", () => {
+    expect(themeFileName("···")).toBe("theme.pgtheme.json");
+  });
+});
+
+describe("exportThemeToFile", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+  });
+
+  it("offers the slugged filename and writes the exported JSON", async () => {
+    mockDialogSave("/home/you/dark-cool.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    const path = await exportThemeToFile("dark-cool");
+
+    expect(path).toBe("/home/you/dark-cool.pgtheme.json");
+    expect(lastDialogSaveOptions()).toMatchObject({
+      defaultPath: "dark-cool.pgtheme.json",
+    });
+    const call = invokeCalls().find((c) => c.cmd === "write_user_file");
+    const written = JSON.parse((call?.args as { contents: string }).contents);
+    expect(written.name).toBe("Dark · Cool");
+    expect(written.colors.accent).toBe("#5aa8e8");
+  });
+
+  it("returns null and writes nothing when the user cancels", async () => {
+    mockDialogSave(null);
+    expect(await exportThemeToFile("dark-cool")).toBeNull();
+    expect(invokeCalls().some((c) => c.cmd === "write_user_file")).toBe(false);
+  });
+});
+
+describe("importThemeFromFile", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+  });
+
+  it("adds the theme in the file to the store and returns it", async () => {
+    mockDialogOpen("/home/you/from-disk.pgtheme.json");
+    mockInvoke("read_user_file", () =>
+      JSON.stringify({
+        version: 1,
+        name: "From disk",
+        mode: "dark",
+        colors: { ...useSettingsStore.getState().getActiveTheme().colors },
+      }),
+    );
+
+    const theme = await importThemeFromFile();
+
+    expect(theme?.name).toBe("From disk");
+    expect(
+      useSettingsStore.getState().customThemes.some((t) => t.name === "From disk"),
+    ).toBe(true);
+  });
+
+  it("returns null when the user cancels, leaving the store alone", async () => {
+    mockDialogOpen(null);
+    expect(await importThemeFromFile()).toBeNull();
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/themeFiles.test.ts`
+Expected: FAIL — cannot resolve `./themeFiles`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/settings/themeFiles.ts`:
+
+```ts
+import {
+  SETTINGS_FILE_FILTERS,
+  THEME_FILE_FILTERS,
+  openTextFile,
+  saveTextFile,
+} from "@/lib/userFile";
+
+import {
+  useSettingsStore,
+  type SettingsExportOptions,
+  type SettingsImportReport,
+  type ThemeColors,
+  type ThemeDef,
+} from "./useSettingsStore";
+
+/**
+ * The side-effecting half of theme and settings export (#435).
+ *
+ * The store keeps the PURE serialisers — `exportTheme`, `exportSettings` — and
+ * this module owns the dialogs and the bytes. Same split `features/report/`
+ * makes between `report.ts` and `fileReport.ts`, and for the same reason: a
+ * pure function is what the tests can assert on cheaply, and the file path is
+ * what changes per platform.
+ *
+ * `downloadTheme` and `downloadSettings` used to live on the store and wrote
+ * their file with an `<a download>` click that WebKitGTK ignores. They are
+ * REMOVED rather than kept as aliases: a working export and a broken one under
+ * two names is worse than either.
+ */
+
+/** `My Cool Theme` → `my-cool-theme.pgtheme.json`. */
+export function themeFileName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return `${slug || "theme"}.pgtheme.json`;
+}
+
+/** Export a saved theme. Resolves to the path written, or `null` on cancel. */
+export async function exportThemeToFile(id: string): Promise<string | null> {
+  const store = useSettingsStore.getState();
+  const contents = store.exportTheme(id);
+  const theme = [...store.customThemes, ...BUILTIN_LOOKUP()].find((t) => t.id === id);
+  return saveTextFile({
+    defaultName: themeFileName(theme?.name ?? "theme"),
+    contents,
+    filters: THEME_FILE_FILTERS,
+  });
+}
+
+/**
+ * Export the editor's UNSAVED draft — the round trip through an external editor
+ * that #435's reporter was trying to make.
+ */
+export async function exportThemeDraftToFile(draft: {
+  name: string;
+  mode: "dark" | "light";
+  colors: ThemeColors;
+}): Promise<string | null> {
+  const contents = JSON.stringify(
+    {
+      $schema: "https://platypusgit.dev/theme.schema.json",
+      version: 1,
+      name: draft.name,
+      mode: draft.mode,
+      colors: draft.colors,
+    },
+    null,
+    2,
+  );
+  return saveTextFile({
+    defaultName: themeFileName(draft.name),
+    contents,
+    filters: THEME_FILE_FILTERS,
+  });
+}
+
+/** Import a theme file into the store. `null` on cancel; throws on bad JSON. */
+export async function importThemeFromFile(): Promise<ThemeDef | null> {
+  const picked = await openTextFile({ filters: THEME_FILE_FILTERS });
+  if (!picked) return null;
+  return useSettingsStore.getState().importThemeJson(picked.contents);
+}
+
+/** Export the whole settings bundle. `null` on cancel. */
+export async function exportSettingsToFile(
+  opts?: SettingsExportOptions,
+): Promise<string | null> {
+  const contents = useSettingsStore.getState().exportSettings(opts);
+  const stamp = new Date().toISOString().slice(0, 10);
+  return saveTextFile({
+    defaultName: `platypusgit-settings-${stamp}.json`,
+    contents,
+    filters: SETTINGS_FILE_FILTERS,
+  });
+}
+
+/** Import a settings bundle. `null` on cancel; throws with a readable message. */
+export async function importSettingsFromFile(): Promise<SettingsImportReport | null> {
+  const picked = await openTextFile({ filters: SETTINGS_FILE_FILTERS });
+  if (!picked) return null;
+  return useSettingsStore.getState().importSettings(picked.contents);
+}
+```
+
+Replace the `BUILTIN_LOOKUP()` placeholder with the real lookup: import
+`BUILTIN_THEMES` from `./useSettingsStore` and write
+
+```ts
+  const theme = [...BUILTIN_THEMES, ...store.customThemes].find((t) => t.id === id);
+```
+
+(There is no exported `findTheme` — it is module-private in the store. Do not
+export it just for this; the two-array spread is the same thing the Appearance
+page already does to build its options.)
+
+- [ ] **Step 4: Delete the broken store methods**
+
+In `src/features/settings/useSettingsStore.ts`:
+- Remove `downloadTheme: (id: string) => void;` from the interface.
+- Remove `downloadSettings: (opts?: SettingsExportOptions) => string;` and its
+  doc comment from the interface.
+- Remove both implementations (`downloadTheme(id) { … }` and
+  `downloadSettings(opts) { … }`) — every line, including the `Blob`,
+  `createObjectURL`, `a.download` and `revokeObjectURL` calls.
+
+Keep `exportTheme` and `exportSettings` exactly as they are.
+
+- [ ] **Step 5: Rewire the Appearance page's export/import**
+
+In `src/features/settings/pages/appearance.tsx`:
+- Delete `fileInputRef`, `onImportClick`, `onImportFile` and the
+  `<input ref={fileInputRef} type="file" … />` element.
+- Import `{ exportThemeToFile, importThemeFromFile } from "@/features/settings/themeFiles"`.
+- Replace the two button handlers:
+
+```tsx
+        <PGButton
+          size="sm"
+          variant="default"
+          icon="download"
+          onClick={() => {
+            void (async () => {
+              try {
+                const path = await exportThemeToFile(active.id);
+                if (path) pgFlash(`Exported to ${path}`);
+              } catch (err) {
+                pgFlash(`Export failed: ${appErrorMessage(err)}`);
+              }
+            })();
+          }}
+          title="Write this theme to a .pgtheme.json file"
+        >
+          Export…
+        </PGButton>
+        <PGButton
+          size="sm"
+          variant="default"
+          icon="upload"
+          onClick={() => {
+            void (async () => {
+              try {
+                const theme = await importThemeFromFile();
+                if (theme) pgFlash(`Imported “${theme.name}”`);
+              } catch (err) {
+                pgFlash(`Import failed: ${appErrorMessage(err)}`);
+              }
+            })();
+          }}
+          title="Read a .pgtheme.json file"
+        >
+          Import…
+        </PGButton>
+```
+
+`Export` gains an ellipsis because it now opens a dialog, which is what an
+ellipsis means everywhere else in this app.
+
+- [ ] **Step 6: Rewire the Backup page's export/import**
+
+In `src/features/settings/pages/backup.tsx`:
+- Delete `fileInputRef`, the `onImportFile` handler's file-reading half and the
+  `<input … data-testid="settings-import-input" type="file" />` element.
+- Import `{ exportSettingsToFile, importSettingsFromFile } from "@/features/settings/themeFiles"`.
+- `onExport` becomes async and records the **path** rather than a bare filename;
+  the hint's copy changes from "Saved `<name>` to your downloads folder." to
+  "Saved to `<path>`." — the old sentence was a guess about a folder the app
+  never chose, and now it knows.
+- `Import settings…`'s handler calls `importSettingsFromFile()`, keeps the
+  existing `report` / `failure` state exactly as it is, and does nothing at all
+  when the result is `null` (cancelled).
+
+Keep every `data-testid` that survives (`settings-import-error`), and keep the
+`ImportReport` rendering untouched.
+
+- [ ] **Step 7: Update the tests that drove the deleted code**
+
+- `src/features/settings/useSettingsStore.export.test.ts`: delete the
+  `describe("downloadSettings", …)` block. The pure `exportSettings` tests above
+  it stay — they are the ones that matter, and Task 3's own test file covers the
+  file path.
+- `src/screens/Settings.export.test.tsx`: the import test drove
+  `fireEvent.change` on the hidden input. Rewrite it to drive the button:
+  `mockDialogOpen("/tmp/settings.json")`, `mockInvoke("read_user_file", () => json)`,
+  click `Import settings…`, then assert the same report text it asserted before.
+  If the `file.text()`→`FileReader` bridge at the top of the file has no
+  remaining user, delete it — jsdom's missing `Blob.text` stops being this
+  suite's problem once no surface reads a `File`.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings src/screens/Settings.export.test.tsx src/lib/userFile.test.ts`
+Expected: PASS. Every reference to `downloadTheme`/`downloadSettings` is gone.
+
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+printf '%s\n' 'fix(settings): export themes and settings through a native save dialog' '' 'Fixes #435.' '' 'Why: downloadTheme and downloadSettings wrote their file with an <a download>' 'click that WebKitGTK ignores, so on Linux both buttons did nothing. They are' 'removed rather than aliased -- a working export and a broken one under two' 'names is worse than either -- and the surfaces now name the path they wrote.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add -A src/features/settings src/screens/Settings.export.test.tsx
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 4: The guard test
+
+**Files:**
+- Create: `test/fileSave.test.ts`
+
+**Interfaces:**
+- Consumes: nothing at runtime — it reads the tree from disk, like
+  `test/privacy.test.ts`.
+- Produces: a build failure for a reintroduced browser download or file input.
+
+- [ ] **Step 1: Write the test**
+
+Create `test/fileSave.test.ts`. It runs in the `docs` vitest project (node env,
+`test/**/*.test.ts`), so it may use `node:fs` freely:
+
+```ts
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * One file save/open path (#435).
+ *
+ * Theme and settings export used to write its file with a `Blob`, an
+ * `<a download>` and a synthetic click; import used a hidden
+ * `<input type="file">`. WebKitGTK ignores the download attribute, so on Linux
+ * every export button did nothing — silently, which is why the bug survived a
+ * release. Both are browser affordances in an app that has native dialogs.
+ *
+ * So this is a guard in the same family as the `Command::new` and native
+ * `<select>` guards: the rule is only as good as the test that fails the build
+ * for breaking it.
+ */
+
+const SRC = join(process.cwd(), "src");
+
+/** Every shipped `.ts`/`.tsx` under `src/`, tests and mocks excluded. */
+function shippedFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      // `src/test/` is the unit suite's own harness, not shipped code.
+      if (entry === "test") continue;
+      shippedFiles(path, out);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry)) continue;
+    if (/\.test\.tsx?$/.test(entry)) continue;
+    out.push(path);
+  }
+  return out;
+}
+
+const FORBIDDEN: { pattern: RegExp; what: string }[] = [
+  {
+    pattern: /URL\.createObjectURL/,
+    what: "a blob URL for a download — WebKitGTK ignores <a download>",
+  },
+  {
+    pattern: /\.download\s*=/,
+    what: "an <a download> assignment — use saveTextFile from @/lib/userFile",
+  },
+  {
+    pattern: /type=["']file["']/,
+    what: "an <input type=\"file\"> — use openTextFile from @/lib/userFile",
+  },
+];
+
+describe("one file save/open path", () => {
+  const files = shippedFiles(SRC);
+
+  it("finds shipped source to check", () => {
+    // A traversal bug that returns [] would make every assertion below pass
+    // while asserting nothing.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  for (const { pattern, what } of FORBIDDEN) {
+    it(`no shipped file under src/ uses ${what}`, () => {
+      const offenders = files.filter((f) => pattern.test(readFileSync(f, "utf8")));
+      expect(
+        offenders.map((f) => f.slice(process.cwd().length + 1)),
+        `Use src/lib/userFile.ts (saveTextFile / openTextFile) instead. See docs/dev/frontend.md.`,
+      ).toEqual([]);
+    });
+  }
+
+  it("lib/userFile.ts is the only module importing the dialog plugin for file bytes", () => {
+    const importers = files.filter((f) => {
+      const body = readFileSync(f, "utf8");
+      return /from ["']@tauri-apps\/plugin-dialog["']/.test(body) && /\bsave\b/.test(body);
+    });
+    expect(importers.map((f) => f.slice(process.cwd().length + 1))).toEqual([
+      "src/lib/userFile.ts",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it passes on the current tree**
+
+Run: `~/Library/pnpm/pnpm vitest run --project docs test/fileSave.test.ts`
+Expected: PASS. If it fails, a caller was missed in Task 3 — fix the caller, not
+the test.
+
+- [ ] **Step 3: Plant a violation and confirm the guard catches it**
+
+A passing guard test proves nothing until you have watched it fail. **Commit
+Task 4 first** (next step) so `git checkout --` cannot eat uncommitted work,
+then:
+
+```bash
+printf '%s\n' 'const a = document.createElement("a"); a.download = "x.json";' >> src/lib/revealWindow.tsx
+~/Library/pnpm/pnpm vitest run --project docs test/fileSave.test.ts
+```
+
+Expected: FAIL, naming `src/lib/revealWindow.tsx`. Then restore:
+
+```bash
+git checkout -- src/lib/revealWindow.tsx
+```
+
+Re-run to confirm green, and note in the commit trailer or the PR body which
+assertion caught it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+printf '%s\n' 'test(files): fail the build for a browser download or file input' '' 'Why: the rule is only as good as the test. #435 survived a release because' 'the broken export failed silently, and the same anchor-click pattern is the' 'obvious thing to reach for again. Planted a download assignment to confirm' 'the guard names the offending file.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add test/fileSave.test.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 5: Extract `themeVars` from `applyTheme`
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts` (`applyTheme`, around lines 488-530)
+- Create: `src/features/settings/theme/themeVars.test.ts`
+
+**Interfaces:**
+- Consumes: `ThemeDef`, `ThemeColors`, `SEMANTIC_TOKENS`, `SELECTION_TOKENS`,
+  `SYNTAX_TOKENS`, `LOGO_PRIMARY`, `LOGO_SECONDARY` — all already in the store
+  module.
+- Produces: `themeVars(theme: ThemeDef): Record<string, string>`, exported from
+  `useSettingsStore.ts`. `applyTheme(theme: ThemeDef): void` keeps its exact
+  signature and behaviour.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/themeVars.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILTIN_THEMES,
+  THEME_COLOR_FIELDS,
+  applyTheme,
+  themeVars,
+} from "@/features/settings/useSettingsStore";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("themeVars", () => {
+  it("carries every editable colour slot", () => {
+    const vars = themeVars(dark);
+    const values = new Set(Object.values(vars));
+    for (const field of THEME_COLOR_FIELDS) {
+      expect(
+        values.has(dark.colors[field.key]!),
+        `no CSS var carries ${field.key}`,
+      ).toBe(true);
+    }
+  });
+
+  it("maps the slots onto the vars the app actually reads", () => {
+    const vars = themeVars(dark);
+    expect(vars["--bg-0"]).toBe(dark.colors.bg0);
+    expect(vars["--bg-titlebar"]).toBe(dark.colors.titlebar);
+    expect(vars["--fg-0"]).toBe(dark.colors.fg0);
+    expect(vars["--border-1"]).toBe(dark.colors.border1);
+    expect(vars["--accent"]).toBe(dark.colors.accent);
+    expect(vars["--accent-ink"]).toBe(dark.colors.accentInk);
+  });
+
+  it("calibrates the semantic tokens per MODE, not per theme", () => {
+    expect(themeVars(dark)["--git-added"]).not.toBe(themeVars(light)["--git-added"]);
+    const otherDark = BUILTIN_THEMES.find((t) => t.id === "dark-warm")!;
+    expect(themeVars(otherDark)["--git-added"]).toBe(themeVars(dark)["--git-added"]);
+  });
+
+  it("fills the logo slots for a theme persisted before they existed", () => {
+    const legacy = {
+      ...dark,
+      colors: { ...dark.colors, logo: undefined, logo2: undefined },
+    } as typeof dark;
+    const vars = themeVars(legacy);
+    expect(vars["--logo"]).toBeTruthy();
+    expect(vars["--logo-2"]).toBeTruthy();
+  });
+
+  it("is exactly what applyTheme writes to :root", () => {
+    // The whole point of the extraction: a preview painted from this map and
+    // the live app painted by applyTheme cannot drift, because there is one
+    // map. If someone adds a setProperty call to applyTheme without adding it
+    // here, this fails.
+    document.documentElement.style.cssText = "";
+    applyTheme(light);
+    const root = document.documentElement.style;
+    const vars = themeVars(light);
+    expect(Object.keys(vars).length).toBeGreaterThan(0);
+    for (const [name, value] of Object.entries(vars)) {
+      expect(root.getPropertyValue(name), `applyTheme did not write ${name}`).toBe(value);
+    }
+    expect(root.length).toBe(Object.keys(vars).length);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/themeVars.test.ts`
+Expected: FAIL — `themeVars` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the body of `applyTheme` in `useSettingsStore.ts` with a map builder
+plus a writer. Keep `applyTheme`'s doc comment and add one for `themeVars`:
+
+```ts
+/**
+ * Every CSS var a theme sets, as a plain map.
+ *
+ * Extracted out of `applyTheme` so a theme can be painted somewhere OTHER than
+ * `:root` — a gallery card, the editor's preview pane — without a second copy
+ * of the slot-to-var mapping. `themeVars.test.ts` asserts this map is exactly
+ * what `applyTheme` writes, so the two cannot drift: a new colour slot or a new
+ * derived token lands here and every surface gets it.
+ */
+export function themeVars(theme: ThemeDef): Record<string, string> {
+  const c = theme.colors;
+  // Mode-calibrated semantics + accent-derived selection tints. Written on
+  // every apply (not only on a mode change) so switching dark → light → dark
+  // can't leave a stale calibration behind.
+  const mode = theme.mode === "light" ? "light" : "dark";
+  return {
+    "--bg-0": c.bg0,
+    "--bg-1": c.bg1,
+    "--bg-2": c.bg2,
+    "--bg-3": c.bg3,
+    "--bg-4": c.bg4,
+    "--bg-titlebar": c.titlebar,
+    "--fg-0": c.fg0,
+    "--fg-1": c.fg1,
+    "--fg-2": c.fg2,
+    "--fg-3": c.fg3,
+    "--fg-4": c.fg4,
+    "--border-0": c.border0,
+    "--border-1": c.border1,
+    "--border-2": c.border2,
+    "--accent": c.accent,
+    "--accent-ink": c.accentInk,
+    // logo colors fall back to the brand palette for themes persisted before
+    // the logo slots existed.
+    "--logo": c.logo ?? LOGO_PRIMARY,
+    "--logo-2": c.logo2 ?? LOGO_SECONDARY,
+    "--ring": `0 0 0 2px ${c.accent}80`,
+    ...SEMANTIC_TOKENS[mode],
+    ...SELECTION_TOKENS[mode],
+    ...SYNTAX_TOKENS[mode],
+  };
+}
+
+/** Apply theme by writing every CSS var it sets to `:root`. */
+export function applyTheme(theme: ThemeDef) {
+  const root = document.documentElement;
+  for (const [name, value] of Object.entries(themeVars(theme))) {
+    root.style.setProperty(name, value);
+  }
+}
+```
+
+**Before deleting the old body, diff it against the map.** Read the current
+`applyTheme` line by line and confirm every `setProperty` call it makes has a
+key above — including anything written after the `SYNTAX_TOKENS` loop that this
+plan's excerpt did not show. The final assertion in Step 1 will catch an
+omission, but only if you have not also dropped the var from the map.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/themeVars.test.ts src/features/settings`
+Expected: PASS, including the existing `themePreference.test.ts` and
+`theme.semantics.test.ts` — those two are what prove `applyTheme` still behaves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+printf '%s\n' 'refactor(theme): make a theme paintable somewhere other than :root' '' 'Why: nothing could render a theme except the active one, which is why there' 'has never been a preview or a swatch anywhere. themeVars is the map and' 'applyTheme is one writer of it; a test pins the two together so a gallery' 'card and the live app cannot drift.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/useSettingsStore.ts src/features/settings/theme/themeVars.test.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 6: Contrast maths
+
+**Files:**
+- Create: `src/features/settings/theme/contrast.ts`
+- Create: `src/features/settings/theme/contrast.test.ts`
+
+**Interfaces:**
+- Consumes: `ThemeColors` from `useSettingsStore`; `normalizeHex` from
+  `./ColorEditor`.
+- Produces:
+  - `contrastRatio(a: string, b: string): number`
+  - `type ContrastLevel = "ok" | "low" | "bad"`
+  - `type ContrastFinding = { a: keyof ThemeColors; b: keyof ThemeColors; what: string; ratio: number; level: ContrastLevel }`
+  - `contrastReport(colors: ThemeColors): ContrastFinding[]` — only findings
+    below `ok`, worst first
+  - `CONTRAST_PAIRS: { a: keyof ThemeColors; b: keyof ThemeColors; what: string }[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/contrast.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+import { contrastRatio, contrastReport } from "./contrast";
+
+describe("contrastRatio", () => {
+  it("is 21 for black on white", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1);
+  });
+
+  it("is 1 for a colour on itself", () => {
+    expect(contrastRatio("#5aa8e8", "#5aa8e8")).toBeCloseTo(1, 5);
+  });
+
+  it("is symmetric", () => {
+    expect(contrastRatio("#1a1d24", "#eef1f5")).toBeCloseTo(
+      contrastRatio("#eef1f5", "#1a1d24"),
+      5,
+    );
+  });
+
+  it("matches a known WCAG value", () => {
+    // #767676 on white is the canonical 4.54:1 boundary case from the WCAG
+    // techniques — if the luminance curve is wrong, this is what shows it.
+    expect(contrastRatio("#767676", "#ffffff")).toBeCloseTo(4.54, 1);
+  });
+
+  it("accepts short hex and a missing hash", () => {
+    expect(contrastRatio("000", "fff")).toBeCloseTo(21, 1);
+  });
+});
+
+describe("contrastReport", () => {
+  it("finds nothing to warn about in the built-in themes", () => {
+    // A built-in theme that trips our own warning would mean the thresholds are
+    // miscalibrated, not that the theme is bad.
+    for (const theme of BUILTIN_THEMES) {
+      expect(
+        contrastReport(theme.colors).filter((f) => f.level === "bad"),
+        `${theme.name} trips a hard contrast warning`,
+      ).toEqual([]);
+    }
+  });
+
+  it("reports primary text that cannot be read on the canvas", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const report = contrastReport({ ...base, fg0: base.bg0 });
+    const finding = report.find((f) => f.a === "fg0" && f.b === "bg0");
+    expect(finding?.level).toBe("bad");
+    expect(finding?.ratio).toBeCloseTo(1, 3);
+  });
+
+  it("reports unreadable ink on the accent", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const report = contrastReport({ ...base, accentInk: base.accent });
+    expect(report.some((f) => f.a === "accentInk" && f.b === "accent")).toBe(true);
+  });
+
+  it("sorts the worst finding first", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const report = contrastReport({
+      ...base,
+      fg0: base.bg0,          // ratio 1 — the worst
+      fg2: base.fg1,          // merely low
+    });
+    expect(report.length).toBeGreaterThan(1);
+    expect(report[0].ratio).toBeLessThanOrEqual(report[1].ratio);
+  });
+
+  it("says nothing about a pair it cannot parse", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    expect(() => contrastReport({ ...base, fg0: "not-a-colour" })).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/contrast.test.ts`
+Expected: FAIL — cannot resolve `./contrast`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/settings/theme/contrast.ts`:
+
+```ts
+import type { ThemeColors } from "@/features/settings/useSettingsStore";
+
+import { normalizeHex } from "./ColorEditor";
+
+/**
+ * WCAG contrast, for the four pairs that decide whether the app is readable.
+ *
+ * The editor let you build a theme with white text on white and said nothing.
+ * That is the worst thing about it: a colour picker with no feedback is a
+ * colour picker that lets you break your own app and then wonder why. So the
+ * editor warns — and only warns. A deliberately low-contrast theme is the
+ * user's call, Save is never disabled by a finding, and nothing here refuses a
+ * colour.
+ */
+
+/** sRGB channel → linear, per WCAG 2.x relative luminance. */
+function channel(v: number): number {
+  const s = v / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function luminance(hex: string): number | null {
+  const norm = normalizeHex(hex);
+  if (!norm) return null;
+  const r = parseInt(norm.slice(1, 3), 16);
+  const g = parseInt(norm.slice(3, 5), 16);
+  const b = parseInt(norm.slice(5, 7), 16);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/**
+ * Contrast ratio between two hex colours, 1 to 21. Returns `NaN` when either
+ * side cannot be parsed — a half-typed hex is not a finding.
+ */
+export function contrastRatio(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  if (la === null || lb === null) return NaN;
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+export type ContrastLevel = "ok" | "low" | "bad";
+
+export type ContrastFinding = {
+  a: keyof ThemeColors;
+  b: keyof ThemeColors;
+  /** User-facing prose. A user never reads a colour-slot key. */
+  what: string;
+  ratio: number;
+  level: ContrastLevel;
+};
+
+/**
+ * The pairs worth checking. Not every combination — a report with twenty
+ * findings is a report nobody reads. These four are the ones that make the app
+ * unusable when they fail.
+ */
+export const CONTRAST_PAIRS: { a: keyof ThemeColors; b: keyof ThemeColors; what: string }[] = [
+  { a: "fg0", b: "bg0", what: "Primary text on the app canvas" },
+  { a: "fg1", b: "bg1", what: "Secondary text on a panel" },
+  { a: "fg2", b: "bg1", what: "Muted text on a panel" },
+  { a: "accentInk", b: "accent", what: "Button text on the accent" },
+];
+
+/** WCAG AA for body text. Below this, warn. */
+const AA_TEXT = 4.5;
+/** WCAG AA for large text / UI. Below this, warn harder. */
+const AA_LARGE = 3;
+
+function level(ratio: number): ContrastLevel {
+  if (ratio < AA_LARGE) return "bad";
+  if (ratio < AA_TEXT) return "low";
+  return "ok";
+}
+
+/** Every pair that falls short, worst first. Empty when the theme is fine. */
+export function contrastReport(colors: ThemeColors): ContrastFinding[] {
+  return CONTRAST_PAIRS.map(({ a, b, what }) => {
+    const ratio = contrastRatio(colors[a] ?? "", colors[b] ?? "");
+    return { a, b, what, ratio, level: level(ratio) };
+  })
+    .filter((f) => Number.isFinite(f.ratio) && f.level !== "ok")
+    .sort((x, y) => x.ratio - y.ratio);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/contrast.test.ts`
+Expected: PASS, 11 tests.
+
+If the "built-in themes trip nothing" case fails, **do not loosen the
+thresholds to make it pass** — read which pair fails in which theme and report
+it. A built-in theme below 3:1 on primary text is a real bug in that theme, and
+the finding is worth surfacing separately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): measure the contrast pairs that decide readability' '' 'Why: the editor let you put white text on a white canvas and said nothing.' 'Four pairs, advisory only -- a low-contrast theme stays the user choice and' 'Save is never disabled by a finding.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/theme/contrast.ts src/features/settings/theme/contrast.test.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 7: `deriveTheme` — the guided start's engine
+
+**Files:**
+- Create: `src/features/settings/theme/deriveTheme.ts`
+- Create: `src/features/settings/theme/deriveTheme.test.ts`
+
+**Interfaces:**
+- Consumes: `ThemeDef`, `ThemeColors` from `useSettingsStore`; `normalizeHex`
+  from `./ColorEditor`; `contrastRatio` from `./contrast`.
+- Produces: `deriveTheme(base: ThemeDef, accent: string): ThemeColors`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/deriveTheme.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES, THEME_COLOR_FIELDS } from "@/features/settings/useSettingsStore";
+import { contrastRatio } from "./contrast";
+import { deriveTheme } from "./deriveTheme";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("deriveTheme", () => {
+  it("puts the chosen accent in the accent slot", () => {
+    expect(deriveTheme(dark, "#ff8800").accent).toBe("#ff8800");
+  });
+
+  it("leaves every other slot alone", () => {
+    const derived = deriveTheme(dark, "#ff8800");
+    for (const field of THEME_COLOR_FIELDS) {
+      if (field.key === "accent" || field.key === "accentInk") continue;
+      expect(derived[field.key], `${field.key} should be untouched`).toBe(
+        dark.colors[field.key],
+      );
+    }
+  });
+
+  it("picks an ink that can actually be read on the accent", () => {
+    for (const accent of ["#ffee00", "#0b1020", "#5aa8e8", "#7a7a7a"]) {
+      const derived = deriveTheme(dark, accent);
+      expect(
+        contrastRatio(derived.accentInk, derived.accent),
+        `unreadable ink on ${accent}`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("flips the ink across the light/dark crossover", () => {
+    const onPale = deriveTheme(dark, "#ffee00").accentInk;
+    const onDeep = deriveTheme(dark, "#101830").accentInk;
+    expect(onPale).not.toBe(onDeep);
+    // Pale accent takes the dark ink, deep accent takes the light one.
+    expect(contrastRatio(onPale, "#ffee00")).toBeGreaterThan(
+      contrastRatio(onDeep, "#ffee00"),
+    );
+  });
+
+  it("works from a light base too", () => {
+    const derived = deriveTheme(light, "#8844cc");
+    expect(derived.accent).toBe("#8844cc");
+    expect(derived.bg0).toBe(light.colors.bg0);
+    expect(contrastRatio(derived.accentInk, derived.accent)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("normalizes a short hex and a missing hash", () => {
+    expect(deriveTheme(dark, "f80").accent).toBe("#ff8800");
+  });
+
+  it("keeps the base accent when the input cannot be parsed", () => {
+    expect(deriveTheme(dark, "nonsense").accent).toBe(dark.colors.accent);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/deriveTheme.test.ts`
+Expected: FAIL — cannot resolve `./deriveTheme`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/settings/theme/deriveTheme.ts`:
+
+```ts
+import type { ThemeColors, ThemeDef } from "@/features/settings/useSettingsStore";
+
+import { normalizeHex } from "./ColorEditor";
+import { contrastRatio } from "./contrast";
+
+/**
+ * The guided start: a base theme plus an accent.
+ *
+ * Deliberately not a palette generator. Forking a built-in theme and then
+ * hunting for the one slot that makes a button look right is the current
+ * two-minute task; swapping the accent and fixing the ink is the two-click
+ * version of it. Hue-shifting the greys as well would produce palettes the
+ * user can neither predict nor correct, and every one of the 18 slots stays
+ * editable underneath — so cleverness here buys nothing and costs
+ * predictability.
+ *
+ * `accentInk` is the one slot that CANNOT be left to the user: it is the text
+ * drawn on the accent, so a bright accent with the base's dark ink is fine and
+ * a bright accent with the base's light ink is an unreadable button. Pick
+ * whichever of the base's own extremes reads better.
+ */
+export function deriveTheme(base: ThemeDef, accent: string): ThemeColors {
+  const norm = normalizeHex(accent);
+  if (!norm) return { ...base.colors };
+
+  // The base's own lightest and darkest inks, so a derived theme stays in its
+  // family instead of jumping to pure black or pure white.
+  const lightInk = base.colors.fg0;
+  const darkInk = base.colors.bg0;
+  const accentInk =
+    contrastRatio(lightInk, norm) >= contrastRatio(darkInk, norm) ? lightInk : darkInk;
+
+  return { ...base.colors, accent: norm, accentInk };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/deriveTheme.test.ts`
+Expected: PASS, 7 tests.
+
+If "picks an ink that can actually be read" fails for a mid-grey accent
+(`#7a7a7a` is the case that bites), the base's own extremes are not far enough
+apart. Fall back to pure `#000000`/`#ffffff` for that case only — pick the base
+extreme when it clears 4.5:1, else the pure extreme — and add a test naming the
+accent that forced it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): derive a theme from a base and an accent' '' 'Why: forking a built-in and hunting for the slot that fixes a button is the' 'current two-minute task. Not a palette generator on purpose -- shifting the' 'greys too would produce palettes nobody can predict, and all 18 slots stay' 'editable underneath.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/theme/deriveTheme.ts src/features/settings/theme/deriveTheme.test.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 8: `ThemePreview` — one renderer for cards and the editor
+
+**Files:**
+- Create: `src/features/settings/theme/ThemePreview.tsx`
+- Create: `src/features/settings/theme/ThemePreview.test.tsx`
+
+**Interfaces:**
+- Consumes: `themeVars` (Task 5), `ThemeDef` / `ThemeColors`, `PGIcon` from
+  `@/design`.
+- Produces:
+  `ThemePreview(props: { theme: { name?: string; mode: "dark" | "light"; colors: ThemeColors }; size: "card" | "pane"; title?: string }): JSX.Element`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/ThemePreview.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+import { ThemePreview } from "./ThemePreview";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("ThemePreview", () => {
+  it("paints from the theme it was handed, not from :root", () => {
+    // The whole reason this component exists: a card on a dark page has to be
+    // able to show a light theme. If it read :root vars it would show the page.
+    document.documentElement.style.setProperty("--bg-0", "#ff00ff");
+    const { container } = render(<ThemePreview theme={light} size="card" />);
+    const root = container.querySelector("[data-testid='theme-preview']") as HTMLElement;
+    expect(root.style.getPropertyValue("--bg-0")).toBe(light.colors.bg0);
+    expect(root.style.getPropertyValue("--bg-0")).not.toBe("#ff00ff");
+  });
+
+  it("carries the mode-calibrated semantic tokens", () => {
+    const { container } = render(<ThemePreview theme={dark} size="card" />);
+    const root = container.querySelector("[data-testid='theme-preview']") as HTMLElement;
+    expect(root.style.getPropertyValue("--git-added")).toBeTruthy();
+    expect(root.style.getPropertyValue("--accent")).toBe(dark.colors.accent);
+  });
+
+  it("shows the surfaces a palette is actually judged on", () => {
+    render(<ThemePreview theme={dark} size="pane" />);
+    expect(screen.getByTestId("theme-preview-titlebar")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-history")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-diff")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-button")).toBeInTheDocument();
+  });
+
+  it("renders both sizes from one tree", () => {
+    const card = render(<ThemePreview theme={dark} size="card" />);
+    expect(card.getByTestId("theme-preview").dataset.size).toBe("card");
+    card.unmount();
+    const pane = render(<ThemePreview theme={dark} size="pane" />);
+    expect(pane.getByTestId("theme-preview").dataset.size).toBe("pane");
+  });
+
+  it("survives a theme missing the logo slots", () => {
+    const legacy = { ...dark, colors: { ...dark.colors, logo: undefined, logo2: undefined } };
+    expect(() =>
+      render(<ThemePreview theme={legacy as typeof dark} size="card" />),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemePreview.test.tsx`
+Expected: FAIL — cannot resolve `./ThemePreview`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/settings/theme/ThemePreview.tsx`. Requirements the test
+pins, plus the ones only a human notices:
+
+- The root element carries `data-testid="theme-preview"`,
+  `data-size={size}`, and **every entry of `themeVars(theme)` as an inline
+  custom property**. Set them with a `style` object — React passes unknown
+  `--*` keys straight through, so
+  `style={{ ...themeVars(theme) } as React.CSSProperties}` works.
+- **Every colour inside comes from `var(--…)`**, never from `props.theme`
+  directly. That is what makes the preview honest: it renders through the same
+  vars the app does, one scope down.
+- The tree, all of it inside the scoped root:
+  - `data-testid="theme-preview-titlebar"` — `var(--bg-titlebar)`, the logo
+    mark in `var(--logo)`/`var(--logo-2)`, a repo name in `var(--fg-1)`, and
+    three window dots in `var(--fg-3)`.
+  - `data-testid="theme-preview-sidebar"` — `var(--bg-1)` with a
+    `var(--border-0)` right edge, three nav rows, one active in
+    `var(--bg-4)` + `var(--accent)` left bar.
+  - `data-testid="theme-preview-history"` — two commit rows on `var(--bg-0)`:
+    subject in `var(--fg-0)`, meta in `var(--fg-2)`, a graph dot and edge in
+    `var(--graph-1)`, and the selected row on `var(--bg-selection)`.
+  - `data-testid="theme-preview-diff"` — a `var(--bg-1)` header, one added line
+    (`var(--git-added-bg)` background, `var(--git-added)` marker) and one
+    removed (`var(--git-removed-bg)` / `var(--git-removed)`), with line numbers
+    in `var(--fg-3)` and code text in `var(--fg-1)`.
+  - `data-testid="theme-preview-button"` — a primary button, `var(--accent)`
+    background and `var(--accent-ink)` text. This is the pair the contrast
+    warning is about, so it has to be visible.
+- Two sizes, one tree: `size === "card"` uses 9px type, 3px gaps and
+  `pointerEvents: "none"`; `size === "pane"` uses 11px type and 6px gaps and
+  fills its container (`width: "100%"`, `minHeight: 240`). Scale with a single
+  `const s = size === "card" ? { fs: 9, gap: 3, row: 14 } : { fs: 11, gap: 6, row: 20 };`
+  rather than two copies of the markup.
+- `overflow: "hidden"`, `borderRadius: "var(--r-3)"`, a `1px solid
+  var(--border-1)` frame, and **no interactive elements** — it is a picture. Use
+  `<div>`s, not `<button>`s, so it never takes focus inside a card that is
+  itself a radio.
+- Icons through `PGIcon` only, and only names already in the `IconName` union
+  (`test/iconSet.test.ts` fails the build for a literal the union lacks). If you
+  want a mark and are unsure of the name, use plain shaped `<div>`s instead —
+  the preview needs no real icons.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemePreview.test.tsx`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Look at it**
+
+A preview nobody has looked at is a preview that is wrong. Take a screenshot
+with the scratch-vite-entry + headless-Chrome route (see the memory note "See
+real pixels without a window"): render a row of `ThemePreview size="card"` for
+all nine built-ins plus one `size="pane"`, and check that a light theme and a
+dark theme are each recognisable at card size. Fix what looks wrong before
+committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): render any theme as a miniature of the real app' '' 'Why: a palette is judged on composed surfaces -- a history row, a diff hunk,' 'a button -- not on 18 swatches. Everything inside paints through var(--..)' 'one scope down, so the preview cannot disagree with the live app.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/theme/ThemePreview.tsx src/features/settings/theme/ThemePreview.test.tsx
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 9: The editor store
+
+**Files:**
+- Create: `src/features/settings/theme/useThemeEditorStore.ts`
+- Create: `src/features/settings/theme/useThemeEditorStore.test.ts`
+- Modify: `src/features/keymap/actions.ts` (`app.closeOverlay`, the chain around lines 301-355)
+- Modify: `src/features/keymap/actions.test.ts` (one case for the new branch)
+
+**Interfaces:**
+- Consumes: `applyTheme`, `useSettingsStore`, `ThemeColors`, `ThemeDef` from the
+  settings store; `deriveTheme` (Task 7).
+- Produces:
+  ```ts
+  type ThemeEditorState = {
+    /** null when the editor is closed. */
+    open: null | { mode: "new" | "edit"; sourceTheme: ThemeDef };
+    name: string;
+    themeMode: "dark" | "light";
+    colors: ThemeColors;
+    /** The theme that was live when the editor opened, restored on close. */
+    originalTheme: ThemeDef | null;
+    baseId: string;
+    openNew: (source: ThemeDef) => void;
+    openEdit: (theme: ThemeDef) => void;
+    /** Dismiss WITHOUT saving, restoring the original theme. */
+    close: () => void;
+    setName: (name: string) => void;
+    setThemeMode: (mode: "dark" | "light") => void;
+    patchColors: (patch: Partial<ThemeColors>) => void;
+    setColors: (colors: ThemeColors) => void;
+    /** Apply the guided start: base theme + accent. */
+    applyBase: (baseId: string, accent?: string) => void;
+    revert: () => void;
+    /** Persist the draft and leave. Returns the saved theme. */
+    save: () => ThemeDef | null;
+  };
+  export const useThemeEditorStore: UseBoundStore<StoreApi<ThemeEditorState>>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/useThemeEditorStore.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+function rootVar(name: string): string {
+  return document.documentElement.style.getPropertyValue(name);
+}
+
+describe("useThemeEditorStore", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+    useThemeEditorStore.getState().close();
+  });
+
+  it("opens a new draft seeded from the source theme, with a distinct name", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    const s = useThemeEditorStore.getState();
+    expect(s.open?.mode).toBe("new");
+    expect(s.colors).toEqual(dark.colors);
+    expect(s.themeMode).toBe("dark");
+    expect(s.name).not.toBe(dark.name);
+    expect(s.name).toContain(dark.name);
+  });
+
+  it("previews the draft on :root as it is edited", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    expect(rootVar("--bg-0")).toBe("#123456");
+  });
+
+  it("restores the theme that was live when it opened, on close", () => {
+    useSettingsStore.getState().setActiveThemeId("light");
+    const before = rootVar("--bg-0");
+    useThemeEditorStore.getState().openNew(light);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    expect(rootVar("--bg-0")).toBe("#123456");
+
+    useThemeEditorStore.getState().close();
+
+    expect(rootVar("--bg-0")).toBe(before);
+    expect(useThemeEditorStore.getState().open).toBeNull();
+  });
+
+  it("saves a new theme, activates it, and leaves the editor", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().setName("My theme");
+    useThemeEditorStore.getState().patchColors({ accent: "#ff8800" });
+
+    const saved = useThemeEditorStore.getState().save();
+
+    expect(saved?.name).toBe("My theme");
+    expect(saved?.colors.accent).toBe("#ff8800");
+    const store = useSettingsStore.getState();
+    expect(store.customThemes.some((t) => t.id === saved!.id)).toBe(true);
+    expect(store.getActiveTheme().id).toBe(saved!.id);
+    expect(useThemeEditorStore.getState().open).toBeNull();
+    // The saved theme stays on screen — close() must NOT restore over a save.
+    expect(rootVar("--accent")).toBe("#ff8800");
+  });
+
+  it("refuses to save an empty name, staying open", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().setName("   ");
+    expect(useThemeEditorStore.getState().save()).toBeNull();
+    expect(useThemeEditorStore.getState().open).not.toBeNull();
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("edits an existing custom theme in place rather than adding one", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().setName("Mine");
+    const created = useThemeEditorStore.getState().save()!;
+
+    useThemeEditorStore.getState().openEdit(
+      useSettingsStore.getState().customThemes.find((t) => t.id === created.id)!,
+    );
+    useThemeEditorStore.getState().patchColors({ accent: "#00ddaa" });
+    useThemeEditorStore.getState().save();
+
+    const customs = useSettingsStore.getState().customThemes;
+    expect(customs).toHaveLength(1);
+    expect(customs[0].colors.accent).toBe("#00ddaa");
+  });
+
+  it("applyBase swaps the whole palette and fixes the ink", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().applyBase("light", "#8844cc");
+    const s = useThemeEditorStore.getState();
+    expect(s.colors.bg0).toBe(light.colors.bg0);
+    expect(s.colors.accent).toBe("#8844cc");
+    expect(s.themeMode).toBe("light");
+  });
+
+  it("revert returns the draft to the source it opened from", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    useThemeEditorStore.getState().setThemeMode("light");
+    useThemeEditorStore.getState().revert();
+    const s = useThemeEditorStore.getState();
+    expect(s.colors).toEqual(dark.colors);
+    expect(s.themeMode).toBe("dark");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/useThemeEditorStore.test.ts`
+Expected: FAIL — cannot resolve `./useThemeEditorStore`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/settings/theme/useThemeEditorStore.ts` as a Zustand store
+matching the interface above. The load-bearing details:
+
+- **`openNew(source)`** seeds `name` as `` `${source.name} (custom)` ``,
+  `themeMode` and `colors` from `source`, `baseId` as `source.id`, and captures
+  `originalTheme` from `useSettingsStore.getState().getActiveTheme()` — read it
+  BEFORE anything is applied.
+- **Every mutator re-applies** the draft: `applyTheme({ id: "__draft__", name,
+  mode: themeMode, colors })`. That is what makes the live window follow the
+  edit, and `"__draft__"` is the id the current dialog already uses.
+- **`close()` restores** `originalTheme` via `applyTheme` and clears `open` and
+  `originalTheme`. It must be a no-op when `open` is already null so
+  `app.closeOverlay` can call it defensively.
+- **`save()`** goes through the settings STORE, never `setState` alone:
+  - `mode === "new"`: `saveAsNewTheme(trimmed)` to get an id, then patch that
+    theme's `name`/`mode`/`colors` via `useSettingsStore.setState`, then
+    `useSettingsStore.getState().setActiveThemeId(created.id)`. The
+    `setActiveThemeId` call is not optional — the draft's dark/light toggle may
+    have flipped the mode the duplicate inherited, and in "follow the system"
+    mode that decides WHICH half of the pairing this theme is.
+  - `mode === "edit"`: patch `customThemes` for `sourceTheme.id`, then
+    `setActiveThemeId(sourceTheme.id)`.
+  - Then clear `open` **without restoring** — the saved theme is what should
+    stay on screen. Return the saved `ThemeDef`.
+  - An empty trimmed name returns `null` and changes nothing. The dialog is what
+    flashes the message; the store does not call `pgFlash` (keep it testable
+    without the design system).
+- **`applyBase(baseId, accent)`** looks the base up in
+  `[...BUILTIN_THEMES, ...customThemes]`, sets `themeMode` to the base's mode,
+  and sets `colors` to `deriveTheme(base, accent ?? base.colors.accent)`.
+- **`revert()`** restores `name`/`themeMode`/`colors` from `open.sourceTheme`.
+
+- [ ] **Step 4: Join the `app.closeOverlay` chain**
+
+In `src/features/keymap/actions.ts`, import `useThemeEditorStore` and add a
+branch **after** the `useReportStore` branch and **before** the
+`useUpdateStore` one:
+
+```ts
+      // Same PGModal base layer as the dialogs above, same rule: it belongs in
+      // THIS chain rather than registering its own handler, because a
+      // registered handler runs BEFORE the default runner and would take
+      // Escape ahead of the credential prompt. `close()` restores the theme
+      // that was live when the editor opened — an Escape that only unmounted
+      // the dialog would leave an abandoned draft painted on the app.
+      if (useThemeEditorStore.getState().open) {
+        useThemeEditorStore.getState().close();
+        return true;
+      }
+```
+
+- [ ] **Step 5: Test the chain's order**
+
+Add to `src/features/keymap/actions.test.ts`, beside the existing
+`app.closeOverlay` cases:
+
+```ts
+  it("app.closeOverlay closes the theme editor, but not before the credential prompt", () => {
+    useThemeEditorStore.getState().openNew(BUILTIN_THEMES[0]);
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+    expect(useThemeEditorStore.getState().open).toBeNull();
+  });
+
+  it("app.closeOverlay restores the pre-draft theme rather than only closing", () => {
+    useSettingsStore.getState().setActiveThemeId("light");
+    const before = document.documentElement.style.getPropertyValue("--bg-0");
+    useThemeEditorStore.getState().openNew(BUILTIN_THEMES[0]);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    ACTIONS["app.closeOverlay"].run?.();
+    expect(document.documentElement.style.getPropertyValue("--bg-0")).toBe(before);
+  });
+```
+
+Match the file's existing setup style for the credential-prompt precedence case
+— read the `#212` test above it and mirror how it seeds `useAuthStore`, so the
+ordering assertion is the same shape as its neighbour.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme src/features/keymap`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): move the editor draft into a store so Escape can reach it' '' 'Why: the dialog owned its own keydown listener, which design/modal.tsx names' 'as the anti-pattern #47 was fixed to avoid. closeOverlay reads stores, and' 'closing has to RESTORE the pre-draft theme -- an Escape that only unmounted' 'left the abandoned draft painted on the app.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/theme/useThemeEditorStore.ts src/features/settings/theme/useThemeEditorStore.test.ts src/features/keymap/actions.ts src/features/keymap/actions.test.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 10: Rebuild the editor dialog
+
+**Files:**
+- Modify: `src/features/settings/theme/ThemeEditorDialog.tsx` (a rewrite)
+- Modify: `src/features/settings/theme/ColorEditor.tsx` (contrast badge, collapsible groups)
+- Create: `src/features/settings/theme/ThemeEditorDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `useThemeEditorStore` (Task 9), `ThemePreview` (Task 8),
+  `contrastReport` (Task 6), `deriveTheme` (Task 7),
+  `exportThemeDraftToFile` / `importThemeFromFile` (Task 3), `PGModal`,
+  `PGButton`, `PGButtonGroup`, `PGInput`, `PGSelect`, `pgFlash`, `pgConfirm`
+  from `@/design`.
+- Produces: `ThemeEditorDialog()` — **no props**. It reads
+  `useThemeEditorStore` for its open state, so the Appearance page mounts it
+  unconditionally in Task 11.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/ThemeEditorDialog.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockDialogSave, lastDialogSaveOptions } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+import { ThemeEditorDialog } from "./ThemeEditorDialog";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+
+describe("ThemeEditorDialog", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+    useThemeEditorStore.getState().close();
+  });
+
+  it("renders nothing while the editor is closed", () => {
+    const { container } = render(<ThemeEditorDialog />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the draft's preview and repaints it on a colour change", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    render(<ThemeEditorDialog />);
+    const preview = () => screen.getByTestId("theme-preview");
+    expect(preview().style.getPropertyValue("--bg-0")).toBe(dark.colors.bg0);
+
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    expect(preview().style.getPropertyValue("--bg-0")).toBe("#123456");
+  });
+
+  it("warns about unreadable text without disabling Save", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    render(<ThemeEditorDialog />);
+    useThemeEditorStore.getState().patchColors({ fg0: dark.colors.bg0 });
+
+    expect(screen.getByTestId("theme-contrast-warnings")).toHaveTextContent(
+      /primary text/i,
+    );
+    // Advisory, never blocking: a low-contrast theme is the user's call.
+    expect(screen.getByRole("button", { name: /create theme/i })).toBeEnabled();
+  });
+
+  it("says nothing when every checked pair is fine", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    render(<ThemeEditorDialog />);
+    expect(screen.queryByTestId("theme-contrast-warnings")).not.toBeInTheDocument();
+  });
+
+  it("exports the unsaved draft to the file the user picked", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().setName("My theme");
+    mockDialogSave("/home/you/my-theme.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+    render(<ThemeEditorDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    return Promise.resolve().then(() => {
+      expect(lastDialogSaveOptions()).toMatchObject({
+        defaultPath: "my-theme.pgtheme.json",
+      });
+      const call = invokeCalls().find((c) => c.cmd === "write_user_file");
+      const written = JSON.parse((call?.args as { contents: string }).contents);
+      expect(written.name).toBe("My theme");
+      // The DRAFT, not a saved theme: nothing was created.
+      expect(useSettingsStore.getState().customThemes).toEqual([]);
+    });
+  });
+
+  it("saves the draft as a new theme and closes", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    useThemeEditorStore.getState().setName("My theme");
+    render(<ThemeEditorDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create theme/i }));
+
+    expect(useSettingsStore.getState().customThemes.map((t) => t.name)).toEqual([
+      "My theme",
+    ]);
+    expect(useThemeEditorStore.getState().open).toBeNull();
+  });
+
+  it("cancel restores the theme that was live when it opened", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    render(<ThemeEditorDialog />);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(document.documentElement.style.getPropertyValue("--bg-0")).toBe(
+      dark.colors.bg0,
+    );
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("reveals all 18 colour slots behind the disclosure", () => {
+    useThemeEditorStore.getState().openNew(dark);
+    render(<ThemeEditorDialog />);
+    fireEvent.click(screen.getByRole("button", { name: /all colou?rs/i }));
+    expect(screen.getByLabelText(/background · base/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/logo · bill/i)).toBeInTheDocument();
+  });
+});
+```
+
+Use `fireEvent`, not `userEvent` — `userEvent.setup()` replaces
+`navigator.clipboard` and detaches spies, and this suite touches the clipboard's
+neighbours. That is the house pattern.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemeEditorDialog.test.tsx`
+Expected: FAIL — the dialog still takes props and renders its own overlay.
+
+- [ ] **Step 3: Rewrite the dialog**
+
+Rewrite `ThemeEditorDialog.tsx` to take **no props** and read the store. The
+structure, following the approved layout:
+
+- `const ed = useThemeEditorStore();` — return `null` when `ed.open` is null.
+- Wrap everything in `<PGModal onCancel={ed.close} width={880}>`. **Delete** the
+  hand-rolled `position: fixed` backdrop, the `zIndex: 100`, and the
+  `window.addEventListener("keydown", …)` Escape effect — Escape now arrives
+  through `app.closeOverlay` (Task 9), and `modal.tsx`'s comment explains why a
+  local listener is wrong.
+- Header: `PGIcon name="edit"`, the title (`New custom theme` / `Edit custom
+  theme`), and a `Revert changes` ghost button wired to `ed.revert`.
+- Left column, in order:
+  - `Name` — `PGInput` bound to `ed.name` / `ed.setName`.
+  - `Mode` — `PGButtonGroup` Dark/Light. **On a flip**, `await pgConfirm({ … })`
+    offering to re-base from the matching built-in theme, and on yes call
+    `ed.applyBase(<matching builtin id>, ed.colors.accent)`; on no, only
+    `ed.setThemeMode(next)`. Copy: title `Re-base the colours for light mode?`,
+    body `Dark greys under a light calibration are unreadable. Re-basing keeps
+    your accent and takes the rest from the built-in light theme.`, confirm
+    label `Re-base colours`. **Skip the prompt** when the draft's colours still
+    equal the source theme's — there is nothing to lose, so just re-base.
+  - `Start from` — a `PGSelect` of every theme (built-ins then customs) bound to
+    `ed.baseId`, plus an accent `ColorField`. Changing either calls
+    `ed.applyBase(baseId, accent)`. A one-line hint: `Takes the palette from
+    another theme and keeps your accent.`
+  - `All colours (18)` — a disclosure `<button>` toggling the existing
+    `<ColorEditor colors={ed.colors} onPatch={ed.patchColors} />`. Collapsed by
+    default so the guided path is what a first-time user sees.
+- Right column: `<ThemePreview theme={{ name: ed.name, mode: ed.themeMode, colors: ed.colors }} size="pane" />`
+  and, under it, the warnings block — rendered **only when
+  `contrastReport(ed.colors)` is non-empty** — as
+  `data-testid="theme-contrast-warnings"`, one row per finding:
+  `PGIcon name="warn"` (the union has no `alert-triangle` — `warn` is the
+  declared name, verified in `src/design/icons.tsx`), the finding's `what`, and
+  `` `${ratio.toFixed(1)}:1` ``. Colour
+  `bad` findings `var(--git-removed)` and `low` ones `var(--git-modified)`.
+- Footer: `Export…` (`exportThemeDraftToFile({ name: ed.name, mode: ed.themeMode, colors: ed.colors })`,
+  flashing the returned path), `Import…` (`importThemeFromFile()`, then
+  `ed.setColors(theme.colors)` + `ed.setThemeMode(theme.mode)` — loading a file
+  into the DRAFT, which is the round trip #435's reporter wanted), a spacer,
+  `Cancel` (`ed.close`), and the primary `Create theme` / `Save changes`
+  (`ed.save()`, flashing `Saved "<name>"`, or flashing
+  `Theme name can't be empty` when it returns null).
+
+Both async footer handlers wrap in `try`/`catch` and flash
+`appErrorMessage(err)`; a `null` return (cancel) flashes nothing.
+
+- [ ] **Step 4: Give `ColorEditor` the contrast badge and the groups**
+
+In `ColorEditor.tsx`:
+- Each `ColorField` gets `aria-label={label}` on its hex input so
+  `getByLabelText(/background · base/i)` finds it. Wrap the swatch and the input
+  in a `<label>` whose text is the field label, or set `aria-label` explicitly —
+  either satisfies the test, and the explicit label is clearer.
+- `ColorField` accepts an optional `badge?: React.ReactNode` rendered right of
+  the hex input. The dialog passes a ratio badge for the four keys in
+  `CONTRAST_PAIRS` so the warning is visible where the colour is edited, not
+  only in the summary.
+- Keep `normalizeHex` exported unchanged — `contrast.ts` and `deriveTheme.ts`
+  both import it.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme`
+Expected: PASS.
+
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): rebuild the theme editor around a live preview' '' 'Why: judging a palette meant squinting past a dimmed backdrop at the 10% of' 'the app the dialog did not cover, and nothing warned you when the result was' 'unreadable. Guided start first, all 18 slots behind a disclosure, warnings' 'that advise and never block, and export that writes a file.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings/theme
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 11: The gallery, on the Appearance page
+
+**Files:**
+- Create: `src/features/settings/theme/ThemeGallery.tsx`
+- Create: `src/features/settings/theme/ThemeGallery.test.tsx`
+- Modify: `src/features/settings/pages/appearance.tsx`
+
+**Interfaces:**
+- Consumes: `ThemePreview` (Task 8), `useThemeEditorStore` (Task 9),
+  `exportThemeToFile` / `importThemeFromFile` (Task 3), `useSettingsStore`.
+- Produces:
+  `ThemeGallery(props: { appearance?: "light" | "dark" }): JSX.Element` —
+  omitting `appearance` shows every theme and picks the active one; passing it
+  filters to that mode and drives that half of the pairing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/ThemeGallery.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+import { ThemeGallery } from "./ThemeGallery";
+
+describe("ThemeGallery", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+    useThemeEditorStore.getState().close();
+  });
+
+  it("shows a card per theme, each painted in its own colours", () => {
+    render(<ThemeGallery />);
+    const cards = screen.getAllByRole("radio");
+    expect(cards).toHaveLength(BUILTIN_THEMES.length);
+    const light = screen.getByRole("radio", { name: /^Light/ });
+    expect(
+      within(light).getByTestId("theme-preview").style.getPropertyValue("--bg-0"),
+    ).toBe(BUILTIN_THEMES.find((t) => t.id === "light")!.colors.bg0);
+  });
+
+  it("marks the active theme as checked", () => {
+    useSettingsStore.getState().setActiveThemeId("nord");
+    render(<ThemeGallery />);
+    expect(screen.getByRole("radio", { name: /^Nord/ })).toBeChecked();
+  });
+
+  it("activates the theme on the card you click", () => {
+    render(<ThemeGallery />);
+    fireEvent.click(screen.getByRole("radio", { name: /^Dracula/ }));
+    expect(useSettingsStore.getState().getActiveTheme().id).toBe("dracula");
+  });
+
+  it("moves the selection with the arrow keys", () => {
+    useSettingsStore.getState().setActiveThemeId("dark-cool");
+    render(<ThemeGallery />);
+    const group = screen.getByRole("radiogroup");
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(useSettingsStore.getState().getActiveTheme().id).toBe("dark-warm");
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+    expect(useSettingsStore.getState().getActiveTheme().id).toBe("dark-cool");
+  });
+
+  it("filters to one mode and drives that half of the pairing", () => {
+    useSettingsStore.getState().setThemeFollowMode("system");
+    render(<ThemeGallery appearance="light" />);
+    for (const card of screen.getAllByRole("radio")) {
+      const name = card.getAttribute("aria-label") ?? "";
+      const theme = BUILTIN_THEMES.find((t) => name.startsWith(t.name));
+      expect(theme?.mode, `${name} is not a light theme`).toBe("light");
+    }
+    fireEvent.click(screen.getByRole("radio", { name: /^GitHub Light/ }));
+    expect(useSettingsStore.getState().themePreference.lightId).toBe("github-light");
+  });
+
+  it("offers Duplicate on a built-in card and opens the editor with it", () => {
+    render(<ThemeGallery />);
+    const card = screen.getByRole("radio", { name: /^Nord/ });
+    fireEvent.click(within(card).getByRole("button", { name: /duplicate/i }));
+    expect(useThemeEditorStore.getState().open?.mode).toBe("new");
+    expect(useThemeEditorStore.getState().open?.sourceTheme.id).toBe("nord");
+  });
+
+  it("offers Edit and Delete only on a custom card", () => {
+    render(<ThemeGallery />);
+    const builtin = screen.getByRole("radio", { name: /^Nord/ });
+    expect(within(builtin).queryByRole("button", { name: /^edit/i })).toBeNull();
+    expect(within(builtin).queryByRole("button", { name: /delete/i })).toBeNull();
+
+    const created = useSettingsStore.getState().duplicateTheme("nord", "Mine");
+    const card = screen.getByRole("radio", { name: /^Mine/ });
+    expect(within(card).getByRole("button", { name: /^edit/i })).toBeInTheDocument();
+    expect(created.name).toBe("Mine");
+  });
+
+  it("exports the theme on the card", () => {
+    mockDialogSave("/home/you/nord.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+    render(<ThemeGallery />);
+    const card = screen.getByRole("radio", { name: /^Nord/ });
+    fireEvent.click(within(card).getByRole("button", { name: /export/i }));
+    return Promise.resolve().then(() => {
+      expect(invokeCalls().some((c) => c.cmd === "write_user_file")).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemeGallery.test.tsx`
+Expected: FAIL — cannot resolve `./ThemeGallery`.
+
+- [ ] **Step 3: Write the gallery**
+
+Create `src/features/settings/theme/ThemeGallery.tsx`:
+
+- The container is `role="radiogroup"` with an `aria-label` of
+  `Theme` / `Light theme` / `Dark theme`, a CSS grid
+  (`repeat(auto-fill, minmax(190px, 1fr))`, gap 10), and an `onKeyDown` handling
+  `ArrowRight`/`ArrowDown` (next), `ArrowLeft`/`ArrowUp` (previous),
+  `Home`/`End`. Each move **activates** the theme it lands on, which is what
+  makes arrow-browsing a live preview rather than a focus walk.
+- Each card is `role="radio"`, `aria-checked`, `aria-label={theme.name}`,
+  `tabIndex={isActive ? 0 : -1}`, and contains
+  `<ThemePreview theme={theme} size="card" />`, the name, a
+  `Built-in` / `Custom` chip, and its action buttons. The active card takes a
+  `2px solid var(--accent)` ring; the rest `1px solid var(--border-1)`.
+- The theme list is `[...BUILTIN_THEMES, ...s.customThemes]`, filtered to
+  `appearance` when given. **A half may only name a theme of its own mode** —
+  the rule `pairOptions` already enforces, because a pairing whose halves share
+  a mode never switches.
+- Click / arrow → `s.setActiveThemeId(id)` with no `appearance`, or
+  `s.setPairedThemeId(appearance, id)` with one.
+- Card actions, all `<button>`s so `within(card).getByRole("button", …)` finds
+  them, each with `e.stopPropagation()` so the click does not also re-activate:
+  - **Duplicate** (every card) → `useThemeEditorStore.getState().openNew(theme)`.
+  - **Edit** (custom only) → `openEdit(theme)`.
+  - **Export…** (every card) → `exportThemeToFile(theme.id)`, flashing the path.
+  - **Delete** (custom only) → the existing `pgConfirm` copy from
+    `appearance.tsx`'s `onDelete`, then `s.deleteTheme(theme.id)`.
+- Icons via `PGIcon` with names the `IconName` union already declares (`copy`,
+  `edit`, `download`, `trash` — **verify each against `src/design/icons.tsx`**;
+  a name the union lacks renders a dashed square and fails
+  `test/iconSet.test.ts`).
+
+- [ ] **Step 4: Rewire the Appearance page**
+
+In `src/features/settings/pages/appearance.tsx`:
+- Delete the `PGSelect` from the `appearance.theme` row and both `PGSelect`s
+  from the `appearance.light` / `appearance.dark` rows, and delete
+  `themeOptions` and `pairOptions`.
+- Make those rows `stacked` with a `<ThemeGallery />` (fixed mode) or
+  `<ThemeGallery appearance="light" />` / `<ThemeGallery appearance="dark" />`
+  (follow-system mode) as the control. **Keep the row `id`s exactly** —
+  `appearance.theme`, `appearance.light`, `appearance.dark` — or
+  `settings.index.test.tsx` fails the build and Settings search stops finding
+  the theme picker.
+- Delete the whole button strip that held Edit / New / Delete / Export /
+  Import — Edit, Duplicate, Export and Delete now live on the cards. Keep a
+  single `Import theme…` button (`importThemeFromFile()`), because importing is
+  the one action that belongs to no existing card.
+- Delete the local `editor` state and the `onDelete` handler (both moved), and
+  render `<ThemeEditorDialog />` unconditionally at the end — it reads its own
+  open state now.
+- In `meta`, extend the keywords: `appearance.theme` gains
+  `gallery preview swatch duplicate import export`, and the light/dark rows gain
+  `gallery preview`.
+- Update the two hints to match reality: the built-in hint becomes
+  `Built-in themes are read-only — Duplicate one to start your own.` and the
+  custom hint `Custom theme. Edit it on its card.`
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings src/screens`
+Expected: PASS, including `settings.index.test.tsx`.
+
+Run: `~/Library/pnpm/pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Look at it**
+
+Screenshot the Appearance page in both fixed and follow-system mode, in a light
+theme and a dark one, using the headless-Chrome route. Check that nine cards
+read as nine distinguishable themes at card size and that the action buttons do
+not swamp the card. Fix what looks wrong before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+printf '%s\n' 'feat(theme): pick a theme by looking at it' '' 'Why: the picker was a dropdown of names with a star in front of the custom' 'ones, so choosing a theme meant applying it to find out. Cards carry a real' 'preview and their own Duplicate/Edit/Export/Delete; the row ids stay put so' 'Settings search keeps finding them.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add src/features/settings
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 12: Docs, and the whole-suite verification
+
+**Files:**
+- Modify: `docs/dev/frontend.md`
+- Modify: `docs/dev/backend.md`
+- Modify: `docs/dev/architecture.md`
+- Modify: `CLAUDE.md`
+- Modify: `e2e/specs/settings.e2e.ts`
+
+- [ ] **Step 1: Document the backend command**
+
+In `docs/dev/backend.md`, add a section for `commands/userfile.rs`: the two
+commands, `MAX_USER_FILE_BYTES = 4 MiB`, `AppError::Io` vs `InvalidPath`, and
+the trust model — **the path comes from a native dialog, the frontend may never
+synthesise one, and that is why `write_user_file` refuses to create parent
+directories.** Say why the app does not use `tauri-plugin-fs`: two thin commands
+match how every other backend capability here is exposed, and the plugin's scope
+config would be a second, parallel answer to "may the webview touch this path".
+
+`test/docs.test.ts` gates backend modules by filename mention across `CLAUDE.md`
+and every `docs/dev/*.md`, so this section satisfies it — but add the tree entry
+in Step 3 anyway, because a command nobody can find is a command that gets
+written twice.
+
+- [ ] **Step 2: Document the frontend**
+
+In `docs/dev/frontend.md`, in the theme area (near the "One theme format"
+bullet), add:
+- **One file save/open path** — `lib/userFile.ts`, why `<a download>` and
+  `<input type="file">` are gone (WebKitGTK ignores the download attribute;
+  #435 was that silence), that every save returns the path, that a cancel is
+  `null` and never a throw, and that `test/fileSave.test.ts` fails the build for
+  a relapse.
+- **One theme renderer** — `themeVars` is the map, `applyTheme` writes it to
+  `:root`, `ThemePreview` writes it to its own subtree and reads no `:root`
+  var; `themeVars.test.ts` pins the two together, so a new colour slot lands in
+  one place.
+- **The editor's draft lives in a store** — because `app.closeOverlay` reads
+  stores and a registered per-component handler would take Escape ahead of the
+  credential prompt, and because closing has to restore the pre-draft theme.
+- **Contrast warnings advise, never block.** Four pairs, Save never disabled.
+
+- [ ] **Step 3: Update the annotated trees**
+
+In `docs/dev/architecture.md`: add `commands/userfile.rs` to the backend tree
+with its one-line job, and add `lib/userFile.ts`,
+`features/settings/themeFiles.ts` and the new
+`features/settings/theme/*` modules (`themeVars` is in the store,
+`contrast.ts`, `deriveTheme.ts`, `ThemePreview.tsx`, `ThemeGallery.tsx`,
+`useThemeEditorStore.ts`) to the frontend tree.
+
+- [ ] **Step 4: Add the CLAUDE.md bullet**
+
+One bullet in the conventions list, in the established voice:
+
+```markdown
+- **One file save/open path — `lib/userFile.ts`.** A webview is not a browser:
+  WebKitGTK ignores `<a download>`, so every export in the app silently did
+  nothing on Linux (#435). Native `save()`/`open()` plus
+  `commands/userfile.rs`; a save returns the PATH so a surface can name the
+  file. No `<a download>`, no `<input type="file">`, no `createObjectURL` in
+  shipped `src/` — `test/fileSave.test.ts` fails the build.
+  (`docs/dev/frontend.md`)
+```
+
+Keep it to that. `CLAUDE.md` is loaded into every session and was cut from 2,456
+lines once; the deep version belongs in `docs/dev/frontend.md`.
+
+- [ ] **Step 5: Extend the e2e spec**
+
+Read `.claude/skills/e2e-testing/SKILL.md` **before** touching
+`e2e/specs/settings.e2e.ts` — it owns the selector and waiting rules, and
+`waitForExist` is the stale-proof wait (`isDisplayed` caches `elementId` and
+dies on a re-render).
+
+Add one case to `settings.e2e.ts`: open Settings → Appearance, click
+**Duplicate** on a built-in card, change one colour in the editor, save, and
+assert the gallery shows the new custom theme as the active card.
+
+**Do not try to cover export or import in e2e.** The dialogs are native and out
+of WebDriver's reach. The Rust tests in Task 1 and the `saveTextFile`
+assertions in Tasks 2, 3, 10 and 11 are what cover the file path — and saying so
+here is the point: **a green e2e suite is not evidence that #435 is fixed.**
+
+- [ ] **Step 6: Verify the whole tree, after the last edit**
+
+A green number is only evidence for the tree it ran on, so this runs last.
+
+```bash
+~/Library/pnpm/pnpm tsc --noEmit
+~/Library/pnpm/pnpm exec tsc -p e2e/tsconfig.json --noEmit
+~/Library/pnpm/pnpm test
+~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+All four must pass. Notes on reading the results:
+- A red `unit` on `ImageDiffView`'s delta test is a known ~1-in-111 flake — re-run
+  rather than audit, and `main` being green does not rule it out.
+- `test/docs.test.ts`, `test/privacy.test.ts`, `test/appErrors.test.ts`,
+  `test/iconSet.test.ts` and `settings.index.test.tsx` are absence-asserting
+  guards. If one is red, it is about this change, not a flake.
+
+Then the e2e gate, rebuilding the snapshot first because `src/` and `src-tauri/`
+both changed. **One cold container build at a time across all worktrees**, and
+never run a full vitest suite alongside a Docker e2e build — contention fakes a
+red:
+
+```bash
+~/Library/pnpm/pnpm test:e2e:docker build
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/settings.e2e.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+printf '%s\n' 'docs(theme): document the file path, the renderer and the editor store' '' 'Why: "a webview is not a browser" is not something the next session guesses,' 'and #435 survived a release because the failure was silent. The CLAUDE.md' 'bullet earns its line the way the proc.rs and PGSelect rules did -- it is' 'guard-tested.' '' 'Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>' > /tmp/pg-msg.txt
+git add CLAUDE.md docs e2e/specs/settings.e2e.ts
+git commit -F /tmp/pg-msg.txt
+```
+
+---
+
+### Task 13: Manual verification against the real bug
+
+**Files:** none — this is the step that decides whether #435 is actually fixed.
+
+The unit suite mocks the dialog plugin and the Rust tests never touch a webview,
+so **nothing automated in this plan proves the button works in the app.** That
+is exactly how #435 shipped.
+
+- [ ] **Step 1: Run the real app**
+
+```bash
+~/Library/pnpm/pnpm tauri dev
+```
+
+- [ ] **Step 2: Walk the flow that was broken**
+
+1. Settings → Appearance. Confirm nine theme cards render, each recognisably its
+   own theme.
+2. Duplicate a built-in. Confirm the editor opens with a preview that changes as
+   you drag a colour.
+3. Set primary text to the canvas colour. Confirm a contrast warning appears and
+   **Save is still enabled**.
+4. `Export…` from the editor footer. **Confirm a native save dialog opens**, pick
+   a path, and confirm the file exists on disk with the draft's JSON in it.
+5. Edit that file in a text editor, change the name, then `Import…` from the
+   editor. Confirm the draft picks up the change. That round trip is what the
+   reporter asked for.
+6. Save the theme. Confirm it appears as a card and is active.
+7. `Export…` from its card, and `Import theme…` from the page.
+8. Settings → Backup: `Export settings`, confirm the dialog and the file, then
+   `Import settings` and confirm the change report.
+9. Press Escape in the editor mid-edit. Confirm the dialog closes **and the app
+   returns to the theme it was on** — not the abandoned draft.
+
+- [ ] **Step 3: Note what you could not verify**
+
+The report on this branch must say plainly that the fix was verified on macOS
+and that **Linux/WebKitGTK — the platform in the report — was not exercised
+directly**. `pnpm test:e2e:docker` runs Linux but cannot drive a native dialog,
+so the Linux evidence is the Rust tests plus the fact that no browser download
+API is left in the tree (`test/fileSave.test.ts`). Ask the reporter to confirm
+on 26.04, or say why that is the right next step.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/theme-editor-revamp
+```
+
+Then `gh pr create` with a body written to a file (`--body-file`, never
+`--body "<prose>"`). The body should carry: the root cause in two sentences, the
+before/after of the file path, the UX changes, **which assertion caught the
+planted guard violation** (Task 4), and the platform caveat from Step 3.
+Reference `#435` so it auto-closes — then **verify** with
+`gh pr view <N> --json closingIssuesReferences` before merging, because a body
+that says "does not close #435" still closes it.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: the file path → Tasks 1-3;
+the guard → Task 4; `themeVars` → Task 5; contrast → Task 6; `deriveTheme` →
+Task 7; `ThemePreview` → Task 8; the editor store and the `closeOverlay` chain →
+Task 9; the rebuilt editor → Task 10; the gallery and the Appearance page →
+Task 11; docs and the CLAUDE.md bullet → Task 12; the manual walk the spec's
+testing section says e2e cannot cover → Task 13.
+
+**Names.** `themeVars`, `contrastReport`, `CONTRAST_PAIRS`, `deriveTheme`,
+`ThemePreview`, `ThemeGallery`, `useThemeEditorStore`, `saveTextFile`,
+`openTextFile`, `themeFileName`, `exportThemeToFile`,
+`exportThemeDraftToFile`, `importThemeFromFile`, `exportSettingsToFile`,
+`importSettingsFromFile`, `readUserFile`, `writeUserFile`, `read_user_file`,
+`write_user_file`, `MAX_USER_FILE_BYTES`, `mockDialogSave`,
+`lastDialogSaveOptions` — each is defined in exactly one task and spelled the
+same everywhere it is consumed.
+
+**Verified while writing this plan, so the tasks above spell them correctly:**
+`mockInvoke(cmd, handler)` takes a **function** and throws for an unregistered
+command; the call log is `getInvokeCalls()`; the icon union declares `warn`
+(there is no `alert-triangle`), and `copy`, `edit`, `download` and `trash` all
+exist. **Still check every other `PGIcon name=` literal** against
+`src/design/icons.tsx` before using it — `name` is typed `IconName | string`,
+so a typo type-checks, renders a dashed square, and is caught only by
+`test/iconSet.test.ts`.

--- a/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
+++ b/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
@@ -1,0 +1,326 @@
+# Theme creation revamp + a working file path — spec
+
+Issue: #435 (`[bug] ubuntu 26.04 > export theme does not work`), plus the
+theme-creation UX revamp the fix was scoped with.
+
+## The bug, precisely
+
+Every "export" in the app writes its file the same way:
+
+```ts
+const blob = new Blob([json], { type: "application/json" });
+const url = URL.createObjectURL(blob);
+const a = document.createElement("a");
+a.href = url;
+a.download = `${slug}.pgtheme.json`;
+a.click();
+```
+
+Three call sites do this — `useSettingsStore.downloadTheme`,
+`useSettingsStore.downloadSettings`, and the editor's inline "Export draft"
+handler. **WebKitGTK ignores the `download` attribute on a blob URL**, so on
+Linux the click is a no-op with no error, no console message and no file: the
+exact report in #435. It is not a Linux-only latent bug either — a webview is
+not a browser, and nothing about `<a download>` is contracted to work in one.
+
+The mirror image is import, which goes through a hidden `<input type="file">`
+in two places (`pages/appearance.tsx`, `pages/backup.tsx`). That one happens to
+work today because WebKitGTK ships a default file chooser, but it is the same
+category of mistake: the app reaches for a browser affordance where it has a
+native one, and it cannot report the path it read, so the UI has to say vague
+things like "your downloads folder".
+
+There is no backend file-write command at all, and only `dialog:allow-open` is
+granted in `capabilities/default.json`. So the fix is a real native save path,
+not a patch to the anchor click.
+
+## Scope
+
+Approved with the issue:
+
+1. **One native file path**, used by every export and import. Covers the
+   settings backup card too — it is broken by the identical mechanism, and
+   fixing the mechanism once while leaving a second caller on the broken one is
+   how this regresses.
+2. **A theme gallery** replacing the name-only dropdown on the Appearance page.
+3. **A rebuilt editor**: design-system modal, an inline live preview of the real
+   UI, a guided base+accent start, and advisory contrast warnings.
+
+Out of scope: new built-in themes, syntax-token editing (`SYNTAX_TOKENS` and
+`SEMANTIC_TOKENS` stay mode-calibrated constants), theme sharing over the
+network (there is none — "no telemetry, no account" is a build gate).
+
+## 1. One file path
+
+### Backend — `src-tauri/src/commands/userfile.rs`
+
+Two commands, thin over `std::fs`, both in `spawn_blocking` because fs is sync:
+
+```rust
+#[tauri::command]
+pub async fn write_user_file(path: String, contents: String) -> AppResult<()>;
+
+#[tauri::command]
+pub async fn read_user_file(path: String) -> AppResult<String>;
+```
+
+- Errors are `AppError::Io` and `AppError::InvalidPath`. **No new `AppError`
+  variant**, so the Rust enum and its TS union stay as they are and
+  `test/appErrors.test.ts` needs nothing.
+- `read_user_file` is capped at `MAX_USER_FILE_BYTES` (4 MiB) and refuses
+  anything larger with `InvalidPath`. A settings bundle with every custom theme
+  is a few tens of KB; the cap is there because the path comes from a file
+  picker and a mis-picked disk image should not be slurped into the webview.
+- `write_user_file` writes the whole string in one `fs::write`, creating or
+  truncating. It does **not** create parent directories: the path came from a
+  native save dialog, so its directory exists, and inventing directories from a
+  webview string is a bigger privilege than this feature needs.
+- The module doc says plainly what the trust model is: these take an absolute
+  path the **user** chose in a native dialog. Nothing in the frontend may
+  synthesise a path for them.
+
+Registered in `commands/mod.rs` and in `invoke_handler![…]` in `lib.rs`, and
+listed in `docs/dev/architecture.md`'s backend tree — `test/docs.test.ts` fails
+the build otherwise.
+
+### Frontend — `src/lib/userFile.ts`
+
+The single place that picks a file and moves its bytes:
+
+```ts
+export type FileFilter = { name: string; extensions: string[] };
+
+/** Native save dialog, then write. `null` when the user cancelled. */
+export async function saveTextFile(opts: {
+  defaultName: string;
+  contents: string;
+  filters?: FileFilter[];
+}): Promise<string | null>;
+
+/** Native open dialog, then read. `null` when the user cancelled. */
+export async function openTextFile(opts?: {
+  filters?: FileFilter[];
+}): Promise<{ path: string; contents: string } | null>;
+```
+
+- `save()` / `open()` come from `@tauri-apps/plugin-dialog`; the read and write
+  go through the typed `invoke` wrappers in `lib/tauri.ts` (never `invoke`
+  directly).
+- **Returning the path is the point.** Every surface can then say *Saved to
+  `/home/you/my-theme.pgtheme.json`* instead of guessing at a downloads folder.
+- Cancel is `null`, never a throw — a dismissed dialog is "no answer", matching
+  how `pgConfirm`/`pgPrompt` read a dismissal.
+
+`dialog:allow-save` joins `capabilities/default.json`. `dialog:allow-open` is
+already there.
+
+### Callers
+
+| Surface | Was | Becomes |
+|---|---|---|
+| Appearance → Export | `downloadTheme(id)` (blob) | `exportThemeToFile(id)` → path |
+| Editor → Export | inline blob handler | same helper, on the unsaved draft |
+| Editor → Import | *(did not exist)* | loads a file into the draft |
+| Appearance → Import | `<input type="file">` | `openTextFile` → `importThemeJson` |
+| Backup → Export settings | `downloadSettings()` (blob) | `exportSettingsToFile()` → path |
+| Backup → Import settings | `<input type="file">` | `openTextFile` → `importSettings` |
+
+`downloadTheme` and `downloadSettings` are **removed** from the store, not kept
+as aliases: a working export and a broken one under two names is worse than
+either. The store keeps the pure `exportTheme` / `exportSettings` serialisers —
+they are what the tests assert on, and keeping the side effect out of them is
+the same split `features/report/` already makes between `report.ts` and
+`fileReport.ts`. The file-writing wrappers live beside them in
+`features/settings/themeFiles.ts`, which is the only module that imports
+`lib/userFile.ts` for settings work.
+
+### The guard
+
+`test/fileSave.test.ts` fails the build when a shipped file under `src/`
+contains `URL.createObjectURL`, an `a.download =` assignment, or an
+`<input type="file">`. That is the house pattern for a rule that cost a release
+(`Command::new` outside `proc.rs`, native `<select>`, `window.confirm`), and it
+is what stops the next export from being written as an anchor click.
+
+## 2. One theme renderer
+
+`applyTheme` today walks 19 `setProperty` calls on `document.documentElement`,
+then writes `SEMANTIC_TOKENS[mode]`, `SELECTION_TOKENS[mode]` and
+`SYNTAX_TOKENS[mode]`. Nothing can paint a theme *other than the active one*,
+which is why neither a gallery card nor a preview pane is possible today.
+
+Extract the map:
+
+```ts
+/** Every CSS var a theme sets, as a plain map. */
+export function themeVars(theme: ThemeDef): Record<string, string>;
+```
+
+`applyTheme(theme)` becomes "write `themeVars(theme)` to `:root`" and keeps its
+signature and behaviour. `ThemePreview` writes the same map as inline style on
+its own root element, so a theme renders identically whether it is the active
+one or a card on a page painted in something else. **One source of truth for
+what a theme means** — a new colour slot or a new derived token lands in
+`themeVars` and both surfaces get it.
+
+`src/features/settings/theme/ThemePreview.tsx` renders a miniature of the real
+app from an explicit `{ colors, mode }`: titlebar with window controls, sidebar,
+two history rows with a graph edge and a HEAD mark, a diff hunk with an added
+and a removed line, a primary button, and a status line. It reads **no**
+`:root` var — everything it paints comes from the map — so it is honest inside
+the editor and inside a card, and a component test can assert its computed
+colours without mounting the app.
+
+Sizes: `size="card"` (gallery, ~180×120) and `size="pane"` (editor, fills its
+column). Same tree, scaled type and spacing — not two components that drift.
+
+## 3. The gallery
+
+`ThemeGallery.tsx`, on the Appearance page, replacing the `PGSelect` whose
+options were `★ ${name}`.
+
+- A card per theme: a `ThemePreview size="card"`, the name, a `Built-in` or
+  `Custom` badge, and a ring plus a check when it is the one in use.
+- Click activates (`setActiveThemeId`, or `setPairedThemeId` for a half).
+- **Follow-system mode shows two galleries**, Light and Dark, each filtered to
+  themes of that mode — the same rule `pairOptions` enforces today, since a
+  pairing whose halves are the same mode never switches. Fixed mode shows one
+  gallery of all nine built-ins plus every custom theme.
+- Actions live on the card, not in a detached button row: **Edit**,
+  **Duplicate**, **Export…**, **Delete** on a custom card; **Duplicate to
+  customise** and **Export…** on a built-in one. `duplicateTheme` already
+  exists in the store and has never had a UI.
+- Keyboard: the gallery is a `radiogroup`, cards are `radio`s, arrow keys move,
+  Enter/Space activates. A visual picker that is mouse-only is not a usability
+  win.
+
+**Settings search keeps working.** The `meta.cards[].rows` ids stay
+`appearance.theme`, `appearance.light`, `appearance.dark` with the gallery as a
+`stacked` control, so `settings.index.test.tsx` and search-by-keyword are
+unaffected. The `keywords` gain `gallery preview swatch duplicate`.
+
+## 4. The editor
+
+`ThemeEditorDialog` keeps its name and its `{ mode, sourceTheme, onClose }`
+props. What changes:
+
+- **It is a `PGModal`.** The hand-rolled `position: fixed` backdrop goes, and
+  so does its local `window.addEventListener("keydown")` Escape handler —
+  `modal.tsx` documents that a component-local capture-phase Escape listener is
+  precisely the anti-pattern issue #47 was fixed to avoid. Escape routes through
+  `app.closeOverlay`, like every other dialog.
+- **Two columns.** Controls left, `ThemePreview size="pane"` right, contrast
+  warnings under the preview. Live-apply to `:root` stays — seeing the real
+  window change is worth keeping, and Cancel still restores the theme captured
+  on open — but it is no longer the *only* feedback, which is what made a
+  dimmed, 90%-obscured window the judge of a palette.
+- **Guided start.** A "Start from" base picker and an accent swatch:
+
+  ```ts
+  export function deriveTheme(base: ThemeDef, accent: string): ThemeColors;
+  ```
+
+  Takes the base palette, sets `accent`, and recomputes `accentInk` to whichever
+  of the base's lightest/darkest ink reads against it. Deliberately no
+  hue-shifting of the greys: a two-click theme that is *legible* beats a
+  generated palette nobody can predict. Everything else stays editable.
+- **All colours** stays — the same 18 fields in the same five groups, collapsed
+  behind a disclosure so the guided path is the default and full control is one
+  click away.
+- **Contrast warnings.** `features/settings/theme/contrast.ts` implements WCAG
+  relative luminance and ratio, and the editor checks the pairs that decide
+  whether the app is readable: `fg0`/`bg0`, `fg1`/`bg1`, `fg2`/`bg1`,
+  `accentInk`/`accent`. Below 4.5:1 warns, below 3:1 warns harder. **Advisory,
+  never blocking** — a deliberately low-contrast theme is the user's call, and
+  Save is never disabled by it. Today you can build an unreadable theme with no
+  feedback at all, which is the single worst thing about the current editor.
+- **Mode flip re-bases.** Switching Dark→Light with dark colours in the draft
+  offers, via `pgConfirm`, to re-base from the matching built-in. Declining
+  keeps the colours. Keeping dark greys under light semantic calibration is
+  unreadable (#61 B4), and silently doing that is how "Light" appears broken.
+- **Export…/Import…** in the footer, on the native path, both operating on the
+  unsaved draft. Import into the editor is new: it is how you round-trip a theme
+  through an external editor, which is what #435's reporter was trying to do.
+
+`ColorEditor.tsx` keeps its `{ colors, onPatch }` shape and its `normalizeHex`
+export. `ColorField` gains the contrast badge for the pairs it participates in.
+
+## Data flow
+
+```
+gallery card ──click──> setActiveThemeId / setPairedThemeId ──> applyResolved
+                                                                    │
+                                                              themeVars ──> :root
+editor draft ──state──> applyTheme(draft)  ──────────────────> themeVars ──> :root
+             └────────> ThemePreview ──────────────────────── themeVars ──> subtree
+             └────────> contrastReport(colors) ─────────────> warnings
+
+Export:  exportTheme(id) ─json──> saveTextFile ──save()──> write_user_file ──> disk
+Import:  openTextFile ──open()──> read_user_file ──json──> importThemeJson ──> store
+```
+
+## Error handling
+
+- A cancelled dialog is `null` and produces no message. Silence on cancel,
+  never a "failed" flash.
+- A failed write flashes the `AppError`'s prose through `appErrorMessage` — the
+  existing path. Export lives in Settings, not on a repository surface, so
+  `PGErrorBanner`'s repo-scoped placement does not apply; `pgFlash` is what the
+  neighbouring settings actions already use.
+- A malformed import keeps today's behaviour: `validateTheme` throws, the
+  message lands in the row's hint, nothing is changed. `normalizeCustomThemes`
+  stays lenient in the direction it already chose — a missing colour is filled
+  from the default theme rather than costing the user the file.
+- A write that succeeds reports **the path**, which is the whole reason the
+  helper returns it.
+
+## Testing
+
+- **Unit** — `contrast.ts` (known WCAG pairs, including the black/white
+  extremes), `deriveTheme` (accent lands, ink flips at the crossover, other
+  slots untouched), `themeVars` (every `ThemeColors` key appears; the map
+  matches what `applyTheme` writes to `:root`, which is what stops the two
+  drifting).
+- **Component** — gallery (renders every theme, click activates, follow-system
+  shows two mode-filtered galleries, arrow-key navigation, per-card actions);
+  editor (preview repaints on a colour change, contrast warning appears and
+  never disables Save, mode flip prompts, export calls `saveTextFile` with the
+  slug and the draft's JSON, import loads a file into the draft); `ThemePreview`
+  (computed colours come from the passed theme, not `:root`).
+  Clipboard-adjacent assertions use `fireEvent`, not `userEvent` — `setup()`
+  replaces `navigator.clipboard` and detaches spies.
+- **Guard** — `test/fileSave.test.ts` as above; `test/docs.test.ts` and
+  `settings.index.test.tsx` must stay green, which pins the docs entry and the
+  settings row ids.
+- **Rust** — `userfile.rs` integration tests: round-trip a file, refuse an
+  oversized read, report a missing path as `Io`, refuse a directory.
+- **E2E** — one addition to `settings.e2e.ts`: open Appearance, duplicate a
+  built-in into a custom theme, change a colour, save, and assert the gallery
+  shows it as active. The file dialogs are native and out of WebDriver's reach,
+  so **e2e does not cover export/import** — that is what the Rust tests and the
+  component tests on `saveTextFile` are for. Saying so here is the point: a
+  green suite is not evidence that #435 is fixed.
+
+## Docs
+
+- `docs/dev/frontend.md` — the gallery and editor, `themeVars` as the one
+  renderer, and why the preview reads no `:root` var.
+- `docs/dev/backend.md` — `commands/userfile.rs`, the cap, and the "path came
+  from a native dialog" trust model.
+- `docs/dev/architecture.md` — `userfile.rs` in the backend tree, the new
+  frontend modules in the frontend tree.
+- `CLAUDE.md` — one bullet: **one file save/open path (`lib/userFile.ts`);
+  never `<a download>`, and a guard test enforces it.** It earns a line for the
+  same reason the `proc.rs` and `PGSelect` rules did — it is guard-tested, and a
+  webview is not a browser is not something the next session will guess.
+
+## What this deliberately does not do
+
+- No new built-in themes. Nine is enough to fork from.
+- No hue-shifting palette generator. `deriveTheme` swaps the accent and fixes
+  the ink; anything cleverer produces palettes the user cannot predict or
+  correct.
+- No blocking on contrast. Warn, never refuse.
+- No `tauri-plugin-fs`. Two thin commands match how every other backend
+  capability in this app is exposed, and the plugin's scope config would be a
+  second, parallel answer to "may the webview touch this path".

--- a/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
+++ b/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
@@ -209,6 +209,24 @@ props. What changes:
   `modal.tsx` documents that a component-local capture-phase Escape listener is
   precisely the anti-pattern issue #47 was fixed to avoid. Escape routes through
   `app.closeOverlay`, like every other dialog.
+- **The draft moves into a store** — `features/settings/theme/useThemeEditorStore.ts`,
+  holding `{ mode, sourceTheme, name, themeMode, colors, originalTheme }`.
+  Two reasons, and the first is not cosmetic:
+  - `app.closeOverlay`'s chain in `features/keymap/actions.ts` reads *stores*
+    (`useCreateStore`, `useCreateTagStore`, `useReportStore`), because a
+    registered per-component handler runs **before** the default runner and
+    would take Escape ahead of the credential prompt. Local React state cannot
+    join that chain, which is why the editor grew the local listener it should
+    not have had.
+  - **Closing must restore.** `close()` re-applies `originalTheme`, so Escape,
+    the backdrop click and Cancel are one path. An Escape that only unmounted
+    the dialog would leave the abandoned draft painted on the app — the bug the
+    current `handleCancel` avoids only because it owns the keystroke itself.
+
+  The editor's branch goes after `useReportStore`'s and before
+  `useUpdateStore`'s: same `PGModal` base layer as the other dialogs, still
+  below the credential prompt's `nested` layer. `actions.test.ts` gets a case
+  pinning that order, the way #212's does.
 - **Two columns.** Controls left, `ThemePreview size="pane"` right, contrast
   warnings under the preview. Live-apply to `:root` stays — seeing the real
   window change is worth keeping, and Cancel still restores the theme captured

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -387,6 +387,81 @@ describe("settings", () => {
   });
 
   /**
+   * The file commands behind every export, over REAL IPC on real WebKitGTK.
+   *
+   * This is the closest thing to evidence for #435 that an automated test can
+   * produce. What it does NOT cover is the native save dialog: WebDriver
+   * cannot drive an OS modal, so `saveTextFile`'s first half is out of reach
+   * here and is covered by component tests against the mocked plugin.
+   *
+   * What it DOES cover is everything the old implementation got wrong, on the
+   * platform that reported it: the commands are registered under the names the
+   * frontend calls, their argument names match, `dialog`/fs access is actually
+   * permitted by `capabilities/default.json`, and a write really lands on a
+   * Linux filesystem and reads back byte-for-byte. The old code never reached
+   * a command at all — it handed the file to an `<a download>` that WebKitGTK
+   * silently ignores.
+   *
+   * executeOnce: a driver-retry re-run would re-issue the write.
+   */
+  it("writes and reads a real file through the export commands", async () => {
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+
+    const path = `/tmp/pg-e2e-theme-${Date.now()}.pgtheme.json`;
+    const body = JSON.stringify(
+      { $schema: "https://platypusgit.dev/theme.schema.json", version: 1, name: "IPC" },
+      null,
+      2,
+    );
+
+    const wrote = await executeOnce(
+      async (p: string, contents: string) => {
+        const core = (window as unknown as {
+          __TAURI__?: { core?: { invoke: (c: string, a?: unknown) => Promise<unknown> } };
+        }).__TAURI__?.core;
+        if (!core) return "no bridge";
+        try {
+          await core.invoke("write_user_file", { path: p, contents });
+          return "ok";
+        } catch (e) {
+          return `write failed: ${String(e)}`;
+        }
+      },
+      path,
+      body,
+    );
+    expect(wrote).toBe("ok");
+
+    const readBack = await browser.execute(async (p: string) => {
+      const core = (window as unknown as {
+        __TAURI__?: { core?: { invoke: (c: string, a?: unknown) => Promise<unknown> } };
+      }).__TAURI__?.core;
+      try {
+        return (await core!.invoke("read_user_file", { path: p })) as string;
+      } catch (e) {
+        return `read failed: ${String(e)}`;
+      }
+    }, path);
+    expect(readBack).toBe(body);
+
+    // A folder is a refusal, not a surprise — the cap and the type checks are
+    // the reason a mis-picked path cannot become a gigabyte-sized IPC message.
+    const folder = await browser.execute(async () => {
+      const core = (window as unknown as {
+        __TAURI__?: { core?: { invoke: (c: string, a?: unknown) => Promise<unknown> } };
+      }).__TAURI__?.core;
+      try {
+        await core!.invoke("read_user_file", { path: "/tmp" });
+        return "unexpectedly succeeded";
+      } catch (e) {
+        return JSON.stringify(e);
+      }
+    });
+    expect(folder).toContain("InvalidPath");
+  });
+
+  /**
    * The report dialog against the real webview.
    *
    * What only a real run proves: the diagnostics commands actually answer on

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -321,6 +321,72 @@ describe("settings", () => {
   });
 
   /**
+   * Creating a custom theme, end to end, in the real webview (#435 revamp).
+   *
+   * What only a real run proves: the gallery renders a card per theme in the
+   * real engine, Duplicate opens the editor seeded from that card, the live
+   * preview and the app repaint from one `themeVars` map, and the saved theme
+   * survives as the active one.
+   *
+   * **Export and import are deliberately NOT here.** They open a NATIVE save
+   * or open dialog, which WebDriver cannot drive at all — so a green e2e suite
+   * is not evidence that #435 is fixed. That evidence is
+   * `src-tauri/tests/user_file.rs` plus the `saveTextFile` component tests,
+   * and `test/fileSave.test.ts` for the pattern never coming back.
+   */
+  it("duplicates a built-in theme into a custom one and keeps it", async () => {
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await openSettings("general.appearance");
+
+    // The gallery, not a dropdown of names: one card per theme, each a real
+    // preview painted in its own colours.
+    const nordCard = $('[role="radio"][aria-label="Nord"]');
+    await nordCard.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "theme gallery never rendered the Nord card",
+    });
+
+    await $('button[aria-label="Duplicate Nord"]').click();
+
+    // The editor is a PGModal reading useThemeEditorStore, so its own name
+    // field is the signal that the draft opened — not the dialog wrapper,
+    // which several other overlays also produce.
+    const nameField = $('[data-testid="theme-editor-name"]');
+    await nameField.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "theme editor never opened from Duplicate",
+    });
+    await nameField.setValue("E2E Theme");
+
+    // The preview paints from the DRAFT, in its own subtree — the property
+    // that makes a card able to show a theme other than the active one.
+    const previewAccent = await browser.execute(() => {
+      const el = document.querySelector("[data-testid='theme-preview']");
+      return el ? (el as HTMLElement).style.getPropertyValue("--accent") : null;
+    });
+    expect(previewAccent).toBeTruthy();
+
+    await $('[data-testid="theme-editor-save"]').click();
+
+    // Acceptance: the new theme is what the app is wearing, and the gallery
+    // says so on its own card. `data-theme` is what `applyTheme` stamps, so a
+    // draft id here would mean the save never went through the store.
+    const savedCard = $('[role="radio"][aria-label="E2E Theme"]');
+    await savedCard.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the saved theme never appeared as a gallery card",
+    });
+    await browser.waitUntil(
+      async () => (await savedCard.getAttribute("aria-checked")) === "true",
+      { timeout: 10_000, timeoutMsg: "the saved theme never became the active card" },
+    );
+    const themeId = await browser.execute(() => document.documentElement.dataset.theme);
+    expect(themeId).not.toBe("__draft__");
+    expect(themeId).toMatch(/^custom-/);
+  });
+
+  /**
    * The report dialog against the real webview.
    *
    * What only a real run proves: the diagnostics commands actually answer on

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "core:webview:allow-set-webview-zoom",
     "dialog:default",
     "dialog:allow-open",
+    "dialog:allow-save",
     "os:default",
     "log:default"
   ]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod stash;
 pub mod submodule;
 pub mod terminal;
 pub mod update;
+pub mod userfile;
 pub mod watch;
 pub mod windows;
 pub mod worktree;

--- a/src-tauri/src/commands/userfile.rs
+++ b/src-tauri/src/commands/userfile.rs
@@ -1,0 +1,73 @@
+//! Reading and writing one file the user picked in a native dialog (#435).
+//!
+//! Export used to be a browser trick: a `Blob`, an `<a download>` and a
+//! synthetic click. WebKitGTK ignores the `download` attribute on a blob URL,
+//! so on Linux "Export theme" did nothing — no file, no error, no log line. A
+//! webview is not a browser, and nothing about `<a download>` is contracted to
+//! work in one, so the fix is a real native path rather than a patch to the
+//! click.
+//!
+//! **The trust model, stated plainly:** these take an absolute path the USER
+//! chose in a native save or open dialog (`@tauri-apps/plugin-dialog`, behind
+//! `src/lib/userFile.ts`). Nothing in the frontend may synthesise a path for
+//! them. That is why `write_user_file` refuses to create parent directories:
+//! a dialog's path always has a parent that exists, so a request to invent one
+//! is a request that did not come from a dialog.
+//!
+//! No `tauri-plugin-fs`. Two thin commands match how every other backend
+//! capability here is exposed, and the plugin's scope config would be a second,
+//! parallel answer to "may the webview touch this path".
+
+use crate::error::{AppError, AppResult};
+
+/// The largest file `read_user_file` will hand to the webview.
+///
+/// A settings bundle with every custom theme is a few tens of kilobytes. The cap
+/// exists because the path comes from a file picker and a mis-picked disk image
+/// should be a refusal, not a webview that swallows a gigabyte of bytes.
+pub const MAX_USER_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Write `contents` to `path`, creating or truncating it.
+#[tauri::command]
+pub async fn write_user_file(path: String, contents: String) -> AppResult<()> {
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidPath("no file was chosen".into()));
+    }
+    // libgit2 is not involved here, but the reason for spawn_blocking is the
+    // same: std::fs is sync, and blocking the async runtime's worker on a slow
+    // network volume would stall every other command with it.
+    tokio::task::spawn_blocking(move || {
+        std::fs::write(&path, contents.as_bytes())
+            .map_err(|e| AppError::Io(format!("cannot write {path}: {e}")))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("write task failed: {e}")))?
+}
+
+/// Read `path` as UTF-8 text, refusing anything that is not a file we can hand
+/// to the webview whole.
+#[tauri::command]
+pub async fn read_user_file(path: String) -> AppResult<String> {
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidPath("no file was chosen".into()));
+    }
+    tokio::task::spawn_blocking(move || {
+        let meta = std::fs::metadata(&path)
+            .map_err(|e| AppError::Io(format!("cannot read {path}: {e}")))?;
+        if meta.is_dir() {
+            return Err(AppError::InvalidPath(format!(
+                "{path} is a folder, not a file"
+            )));
+        }
+        if meta.len() > MAX_USER_FILE_BYTES {
+            return Err(AppError::InvalidPath(format!(
+                "{path} is too large to read ({} bytes; the limit is {MAX_USER_FILE_BYTES})",
+                meta.len()
+            )));
+        }
+        std::fs::read_to_string(&path)
+            .map_err(|e| AppError::Io(format!("cannot read {path}: {e}")))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("read task failed: {e}")))?
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -491,6 +491,8 @@ pub fn run() {
             commands::ssh::ssh_key_generate,
             commands::update::check_for_update,
             commands::update::get_update_capability,
+            commands::userfile::read_user_file,
+            commands::userfile::write_user_file,
             commands::custom_action::run_custom_action,
             commands::windows::register_window_repos,
             commands::windows::next_window_label,

--- a/src-tauri/tests/user_file.rs
+++ b/src-tauri/tests/user_file.rs
@@ -1,0 +1,106 @@
+//! Reading and writing a file the USER picked in a native dialog (#435).
+//!
+//! Theme and settings export used to write its file with a blob URL and an
+//! `<a download>` click, which WebKitGTK ignores — so on Linux the button did
+//! nothing at all. These commands are the native replacement, and the property
+//! worth asserting is that they are boring: an exact round trip, and a refusal
+//! rather than a surprise for every input that is not a writable file.
+
+use platypusgit_lib::commands::userfile::{read_user_file, write_user_file, MAX_USER_FILE_BYTES};
+use platypusgit_lib::error::AppError;
+
+#[tokio::test]
+async fn round_trips_a_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("my-theme.pgtheme.json");
+    let body = "{\n  \"name\": \"My theme\"\n}\n";
+
+    write_user_file(path.to_string_lossy().to_string(), body.to_string())
+        .await
+        .expect("write should succeed");
+
+    let read = read_user_file(path.to_string_lossy().to_string())
+        .await
+        .expect("read should succeed");
+    assert_eq!(read, body);
+}
+
+#[tokio::test]
+async fn write_truncates_an_existing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("theme.json");
+    let p = path.to_string_lossy().to_string();
+
+    write_user_file(p.clone(), "a-much-longer-first-write".to_string())
+        .await
+        .unwrap();
+    write_user_file(p.clone(), "short".to_string()).await.unwrap();
+
+    assert_eq!(read_user_file(p).await.unwrap(), "short");
+}
+
+#[tokio::test]
+async fn read_reports_a_missing_file_as_io() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nope.json");
+    match read_user_file(path.to_string_lossy().to_string()).await {
+        Err(AppError::Io(_)) => {}
+        other => panic!("expected Io for a missing file, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn read_refuses_a_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    match read_user_file(dir.path().to_string_lossy().to_string()).await {
+        Err(AppError::InvalidPath(_)) => {}
+        other => panic!("expected InvalidPath for a directory, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn read_refuses_an_oversized_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("huge.json");
+    // One byte over the cap is enough: the check is on metadata, so the test
+    // does not need to write a realistic 4 MiB of JSON to prove the refusal.
+    let big = vec![b'x'; (MAX_USER_FILE_BYTES + 1) as usize];
+    std::fs::write(&path, big).unwrap();
+
+    match read_user_file(path.to_string_lossy().to_string()).await {
+        Err(AppError::InvalidPath(m)) => {
+            assert!(m.contains("too large"), "the refusal should say why: {m}")
+        }
+        other => panic!("expected InvalidPath for an oversized file, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_refuses_an_empty_path() {
+    match write_user_file(String::new(), "x".to_string()).await {
+        Err(AppError::InvalidPath(_)) => {}
+        other => panic!("expected InvalidPath for an empty path, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn read_refuses_an_empty_path() {
+    match read_user_file("   ".to_string()).await {
+        Err(AppError::InvalidPath(_)) => {}
+        other => panic!("expected InvalidPath for a blank path, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_does_not_create_parent_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("no-such-dir").join("theme.json");
+    match write_user_file(path.to_string_lossy().to_string(), "x".to_string()).await {
+        Err(AppError::Io(_)) => {}
+        other => panic!("expected Io when the parent is missing, got {other:?}"),
+    }
+    assert!(
+        !dir.path().join("no-such-dir").exists(),
+        "a webview string must not be able to mkdir"
+    );
+}

--- a/src/features/keymap/actions.test.ts
+++ b/src/features/keymap/actions.test.ts
@@ -6,6 +6,11 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
 import { useOverlayStore } from "./useOverlayStore";
 import { useReportStore } from "@/features/report/useReportStore";
+import { useThemeEditorStore } from "@/features/settings/theme/useThemeEditorStore";
+import {
+  BUILTIN_THEMES,
+  useSettingsStore,
+} from "@/features/settings/useSettingsStore";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { newTab } from "@/features/repo/tabs";
@@ -123,6 +128,49 @@ describe("default runners", () => {
     expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
     expect(useReportStore.getState().open).toBe(true);
     useReportStore.setState({ open: false, seed: "" });
+  });
+
+  it("app.closeOverlay closes the theme editor AND restores the pre-draft theme", () => {
+    useOverlayStore.setState({ cheatSheetOpen: false });
+    useSettingsStore.getState().setActiveThemeId("light");
+    const before = document.documentElement.style.getPropertyValue("--bg-0");
+
+    useThemeEditorStore.getState().openNew(BUILTIN_THEMES[0]);
+    useThemeEditorStore.getState().patchColors({ bg0: "#123456" });
+    expect(document.documentElement.style.getPropertyValue("--bg-0")).toBe("#123456");
+
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+
+    expect(useThemeEditorStore.getState().open).toBeNull();
+    // Closing has to RESTORE, not merely unmount: an Escape that only hid the
+    // dialog would leave the abandoned draft painted on the whole app.
+    expect(document.documentElement.style.getPropertyValue("--bg-0")).toBe(before);
+    // ...and declines once there is nothing left to close.
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(false);
+  });
+
+  it("app.closeOverlay dismisses the credential prompt before the theme editor", () => {
+    useOverlayStore.setState({ cheatSheetOpen: false });
+    // Same precedence the report dialog is pinned for (#212). The editor is on
+    // PGModal's base layer; the prompt is on `nested`, above it, and is
+    // answered first — otherwise Escape closes the editor out from under a
+    // prompt some other op is still waiting on.
+    useThemeEditorStore.getState().openNew(BUILTIN_THEMES[0]);
+    useAuthStore.getState().raise({
+      host: "github.com",
+      kind: "Https",
+      retry: async () => {},
+      onDismiss: () => {},
+    });
+
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+
+    expect(useAuthStore.getState().challenge).toBeNull();
+    expect(useThemeEditorStore.getState().open).not.toBeNull();
+
+    // A second Escape then closes the editor itself.
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+    expect(useThemeEditorStore.getState().open).toBeNull();
   });
 
   it("app.closeOverlay also closes an open create dialog (clone or init)", () => {

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -13,6 +13,7 @@ import { useAuthStore } from "@/features/auth/useAuthStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useCreateTagStore } from "@/features/tags/useCreateTagStore";
 import { useReportStore } from "@/features/report/useReportStore";
+import { useThemeEditorStore } from "@/features/settings/theme/useThemeEditorStore";
 import { useForgeStore } from "@/features/forge/useForgeStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
@@ -345,6 +346,16 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
       // failure the auth branch above is ordered to prevent.
       if (useReportStore.getState().open) {
         useReportStore.getState().closeReport();
+        return true;
+      }
+      // The theme editor, on the same PGModal base layer and in this chain for
+      // the same reason. Its `close()` also RESTORES the theme that was live
+      // when it opened: an Escape that only unmounted the dialog would leave
+      // the abandoned draft painted on the app, which is why the dialog used
+      // to own its own keydown listener — the anti-pattern design/modal.tsx
+      // names.
+      if (useThemeEditorStore.getState().open) {
+        useThemeEditorStore.getState().close();
         return true;
       }
       if (useUpdateStore.getState().panelOpen) {

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -13,12 +13,12 @@ import {
   ZOOM_MAX,
   ZOOM_MIN,
   useSettingsStore,
-  type ThemeDef,
   type ThemeFollowMode,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { SettingsCard, SettingsRow } from "@/features/settings/layout/SettingsCard";
 import { ThemeEditorDialog } from "@/features/settings/theme/ThemeEditorDialog";
+import { useThemeEditorStore } from "@/features/settings/theme/useThemeEditorStore";
 import {
   exportThemeToFile,
   importThemeFromFile,
@@ -65,10 +65,6 @@ export function AppearancePage() {
   const s = useSettingsStore();
   const active = s.getActiveTheme();
   const isBuiltin = !!active.builtin;
-
-  const [editor, setEditor] = React.useState<
-    { kind: "new"; source: ThemeDef } | { kind: "edit"; id: string } | null
-  >(null);
 
   const themeOptions = React.useMemo(() => {
     const builtins = BUILTIN_THEMES.map((t) => ({
@@ -228,7 +224,7 @@ export function AppearancePage() {
             size="sm"
             variant="primary"
             icon="edit"
-            onClick={() => setEditor({ kind: "edit", id: active.id })}
+            onClick={() => useThemeEditorStore.getState().openEdit(active)}
           >
             Edit custom theme…
           </PGButton>
@@ -237,7 +233,7 @@ export function AppearancePage() {
           size="sm"
           variant={isBuiltin ? "primary" : "default"}
           icon="plus"
-          onClick={() => setEditor({ kind: "new", source: active })}
+          onClick={() => useThemeEditorStore.getState().openNew(active)}
           title="Create a new custom theme starting from the active one"
         >
           New custom theme…
@@ -373,17 +369,10 @@ export function AppearancePage() {
         }
       />
 
-      {editor && (
-        <ThemeEditorDialog
-          mode={editor.kind}
-          sourceTheme={
-            editor.kind === "new"
-              ? editor.source
-              : (s.customThemes.find((t) => t.id === editor.id) ?? active)
-          }
-          onClose={() => setEditor(null)}
-        />
-      )}
+      {/* Mounted unconditionally: the editor reads its own open state from
+          `useThemeEditorStore`, which is what lets `app.closeOverlay` close it
+          and restore the pre-draft theme. */}
+      <ThemeEditorDialog />
     </SettingsCard>
   );
 }

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -1,14 +1,5 @@
-import React from "react";
+import { PGButton, PGButtonGroup, PGIconButton, pgFlash } from "@/design";
 import {
-  PGButton,
-  PGButtonGroup,
-  PGIconButton,
-  PGSelect,
-  pgConfirm,
-  pgFlash,
-} from "@/design";
-import {
-  BUILTIN_THEMES,
   DENSITY_STEP_PX,
   ZOOM_MAX,
   ZOOM_MIN,
@@ -18,11 +9,8 @@ import {
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { SettingsCard, SettingsRow } from "@/features/settings/layout/SettingsCard";
 import { ThemeEditorDialog } from "@/features/settings/theme/ThemeEditorDialog";
-import { useThemeEditorStore } from "@/features/settings/theme/useThemeEditorStore";
-import {
-  exportThemeToFile,
-  importThemeFromFile,
-} from "@/features/settings/themeFiles";
+import { ThemeGallery } from "@/features/settings/theme/ThemeGallery";
+import { importThemeFromFile } from "@/features/settings/themeFiles";
 import type { SettingsPageMeta } from "@/features/settings/nav/types";
 import { commitDateText, type DateFormat } from "@/lib/commitDate";
 import { appErrorMessage } from "@/lib/errors";
@@ -44,9 +32,9 @@ export const meta: SettingsPageMeta = {
         // Ungated, the index described all three at once and a search for
         // "light theme" on a fresh install (mode "fixed") reported "1 result"
         // and drew a card header with no rows under it.
-        { id: "appearance.light", label: "Light theme", when: "themeFollowsSystem" },
-        { id: "appearance.dark", label: "Dark theme", keywords: "dark mode", when: "themeFollowsSystem" },
-        { id: "appearance.theme", label: "Theme", keywords: "colors palette custom editor export", when: "themeFixed" },
+        { id: "appearance.light", label: "Light theme", keywords: "gallery preview swatch", when: "themeFollowsSystem" },
+        { id: "appearance.dark", label: "Dark theme", keywords: "dark mode gallery preview swatch", when: "themeFollowsSystem" },
+        { id: "appearance.theme", label: "Theme", keywords: "colors palette custom editor export import gallery preview swatch duplicate contrast", when: "themeFixed" },
         { id: "appearance.density", label: "UI density", keywords: "compact cozy comfortable row height spacing" },
         { id: "appearance.dateFormat", label: "Date format", keywords: "relative absolute iso timestamp" },
         { id: "appearance.headMarks", label: "Current position (HEAD)", keywords: "bar tint ring marker" },
@@ -66,44 +54,7 @@ export function AppearancePage() {
   const active = s.getActiveTheme();
   const isBuiltin = !!active.builtin;
 
-  const themeOptions = React.useMemo(() => {
-    const builtins = BUILTIN_THEMES.map((t) => ({
-      value: t.id,
-      label: t.name,
-    }));
-    const customs = s.customThemes.map((t) => ({
-      value: t.id,
-      label: `★ ${t.name}`,
-    }));
-    return [...builtins, ...customs];
-  }, [s.customThemes]);
-
-  // Each half of the pairing may only name a theme of its own mode — offering
-  // a dark theme as "the light one" would let the user build a pairing that
-  // never switches.
-  const pairOptions = React.useMemo(() => {
-    const of = (mode: "dark" | "light") => [
-      ...BUILTIN_THEMES.filter((t) => t.mode === mode).map((t) => ({
-        value: t.id,
-        label: t.name,
-      })),
-      ...s.customThemes
-        .filter((t) => t.mode === mode)
-        .map((t) => ({ value: t.id, label: `★ ${t.name}` })),
-    ];
-    return { light: of("light"), dark: of("dark") };
-  }, [s.customThemes]);
-
   const following = s.themePreference.mode === "system";
-
-  const onExport = async () => {
-    try {
-      const path = await exportThemeToFile(active.id);
-      if (path) pgFlash(`Exported to ${path}`);
-    } catch (err) {
-      pgFlash(`Export failed: ${appErrorMessage(err)}`);
-    }
-  };
 
   const onImport = async () => {
     try {
@@ -112,19 +63,6 @@ export function AppearancePage() {
     } catch (err) {
       pgFlash(`Import failed: ${appErrorMessage(err)}`);
     }
-  };
-
-  const onDelete = async () => {
-    if (
-      !(await pgConfirm({
-        title: `Delete theme "${active.name}"?`,
-        body: "Custom themes aren't recoverable unless you exported the file.",
-        danger: true,
-        confirmLabel: "Delete theme",
-      }))
-    )
-      return;
-    s.deleteTheme(active.id);
   };
 
   return (
@@ -161,53 +99,35 @@ export function AppearancePage() {
           <SettingsRow
             id="appearance.light"
             label="Light theme"
-            hint="Applied while the OS is in light appearance."
-            control={
-              <PGSelect
-                value={s.themePreference.lightId}
-                onChange={(v) => s.setPairedThemeId("light", v)}
-                options={pairOptions.light}
-                size="sm"
-                style={{ minWidth: 200 }}
-              />
-            }
+            stacked
+            hint="Applied while the OS is in light appearance. Only light themes are offered — a pairing whose halves share a mode never switches."
+            control={<ThemeGallery appearance="light" />}
           />
           <SettingsRow
             id="appearance.dark"
             label="Dark theme"
+            stacked
             hint="Applied while the OS is in dark appearance."
-            control={
-              <PGSelect
-                value={s.themePreference.darkId}
-                onChange={(v) => s.setPairedThemeId("dark", v)}
-                options={pairOptions.dark}
-                size="sm"
-                style={{ minWidth: 200 }}
-              />
-            }
+            control={<ThemeGallery appearance="dark" />}
           />
         </>
       ) : (
         <SettingsRow
           id="appearance.theme"
           label="Theme"
+          stacked
           hint={
             isBuiltin
-              ? "Built-in themes are read-only. Click “New custom theme” to fork and edit."
-              : "Custom theme. Click “Edit custom theme” to change its colors."
+              ? "Built-in themes are read-only — Duplicate one to start your own."
+              : "Custom theme. Edit, duplicate, export or delete it on its card."
           }
-          control={
-            <PGSelect
-              value={active.id}
-              onChange={(v) => s.setActiveThemeId(v)}
-              options={themeOptions}
-              size="sm"
-              style={{ minWidth: 200 }}
-            />
-          }
+          control={<ThemeGallery />}
         />
       )}
 
+      {/* Edit, Duplicate, Export and Delete live on the cards, next to the
+          theme they act on. Import is the one action that belongs to no
+          existing card, so it is the only button left here. */}
       <div
         style={{
           padding: "10px 16px",
@@ -219,45 +139,6 @@ export function AppearancePage() {
           background: "var(--bg-0)",
         }}
       >
-        {!isBuiltin && (
-          <PGButton
-            size="sm"
-            variant="primary"
-            icon="edit"
-            onClick={() => useThemeEditorStore.getState().openEdit(active)}
-          >
-            Edit custom theme…
-          </PGButton>
-        )}
-        <PGButton
-          size="sm"
-          variant={isBuiltin ? "primary" : "default"}
-          icon="plus"
-          onClick={() => useThemeEditorStore.getState().openNew(active)}
-          title="Create a new custom theme starting from the active one"
-        >
-          New custom theme…
-        </PGButton>
-        {!isBuiltin && (
-          <PGButton
-            size="sm"
-            variant="default"
-            icon="trash"
-            onClick={() => void onDelete()}
-          >
-            Delete
-          </PGButton>
-        )}
-        <div style={{ flex: 1 }} />
-        <PGButton
-          size="sm"
-          variant="default"
-          icon="download"
-          onClick={() => void onExport()}
-          title="Write this theme to a .pgtheme.json file"
-        >
-          Export…
-        </PGButton>
         <PGButton
           size="sm"
           variant="default"
@@ -265,8 +146,11 @@ export function AppearancePage() {
           onClick={() => void onImport()}
           title="Read a .pgtheme.json file"
         >
-          Import…
+          Import theme…
         </PGButton>
+        <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+          Adds a theme from a file someone exported.
+        </span>
       </div>
 
       <SettingsRow

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -19,6 +19,10 @@ import {
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { SettingsCard, SettingsRow } from "@/features/settings/layout/SettingsCard";
 import { ThemeEditorDialog } from "@/features/settings/theme/ThemeEditorDialog";
+import {
+  exportThemeToFile,
+  importThemeFromFile,
+} from "@/features/settings/themeFiles";
 import type { SettingsPageMeta } from "@/features/settings/nav/types";
 import { commitDateText, type DateFormat } from "@/lib/commitDate";
 import { appErrorMessage } from "@/lib/errors";
@@ -60,7 +64,6 @@ const DATE_SAMPLE_TS = Math.floor(DATE_SAMPLE_NOW / 1000) - 60 * 60 * 24 * 21;
 export function AppearancePage() {
   const s = useSettingsStore();
   const active = s.getActiveTheme();
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
   const isBuiltin = !!active.builtin;
 
   const [editor, setEditor] = React.useState<
@@ -97,16 +100,19 @@ export function AppearancePage() {
 
   const following = s.themePreference.mode === "system";
 
-  const onImportClick = () => fileInputRef.current?.click();
-
-  const onImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = "";
-    if (!file) return;
+  const onExport = async () => {
     try {
-      const text = await file.text();
-      const theme = s.importThemeJson(text);
-      pgFlash(`Imported "${theme.name}"`);
+      const path = await exportThemeToFile(active.id);
+      if (path) pgFlash(`Exported to ${path}`);
+    } catch (err) {
+      pgFlash(`Export failed: ${appErrorMessage(err)}`);
+    }
+  };
+
+  const onImport = async () => {
+    try {
+      const theme = await importThemeFromFile();
+      if (theme) pgFlash(`Imported “${theme.name}”`);
     } catch (err) {
       pgFlash(`Import failed: ${appErrorMessage(err)}`);
     }
@@ -251,27 +257,20 @@ export function AppearancePage() {
           size="sm"
           variant="default"
           icon="download"
-          onClick={() => s.downloadTheme(active.id)}
-          title="Download as .pgtheme.json"
+          onClick={() => void onExport()}
+          title="Write this theme to a .pgtheme.json file"
         >
-          Export
+          Export…
         </PGButton>
         <PGButton
           size="sm"
           variant="default"
           icon="upload"
-          onClick={onImportClick}
-          title="Import a .pgtheme.json file"
+          onClick={() => void onImport()}
+          title="Read a .pgtheme.json file"
         >
           Import…
         </PGButton>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json,.json,.pgtheme.json"
-          onChange={onImportFile}
-          style={{ display: "none" }}
-        />
       </div>
 
       <SettingsRow

--- a/src/features/settings/pages/backup.tsx
+++ b/src/features/settings/pages/backup.tsx
@@ -9,6 +9,10 @@ import {
   type SettingsImportReport,
 } from "@/features/settings/useSettingsStore";
 import { appErrorMessage } from "@/lib/errors";
+import {
+  exportSettingsToFile,
+  readSettingsFile,
+} from "@/features/settings/themeFiles";
 import { buildReport } from "@/features/report/report";
 import { useReportStore } from "@/features/report/useReportStore";
 import { diagnosticsReport, readLogTail, revealLogFile } from "@/lib/tauri";
@@ -55,37 +59,41 @@ export const meta: SettingsPageMeta = {
  * enough on its own to earn a file.
  */
 export function BackupPage() {
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
   const [exportedTo, setExportedTo] = React.useState<string | null>(null);
   const [report, setReport] = React.useState<
     (SettingsImportReport & { keymapApplied: string | null }) | null
   >(null);
   const [failure, setFailure] = React.useState<string | null>(null);
 
-  const onExport = () => {
+  const onExport = async () => {
     setReport(null);
     setFailure(null);
-    const name = useSettingsStore.getState().downloadSettings({
-      keymapPresetId: useKeymapStore.getState().activePresetId,
-    });
-    setExportedTo(name);
-    pgFlash(`Exported ${name}`);
+    try {
+      const path = await exportSettingsToFile({
+        keymapPresetId: useKeymapStore.getState().activePresetId,
+      });
+      // Cancel is not a failure and says nothing.
+      if (!path) return;
+      setExportedTo(path);
+      pgFlash(`Exported to ${path}`);
+    } catch (err) {
+      setFailure(appErrorMessage(err));
+    }
   };
 
-  const onImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = "";
-    if (!file) return;
+  const onImport = async () => {
     setExportedTo(null);
     setReport(null);
     setFailure(null);
-    let text: string;
+    let picked: { path: string; contents: string } | null;
     try {
-      text = await file.text();
+      picked = await readSettingsFile();
     } catch (err) {
       setFailure(appErrorMessage(err));
       return;
     }
+    // Cancel is "no answer", not a failure.
+    if (!picked) return;
     // Asked before applying, not after: an import replaces every preference at
     // once, and the file is the one thing the user can still recognise here.
     if (
@@ -93,7 +101,7 @@ export function BackupPage() {
         title: "Replace your settings with this file?",
         body: (
           <>
-            Every preference in <Mono>{file.name}</Mono> is applied to this
+            Every preference in <Mono>{picked.path}</Mono> is applied to this
             machine. Nothing in your repositories changes, and what changed is
             listed afterwards.
           </>
@@ -105,7 +113,7 @@ export function BackupPage() {
 
     let result: SettingsImportReport;
     try {
-      result = useSettingsStore.getState().importSettings(text);
+      result = useSettingsStore.getState().importSettings(picked.contents);
     } catch (err) {
       setFailure(appErrorMessage(err));
       return;
@@ -197,7 +205,7 @@ export function BackupPage() {
           hint={
             exportedTo ? (
               <span data-testid="settings-export-result">
-                Saved <Mono>{exportedTo}</Mono> to your downloads folder.
+                Saved to <Mono>{exportedTo}</Mono>.
               </span>
             ) : (
               <>
@@ -208,8 +216,8 @@ export function BackupPage() {
             )
           }
           control={
-            <PGButton size="sm" icon="download" onClick={onExport}>
-              Export settings
+            <PGButton size="sm" icon="download" onClick={() => void onExport()}>
+              Export settings…
             </PGButton>
           }
         />
@@ -234,22 +242,10 @@ export function BackupPage() {
             )
           }
           control={
-            <PGButton
-              size="sm"
-              icon="upload"
-              onClick={() => fileInputRef.current?.click()}
-            >
+            <PGButton size="sm" icon="upload" onClick={() => void onImport()}>
               Import settings…
             </PGButton>
           }
-        />
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json,.json"
-          onChange={onImportFile}
-          data-testid="settings-import-input"
-          style={{ display: "none" }}
         />
       </SettingsCard>
 

--- a/src/features/settings/theme/ColorEditor.tsx
+++ b/src/features/settings/theme/ColorEditor.tsx
@@ -5,9 +5,16 @@ import { THEME_COLOR_FIELDS, type ThemeColors } from "@/features/settings/useSet
 export function ColorEditor({
   colors,
   onPatch,
+  badgeFor,
 }: {
   colors: ThemeColors;
   onPatch: (p: Partial<ThemeColors>) => void;
+  /**
+   * Optional trailing content per field — the editor passes a contrast ratio
+   * for the pairs `CONTRAST_PAIRS` names, so a finding is visible where the
+   * colour is edited and not only in the summary under the preview.
+   */
+  badgeFor?: (key: keyof ThemeColors) => React.ReactNode;
 }) {
   const groups: Array<{
     title: string;
@@ -40,7 +47,10 @@ export function ColorEditor({
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+              // 190px, not 240: the editor's left column is ~410px, so a 240px
+              // minimum fitted exactly ONE field per row and made the list
+              // twice as long to scroll as it needs to be.
+              gridTemplateColumns: "repeat(auto-fill, minmax(190px, 1fr))",
               gap: 8,
             }}
           >
@@ -53,6 +63,7 @@ export function ColorEditor({
                 onChange={(v) =>
                   onPatch({ [f.key]: v } as Partial<ThemeColors>)
                 }
+                badge={badgeFor?.(f.key)}
               />
             ))}
           </div>
@@ -67,11 +78,13 @@ export function ColorField({
   hint,
   value,
   onChange,
+  badge,
 }: {
   label: string;
   hint?: string;
   value: string;
   onChange: (v: string) => void;
+  badge?: React.ReactNode;
 }) {
   const [draft, setDraft] = React.useState(value);
   React.useEffect(() => setDraft(value), [value]);
@@ -111,6 +124,7 @@ export function ColorField({
       >
         <input
           type="color"
+          aria-label={`${label} colour picker`}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           style={{
@@ -137,6 +151,9 @@ export function ColorField({
         </div>
         <div style={{ marginTop: 2 }}>
           <input
+            // The field's accessible name, so a test (and a screen reader)
+            // can reach "Background · base" rather than an unlabelled box.
+            aria-label={label}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={() => commitHex(draft)}
@@ -164,6 +181,7 @@ export function ColorField({
           />
         </div>
       </div>
+      {badge}
     </div>
   );
 }

--- a/src/features/settings/theme/ThemeEditorDialog.test.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.test.tsx
@@ -1,0 +1,220 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { WithDialogs, acceptDialog, dismissDialog, resetDialogs } from "@/test/dialog";
+import { lastDialogSaveOptions, mockDialogOpen, mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { ThemeEditorDialog } from "./ThemeEditorDialog";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const ed = () => useThemeEditorStore.getState();
+
+/** The dialog reads its own open state, so it always mounts. */
+function mount() {
+  return render(
+    <WithDialogs>
+      <ThemeEditorDialog />
+    </WithDialogs>,
+  );
+}
+
+const preview = () => screen.getByTestId("theme-preview");
+const written = () => getInvokeCalls().filter((c) => c.cmd === "write_user_file");
+
+describe("ThemeEditorDialog", () => {
+  beforeEach(() => {
+    resetDialogs();
+    ed().close();
+    useSettingsStore.getState().reset();
+  });
+
+  it("renders nothing while the editor is closed", () => {
+    const { container } = mount();
+    expect(container.querySelector("[role='dialog']")).toBeNull();
+  });
+
+  it("shows the draft's preview and repaints it on a colour change", () => {
+    ed().openNew(dark);
+    mount();
+    expect(preview().style.getPropertyValue("--bg-0")).toBe(dark.colors.bg0);
+
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    const field = screen.getByLabelText(/^background · base$/i);
+    fireEvent.change(field, { target: { value: "#123456" } });
+    fireEvent.blur(field);
+
+    expect(ed().colors.bg0).toBe("#123456");
+    expect(preview().style.getPropertyValue("--bg-0")).toBe("#123456");
+  });
+
+  it("warns about unreadable text without disabling Save", () => {
+    ed().openNew(dark);
+    mount();
+    // A store write from outside an event handler needs act() to flush the
+    // re-render before the assertion reads the DOM.
+    act(() => ed().patchColors({ fg0: dark.colors.bg0 }));
+
+    expect(screen.getByTestId("theme-contrast-warnings")).toHaveTextContent(
+      /primary text/i,
+    );
+    // Advisory, never blocking: a low-contrast theme is the user's own call.
+    expect(screen.getByRole("button", { name: /create theme/i })).toBeEnabled();
+  });
+
+  it("says nothing when every checked pair is fine", () => {
+    ed().openNew(dark);
+    mount();
+    expect(screen.queryByTestId("theme-contrast-warnings")).not.toBeInTheDocument();
+  });
+
+  it("never spells a colour-slot key in a warning", () => {
+    ed().openNew(dark);
+    mount();
+    act(() => ed().patchColors({ fg0: dark.colors.bg0 }));
+    const warnings = screen.getByTestId("theme-contrast-warnings");
+    expect(warnings.textContent).not.toMatch(/\bfg0\b|\bbg0\b/);
+  });
+
+  it("exports the unsaved draft to the file the user picked", async () => {
+    ed().openNew(dark);
+    ed().setName("My theme");
+    mockDialogSave("/home/you/my-theme.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+    mount();
+
+    fireEvent.click(screen.getByRole("button", { name: /^export/i }));
+
+    await waitFor(() => expect(written()).toHaveLength(1));
+    expect(lastDialogSaveOptions()).toMatchObject({
+      defaultPath: "my-theme.pgtheme.json",
+    });
+    const body = JSON.parse((written()[0].args as { contents: string }).contents);
+    expect(body.name).toBe("My theme");
+    // The DRAFT, not a saved theme: nothing was created.
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("loads a file into the draft without keeping it", async () => {
+    ed().openNew(dark);
+    mount();
+    mockDialogOpen("/home/you/from-disk.pgtheme.json");
+    mockInvoke("read_user_file", () =>
+      JSON.stringify({
+        version: 1,
+        name: "From disk",
+        mode: "light",
+        colors: { ...dark.colors, accent: "#abcdef" },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^import/i }));
+
+    await waitFor(() => expect(ed().colors.accent).toBe("#abcdef"));
+    expect(ed().themeMode).toBe("light");
+    // Round-tripping through an external editor is the point (#435) — the file
+    // is loaded into the draft, not added to the store behind the user's back.
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("saves the draft as a new theme and closes", () => {
+    ed().openNew(dark);
+    ed().setName("My theme");
+    mount();
+
+    fireEvent.click(screen.getByRole("button", { name: /create theme/i }));
+
+    expect(useSettingsStore.getState().customThemes.map((t) => t.name)).toEqual([
+      "My theme",
+    ]);
+    expect(ed().open).toBeNull();
+  });
+
+  it("refuses an empty name and stays open", () => {
+    ed().openNew(dark);
+    ed().setName("  ");
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /create theme/i }));
+    expect(ed().open).not.toBeNull();
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("cancel restores the theme that was live when it opened", () => {
+    ed().openNew(dark);
+    mount();
+    act(() => ed().patchColors({ bg0: "#123456" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(document.documentElement.style.getPropertyValue("--bg-0")).toBe(
+      dark.colors.bg0,
+    );
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("reveals all 18 colour slots behind the disclosure", () => {
+    ed().openNew(dark);
+    mount();
+    // Collapsed by default so the guided path is what a first-timer sees.
+    expect(screen.queryByLabelText(/^background · base$/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    expect(screen.getByLabelText(/^background · base$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^logo · bill$/i)).toBeInTheDocument();
+  });
+
+  it("applies the guided start from a base theme", () => {
+    ed().openNew(dark);
+    mount();
+    // PGSelect is a custom combobox, not a native <select> (a guard test
+    // forbids those), and it opens on mouseDown rather than click — the same
+    // way primitives.select.test.tsx drives it.
+    fireEvent.mouseDown(screen.getByTestId("theme-editor-base"), { button: 0 });
+    const option = document.querySelector<HTMLElement>(
+      "[data-pg-option][data-value='nord']",
+    );
+    expect(option, "the base picker should list every theme").not.toBeNull();
+    fireEvent.click(option!);
+    expect(ed().colors.bg0).toBe(BUILTIN_THEMES.find((t) => t.id === "nord")!.colors.bg0);
+  });
+
+  it("offers to re-base the palette when the mode is flipped", async () => {
+    ed().openNew(dark);
+    ed().patchColors({ bg0: "#123456" }); // an edited draft, so there is something to lose
+    mount();
+
+
+    fireEvent.click(screen.getByRole("button", { name: /^light$/i }));
+
+    // Dark greys under a light calibration are unreadable, and doing that
+    // silently is how "Light" appears broken.
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    await waitFor(() => expect(ed().themeMode).toBe("light"));
+    expect(ed().colors.bg0).not.toBe("#123456");
+  });
+
+  it("keeps the colours when the re-base offer is declined", async () => {
+    ed().openNew(dark);
+    ed().patchColors({ bg0: "#123456" });
+    mount();
+
+    fireEvent.click(screen.getByRole("button", { name: /^light$/i }));
+    await screen.findByTestId("dialog-confirm");
+    await dismissDialog();
+
+    await waitFor(() => expect(ed().themeMode).toBe("light"));
+    expect(ed().colors.bg0).toBe("#123456");
+  });
+
+  it("does not ask when the draft is still the source's own colours", async () => {
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /^light$/i }));
+    // Nothing to lose, so no question — it just re-bases.
+    await waitFor(() => expect(ed().themeMode).toBe("light"));
+    expect(screen.queryByTestId("dialog-confirm")).toBeNull();
+    expect(ed().colors.bg0).not.toBe(dark.colors.bg0);
+  });
+});

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -1,178 +1,126 @@
 import React from "react";
-import { PGButton, PGButtonGroup, PGIcon, PGInput, pgFlash } from "@/design";
+
 import {
-  applyTheme,
+  PGButton,
+  PGButtonGroup,
+  PGIcon,
+  PGInput,
+  PGModal,
+  PGSelect,
+  pgConfirm,
+  pgFlash,
+} from "@/design";
+import {
+  BUILTIN_THEMES,
   useSettingsStore,
   type ThemeColors,
-  type ThemeDef,
 } from "@/features/settings/useSettingsStore";
-
-import { exportThemeDraftToFile } from "@/features/settings/themeFiles";
+import {
+  exportThemeDraftToFile,
+  readThemeFromFile,
+} from "@/features/settings/themeFiles";
 import { appErrorMessage } from "@/lib/errors";
 
-import { ColorEditor } from "./ColorEditor";
+import { ColorEditor, ColorField } from "./ColorEditor";
+import { CONTRAST_PAIRS, contrastRatio, contrastReport } from "./contrast";
+import { ThemePreview } from "./ThemePreview";
+import { useThemeEditorStore } from "./useThemeEditorStore";
 
-export function ThemeEditorDialog({
-  mode,
-  sourceTheme,
-  onClose,
-}: {
-  mode: "new" | "edit";
-  sourceTheme: ThemeDef;
-  onClose: () => void;
-}) {
-  const [name, setName] = React.useState(
-    mode === "new" ? `${sourceTheme.name} (custom)` : sourceTheme.name,
+/**
+ * The theme editor.
+ *
+ * Takes no props: it reads `useThemeEditorStore` for its open state, so the
+ * Appearance page mounts it unconditionally and `app.closeOverlay` can close it
+ * (see the store's own comment for why that matters). There is deliberately no
+ * local Escape listener — `design/modal.tsx` documents that a component-local
+ * capture-phase handler is the anti-pattern #47 was fixed to avoid.
+ *
+ * Two columns: controls, and a preview of the real UI. Live-apply to `:root`
+ * stays — seeing the actual window change is worth keeping — but it is no
+ * longer the ONLY feedback, which is what made a dimmed, 90%-obscured window
+ * the judge of a palette.
+ */
+export function ThemeEditorDialog() {
+  const ed = useThemeEditorStore();
+  const customThemes = useSettingsStore((s) => s.customThemes);
+  const [showAll, setShowAll] = React.useState(false);
+
+  if (!ed.open) return null;
+
+  const isNew = ed.open.mode === "new";
+  const source = ed.open.sourceTheme;
+  const findings = contrastReport(ed.colors);
+
+  /** Every theme the guided start can begin from. */
+  const baseOptions = [
+    ...BUILTIN_THEMES.map((t) => ({ value: t.id, label: t.name })),
+    ...customThemes.map((t) => ({ value: t.id, label: `★ ${t.name}` })),
+  ];
+
+  /** True while the draft still holds exactly the colours it opened with. */
+  const untouched = (Object.keys(ed.colors) as (keyof ThemeColors)[]).every(
+    (k) => ed.colors[k] === source.colors[k],
   );
-  const [themeMode, setThemeMode] = React.useState<"dark" | "light">(sourceTheme.mode);
-  const [colors, setColors] = React.useState<ThemeColors>({ ...sourceTheme.colors });
 
-  // Capture the theme that was active on open, so Cancel can restore it.
-  const originalActiveRef = React.useRef<ThemeDef | null>(null);
-  if (originalActiveRef.current === null) {
-    originalActiveRef.current = useSettingsStore.getState().getActiveTheme();
-  }
-
-  // Live preview: apply draft to CSS vars whenever it changes.
-  React.useEffect(() => {
-    applyTheme({
-      id: "__draft__",
-      name,
-      mode: themeMode,
-      colors,
-    });
-  }, [name, themeMode, colors]);
-
-  // Close on Escape.
-  React.useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") handleCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleCancel = () => {
-    // Restore the theme that was active before the dialog opened.
-    const orig = originalActiveRef.current;
-    if (orig) applyTheme(orig);
-    onClose();
-  };
-
-  const handleSave = () => {
-    const trimmed = name.trim();
-    if (!trimmed) {
-      pgFlash("Theme name can't be empty");
+  const onModeChange = async (next: "dark" | "light") => {
+    if (next === ed.themeMode) return;
+    const rebaseTo = BUILTIN_THEMES.find((t) => t.mode === next)!;
+    // Nothing to lose while the draft is still the source's own palette, so
+    // re-base without asking.
+    if (untouched) {
+      ed.applyBase(rebaseTo.id, ed.colors.accent);
       return;
     }
-    const store = useSettingsStore.getState();
-    if (mode === "new") {
-      // Create a new custom theme, make it active.
-      // First switch to source so saveAsNewTheme copies right colors — but we
-      // have our own draft, so inject directly.
-      const created = store.saveAsNewTheme(trimmed);
-      // Overwrite its colors/mode with the draft.
-      useSettingsStore.setState((st) => ({
-        customThemes: st.customThemes.map((t) =>
-          t.id === created.id
-            ? { ...t, name: trimmed, mode: themeMode, colors: { ...colors } }
-            : t,
-        ),
-      }));
-      // Through the store, not just `setState`: the draft's dark/light toggle
-      // may have flipped the mode the duplicate inherited, and in "follow the
-      // system" mode that decides WHICH half of the pairing this theme is.
-      useSettingsStore.getState().setActiveThemeId(created.id);
-      // Re-apply so the saved version is what's showing.
-      applyTheme({
-        ...created,
-        name: trimmed,
-        mode: themeMode,
-        colors,
-      });
-      pgFlash(`Saved "${trimmed}"`);
-    } else {
-      // Edit existing custom theme.
-      useSettingsStore.setState((st) => ({
-        customThemes: st.customThemes.map((t) =>
-          t.id === sourceTheme.id
-            ? { ...t, name: trimmed, mode: themeMode, colors: { ...colors } }
-            : t,
-        ),
-      }));
-      useSettingsStore.getState().setActiveThemeId(sourceTheme.id);
-      applyTheme({
-        ...sourceTheme,
-        name: trimmed,
-        mode: themeMode,
-        colors,
-      });
-      pgFlash(`Saved "${trimmed}"`);
-    }
-    onClose();
+    const rebase = await pgConfirm({
+      title: `Re-base the colours for ${next} mode?`,
+      body: `${
+        next === "light" ? "Dark greys under a light calibration" : "Light greys under a dark calibration"
+      } are unreadable. Re-basing keeps your accent and takes the rest from the built-in ${next} theme. Your edits to the other colours are lost.`,
+      confirmLabel: "Re-base colours",
+      cancelLabel: "Keep my colours",
+    });
+    if (rebase) ed.applyBase(rebaseTo.id, ed.colors.accent);
+    else ed.setThemeMode(next);
   };
 
-  /** Write the UNSAVED draft to a file the user picks. */
-  const handleExportDraft = async () => {
+  const onExport = async () => {
     try {
-      const path = await exportThemeDraftToFile({ name, mode: themeMode, colors });
+      const path = await exportThemeDraftToFile({
+        name: ed.name,
+        mode: ed.themeMode,
+        colors: ed.colors,
+      });
       if (path) pgFlash(`Exported to ${path}`);
     } catch (err) {
       pgFlash(`Export failed: ${appErrorMessage(err)}`);
     }
   };
 
-  const handleResetColors = () => {
-    setColors({ ...sourceTheme.colors });
-    setThemeMode(sourceTheme.mode);
+  const onImport = async () => {
+    try {
+      const theme = await readThemeFromFile();
+      if (!theme) return;
+      ed.setColors(theme.colors);
+      ed.setThemeMode(theme.mode);
+      pgFlash(`Loaded “${theme.name}” into this draft`);
+    } catch (err) {
+      pgFlash(`Import failed: ${appErrorMessage(err)}`);
+    }
   };
 
-  const patch = (p: Partial<ThemeColors>) =>
-    setColors((c) => ({ ...c, ...p }));
+  const onSave = () => {
+    const saved = ed.save();
+    if (!saved) {
+      pgFlash("Theme name can't be empty");
+      return;
+    }
+    pgFlash(`Saved “${saved.name}”`);
+  };
 
   return (
-    <div
-      onClick={handleCancel}
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.55)",
-        backdropFilter: "blur(2px)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 100,
-        padding: 24,
-      }}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-label={mode === "new" ? "New custom theme" : "Edit custom theme"}
-        style={{
-          width: "min(860px, 100%)",
-          maxHeight: "100%",
-          display: "flex",
-          flexDirection: "column",
-          background: "var(--bg-1)",
-          border: "1px solid var(--border-1)",
-          borderRadius: "var(--r-5)",
-          boxShadow: "var(--shadow-3)",
-          overflow: "hidden",
-        }}
-      >
-        <header
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            padding: "12px 16px",
-            borderBottom: "1px solid var(--border-0)",
-            background: "var(--bg-2)",
-          }}
-        >
+    <PGModal onCancel={ed.close} width={920}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <header style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <PGIcon name="edit" size={14} style={{ color: "var(--accent)" }} />
           <div
             style={{
@@ -184,106 +132,248 @@ export function ThemeEditorDialog({
               fontWeight: 600,
             }}
           >
-            {mode === "new" ? "New custom theme" : "Edit custom theme"}
+            {isNew ? "New custom theme" : "Edit custom theme"}
           </div>
           <div style={{ flex: 1 }} />
-          <PGButton size="sm" variant="ghost" onClick={handleResetColors}>
+          <PGButton size="sm" variant="ghost" onClick={ed.revert}>
             Revert changes
           </PGButton>
         </header>
 
-        <div style={{ padding: "14px 16px", borderBottom: "1px solid var(--border-0)" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(320px, 1fr) minmax(300px, 1fr)",
+            gap: 16,
+            alignItems: "start",
+          }}
+        >
+          {/* ── Controls ─────────────────────────────────────────────────── */}
           <div
             style={{
               display: "flex",
-              gap: 12,
-              alignItems: "center",
-              flexWrap: "wrap",
+              flexDirection: "column",
+              gap: 10,
+              maxHeight: "62vh",
+              overflow: "auto",
             }}
           >
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                flex: 1,
-                minWidth: 240,
-              }}
-            >
-              <span
-                style={{
-                  fontSize: "var(--fs-12)",
-                  color: "var(--fg-2)",
-                  width: 48,
-                  flexShrink: 0,
-                }}
-              >
-                Name
-              </span>
+            <Field label="Name">
               <PGInput
-                value={name}
-                onChange={setName}
+                value={ed.name}
+                onChange={ed.setName}
                 placeholder="My cool theme"
                 style={{ flex: 1 }}
               />
-            </label>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontSize: "var(--fs-12)", color: "var(--fg-2)" }}>
-                Mode
-              </span>
+            </Field>
+
+            <Field label="Mode">
               <PGButtonGroup
                 size="sm"
-                value={themeMode}
-                onChange={(v) => setThemeMode(v as "dark" | "light")}
+                value={ed.themeMode}
+                onChange={(v) => void onModeChange(v as "dark" | "light")}
                 options={[
                   { value: "dark", label: "Dark" },
                   { value: "light", label: "Light" },
                 ]}
               />
+            </Field>
+
+            <Field label="Start from">
+              <PGSelect
+                data-testid="theme-editor-base"
+                title="Take the palette from another theme"
+                value={ed.baseId}
+                onChange={(v) => ed.applyBase(v, ed.colors.accent)}
+                options={baseOptions}
+                size="sm"
+                style={{ flex: 1 }}
+              />
+            </Field>
+
+            <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+              <span style={{ width: 76, flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <ColorField
+                  label="Accent"
+                  hint="Primary actions, active tabs, focus rings. Everything else comes from the base."
+                  value={ed.colors.accent}
+                  onChange={(v) => ed.applyBase(ed.baseId, v)}
+                  badge={<RatioBadge a="accentInk" b="accent" colors={ed.colors} />}
+                />
+                <div
+                  style={{
+                    marginTop: 4,
+                    fontSize: "var(--fs-11)",
+                    color: "var(--fg-3)",
+                  }}
+                >
+                  Takes the palette from another theme and keeps your accent — the
+                  button text is recalculated so it stays readable.
+                </div>
+              </div>
             </div>
+
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                background: "transparent",
+                border: "none",
+                padding: "6px 0",
+                cursor: "pointer",
+                color: "var(--fg-1)",
+                fontSize: "var(--fs-12)",
+                textAlign: "left",
+              }}
+              aria-expanded={showAll}
+            >
+              <PGIcon name={showAll ? "chevronDown" : "chevronRight"} size={12} />
+              All colours (18)
+            </button>
+
+            {showAll && (
+              <div style={{ margin: "0 -16px" }}>
+                <ColorEditor
+                  colors={ed.colors}
+                  onPatch={ed.patchColors}
+                  badgeFor={(key) => {
+                    const pair = CONTRAST_PAIRS.find((p) => p.a === key);
+                    return pair ? (
+                      <RatioBadge a={pair.a} b={pair.b} colors={ed.colors} />
+                    ) : null;
+                  }}
+                />
+              </div>
+            )}
           </div>
-          <div
-            style={{
-              marginTop: 6,
-              fontSize: "var(--fs-11)",
-              color: "var(--fg-3)",
-            }}
-          >
-            Changes preview live. Cancel to discard, Save to keep.
+
+          {/* ── Preview ──────────────────────────────────────────────────── */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <ThemePreview
+              theme={{ name: ed.name, mode: ed.themeMode, colors: ed.colors }}
+              size="pane"
+            />
+            {findings.length > 0 && (
+              <div
+                data-testid="theme-contrast-warnings"
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                  padding: "8px 10px",
+                  border: "1px solid var(--border-0)",
+                  borderRadius: "var(--r-3)",
+                  background: "var(--bg-1)",
+                }}
+              >
+                {findings.map((f) => (
+                  <div
+                    key={`${f.a}-${f.b}`}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      fontSize: "var(--fs-11)",
+                      color:
+                        f.level === "bad" ? "var(--git-removed)" : "var(--git-modified)",
+                    }}
+                  >
+                    <PGIcon name="warn" size={12} />
+                    <span style={{ flex: 1, minWidth: 0 }}>{f.what}</span>
+                    <span style={{ fontFamily: "var(--font-mono)" }}>
+                      {f.ratio.toFixed(1)}:1
+                    </span>
+                  </div>
+                ))}
+                <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+                  Below the 4.5:1 readability guideline. Saving is still up to you.
+                </div>
+              </div>
+            )}
           </div>
         </div>
 
-        <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
-          <ColorEditor colors={colors} onPatch={patch} />
-        </div>
-
-        <footer
-          style={{
-            padding: "10px 16px",
-            borderTop: "1px solid var(--border-0)",
-            display: "flex",
-            gap: 6,
-            alignItems: "center",
-            background: "var(--bg-2)",
-          }}
-        >
-          <PGButton
-            size="sm"
-            variant="default"
-            icon="download"
-            onClick={() => void handleExportDraft()}
-          >
+        <footer style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <PGButton size="sm" icon="download" onClick={() => void onExport()}>
             Export draft…
           </PGButton>
+          <PGButton size="sm" icon="upload" onClick={() => void onImport()}>
+            Import into draft…
+          </PGButton>
           <div style={{ flex: 1 }} />
-          <PGButton size="sm" variant="ghost" onClick={handleCancel}>
+          <PGButton size="sm" variant="ghost" onClick={ed.close}>
             Cancel
           </PGButton>
-          <PGButton size="sm" variant="primary" icon="check" onClick={handleSave}>
-            {mode === "new" ? "Create theme" : "Save changes"}
+          <PGButton size="sm" variant="primary" icon="check" onClick={onSave}>
+            {isNew ? "Create theme" : "Save changes"}
           </PGButton>
         </footer>
       </div>
+    </PGModal>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <label
+        htmlFor={htmlFor}
+        style={{
+          fontSize: "var(--fs-12)",
+          color: "var(--fg-2)",
+          width: 76,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </label>
+      {children}
     </div>
+  );
+}
+
+/**
+ * The measured ratio, beside the colour it belongs to.
+ *
+ * The summary under the preview says what is wrong; this says it where the
+ * colour is actually edited, so a fix does not require scrolling back.
+ */
+function RatioBadge({
+  a,
+  b,
+  colors,
+}: {
+  a: keyof ThemeColors;
+  b: keyof ThemeColors;
+  colors: ThemeColors;
+}) {
+  const ratio = contrastRatio(colors[a] ?? "", colors[b] ?? "");
+  if (!Number.isFinite(ratio)) return null;
+  const bad = ratio < 3;
+  const low = ratio < 4.5;
+  return (
+    <span
+      title={`Contrast against the paired colour: ${ratio.toFixed(2)}:1`}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-10)",
+        color: bad ? "var(--git-removed)" : low ? "var(--git-modified)" : "var(--fg-3)",
+        flexShrink: 0,
+      }}
+    >
+      {ratio.toFixed(1)}:1
+    </span>
   );
 }

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -160,6 +160,7 @@ export function ThemeEditorDialog() {
           >
             <Field label="Name">
               <PGInput
+                data-testid="theme-editor-name"
                 value={ed.name}
                 onChange={ed.setName}
                 placeholder="My cool theme"
@@ -308,7 +309,13 @@ export function ThemeEditorDialog() {
           <PGButton size="sm" variant="ghost" onClick={ed.close}>
             Cancel
           </PGButton>
-          <PGButton size="sm" variant="primary" icon="check" onClick={onSave}>
+          <PGButton
+            data-testid="theme-editor-save"
+            size="sm"
+            variant="primary"
+            icon="check"
+            onClick={onSave}
+          >
             {isNew ? "Create theme" : "Save changes"}
           </PGButton>
         </footer>

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -7,6 +7,9 @@ import {
   type ThemeDef,
 } from "@/features/settings/useSettingsStore";
 
+import { exportThemeDraftToFile } from "@/features/settings/themeFiles";
+import { appErrorMessage } from "@/lib/errors";
+
 import { ColorEditor } from "./ColorEditor";
 
 export function ThemeEditorDialog({
@@ -108,6 +111,16 @@ export function ThemeEditorDialog({
       pgFlash(`Saved "${trimmed}"`);
     }
     onClose();
+  };
+
+  /** Write the UNSAVED draft to a file the user picks. */
+  const handleExportDraft = async () => {
+    try {
+      const path = await exportThemeDraftToFile({ name, mode: themeMode, colors });
+      if (path) pgFlash(`Exported to ${path}`);
+    } catch (err) {
+      pgFlash(`Export failed: ${appErrorMessage(err)}`);
+    }
   };
 
   const handleResetColors = () => {
@@ -258,35 +271,9 @@ export function ThemeEditorDialog({
             size="sm"
             variant="default"
             icon="download"
-            onClick={() => {
-              // Export the current draft without saving.
-              const payload = JSON.stringify(
-                {
-                  $schema: "https://platypusgit.dev/theme.schema.json",
-                  version: 1,
-                  name,
-                  mode: themeMode,
-                  colors,
-                },
-                null,
-                2,
-              );
-              const slug = (name || "theme")
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, "-")
-                .replace(/(^-|-$)/g, "");
-              const blob = new Blob([payload], { type: "application/json" });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = `${slug || "theme"}.pgtheme.json`;
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-              URL.revokeObjectURL(url);
-            }}
+            onClick={() => void handleExportDraft()}
           >
-            Export draft
+            Export draft…
           </PGButton>
           <div style={{ flex: 1 }} />
           <PGButton size="sm" variant="ghost" onClick={handleCancel}>

--- a/src/features/settings/theme/ThemeGallery.test.tsx
+++ b/src/features/settings/theme/ThemeGallery.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { WithDialogs, acceptDialog, resetDialogs } from "@/test/dialog";
+import { mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { ThemeGallery } from "./ThemeGallery";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+const ed = () => useThemeEditorStore.getState();
+const st = () => useSettingsStore.getState();
+
+function mount(appearance?: "light" | "dark") {
+  return render(
+    <WithDialogs>
+      <ThemeGallery appearance={appearance} />
+    </WithDialogs>,
+  );
+}
+
+describe("ThemeGallery", () => {
+  beforeEach(() => {
+    resetDialogs();
+    ed().close();
+    st().reset();
+  });
+
+  it("shows a card per theme, each painted in its own colours", () => {
+    mount();
+    expect(screen.getAllByRole("radio")).toHaveLength(BUILTIN_THEMES.length);
+    const light = screen.getByRole("radio", { name: "Light" });
+    expect(
+      within(light).getByTestId("theme-preview").style.getPropertyValue("--bg-0"),
+    ).toBe(BUILTIN_THEMES.find((t) => t.id === "light")!.colors.bg0);
+  });
+
+  it("marks the active theme as checked", () => {
+    st().setActiveThemeId("nord");
+    mount();
+    expect(screen.getByRole("radio", { name: "Nord" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Dracula" })).not.toBeChecked();
+  });
+
+  it("activates the theme on the card you click", () => {
+    mount();
+    fireEvent.click(screen.getByRole("radio", { name: "Dracula" }));
+    expect(st().getActiveTheme().id).toBe("dracula");
+  });
+
+  it("moves the selection with the arrow keys, activating as it goes", () => {
+    st().setActiveThemeId("dark-cool");
+    mount();
+    const group = screen.getByRole("radiogroup");
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(st().getActiveTheme().id).toBe("dark-warm");
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+    expect(st().getActiveTheme().id).toBe("dark-cool");
+    fireEvent.keyDown(group, { key: "End" });
+    expect(st().getActiveTheme().id).toBe("github-light");
+    fireEvent.keyDown(group, { key: "Home" });
+    expect(st().getActiveTheme().id).toBe("dark-cool");
+  });
+
+  it("does not wrap past either end", () => {
+    st().setActiveThemeId("dark-cool");
+    mount();
+    const group = screen.getByRole("radiogroup");
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+    // Still the first one — a silent wrap in a grid the user is looking at
+    // reads as a bug.
+    expect(st().getActiveTheme().id).toBe("dark-cool");
+  });
+
+  it("filters to one mode and drives that half of the pairing", () => {
+    st().setThemeFollowMode("system");
+    mount("light");
+    for (const card of screen.getAllByRole("radio")) {
+      const name = card.getAttribute("aria-label") ?? "";
+      const theme = BUILTIN_THEMES.find((t) => t.name === name);
+      expect(theme?.mode, `${name} is not a light theme`).toBe("light");
+    }
+    fireEvent.click(screen.getByRole("radio", { name: "GitHub Light" }));
+    expect(st().themePreference.lightId).toBe("github-light");
+  });
+
+  it("offers Duplicate on a built-in card and opens the editor with it", () => {
+    mount();
+    const card = screen.getByRole("radio", { name: "Nord" });
+    fireEvent.click(within(card).getByRole("button", { name: /duplicate/i }));
+    expect(ed().open?.mode).toBe("new");
+    expect(ed().open?.sourceTheme.id).toBe("nord");
+  });
+
+  it("offers Edit and Delete only on a custom card", () => {
+    const created = st().duplicateTheme("nord", "Mine");
+    expect(created.name).toBe("Mine");
+    mount();
+
+    const builtin = screen.getByRole("radio", { name: "Nord" });
+    expect(within(builtin).queryByRole("button", { name: /^edit/i })).toBeNull();
+    expect(within(builtin).queryByRole("button", { name: /^delete/i })).toBeNull();
+
+    const custom = screen.getByRole("radio", { name: "Mine" });
+    expect(within(custom).getByRole("button", { name: /^edit/i })).toBeInTheDocument();
+    expect(within(custom).getByRole("button", { name: /^delete/i })).toBeInTheDocument();
+  });
+
+  it("marks a custom theme as custom and a built-in as built-in", () => {
+    st().duplicateTheme("nord", "Mine");
+    mount();
+    expect(screen.getByRole("radio", { name: "Mine" })).toHaveTextContent("Custom");
+    expect(screen.getByRole("radio", { name: "Nord" })).toHaveTextContent("Built-in");
+  });
+
+  it("opens the editor on Edit for the theme whose card it is", () => {
+    const created = st().duplicateTheme("nord", "Mine");
+    mount();
+    const card = screen.getByRole("radio", { name: "Mine" });
+    fireEvent.click(within(card).getByRole("button", { name: /^edit/i }));
+    expect(ed().open?.mode).toBe("edit");
+    expect(ed().open?.sourceTheme.id).toBe(created.id);
+  });
+
+  it("exports the theme on the card", async () => {
+    mockDialogSave("/home/you/nord.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+    mount();
+    const card = screen.getByRole("radio", { name: "Nord" });
+    fireEvent.click(within(card).getByRole("button", { name: /^export/i }));
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "write_user_file")).toBe(true),
+    );
+  });
+
+  it("asks before deleting, and does not re-activate the card it was on", async () => {
+    st().setActiveThemeId("dark-cool");
+    const created = st().duplicateTheme("nord", "Mine");
+    // duplicateTheme activates its copy, so put the selection back.
+    st().setActiveThemeId("dark-cool");
+    mount();
+
+    fireEvent.click(
+      within(screen.getByRole("radio", { name: "Mine" })).getByRole("button", {
+        name: /^delete/i,
+      }),
+    );
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+
+    await waitFor(() =>
+      expect(st().customThemes.some((t) => t.id === created.id)).toBe(false),
+    );
+    // The action button stops its click reaching the card, so pressing Delete
+    // must not also switch the app to the theme being deleted.
+    expect(st().getActiveTheme().id).toBe("dark-cool");
+  });
+});

--- a/src/features/settings/theme/ThemeGallery.tsx
+++ b/src/features/settings/theme/ThemeGallery.tsx
@@ -1,0 +1,254 @@
+import React from "react";
+
+import { PGIcon, pgConfirm, pgFlash } from "@/design";
+import {
+  BUILTIN_THEMES,
+  useSettingsStore,
+  type ThemeDef,
+} from "@/features/settings/useSettingsStore";
+import { exportThemeToFile } from "@/features/settings/themeFiles";
+import { appErrorMessage } from "@/lib/errors";
+
+import { ThemePreview } from "./ThemePreview";
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+/**
+ * Pick a theme by looking at it.
+ *
+ * The picker used to be a `PGSelect` of names with a star in front of the
+ * custom ones, so choosing a theme meant applying it to find out what it was.
+ * Each card carries a real `ThemePreview` painted in that theme's own colours.
+ *
+ * With `appearance` given, the gallery drives ONE HALF of the light/dark
+ * pairing and lists only themes of that mode — the rule the old `pairOptions`
+ * enforced, because a pairing whose halves share a mode never switches.
+ * Without it, it drives `activeThemeId`.
+ *
+ * It is a `radiogroup`: arrow keys move, and each move ACTIVATES the theme it
+ * lands on, so arrow-browsing is a live preview rather than a focus walk. A
+ * visual picker that is mouse-only is not a usability win.
+ */
+export function ThemeGallery({ appearance }: { appearance?: "light" | "dark" }) {
+  const customThemes = useSettingsStore((s) => s.customThemes);
+  const activeThemeId = useSettingsStore((s) => s.activeThemeId);
+  const themePreference = useSettingsStore((s) => s.themePreference);
+
+  const themes = React.useMemo(() => {
+    const all = [...BUILTIN_THEMES, ...customThemes];
+    return appearance ? all.filter((t) => t.mode === appearance) : all;
+  }, [customThemes, appearance]);
+
+  const selectedId = appearance
+    ? appearance === "light"
+      ? themePreference.lightId
+      : themePreference.darkId
+    : activeThemeId;
+
+  const pick = (id: string) => {
+    const s = useSettingsStore.getState();
+    if (appearance) s.setPairedThemeId(appearance, id);
+    else s.setActiveThemeId(id);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const i = themes.findIndex((t) => t.id === selectedId);
+    const at = i < 0 ? 0 : i;
+    let next = -1;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") next = at + 1;
+    else if (e.key === "ArrowLeft" || e.key === "ArrowUp") next = at - 1;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = themes.length - 1;
+    else return;
+    e.preventDefault();
+    if (next < 0 || next >= themes.length) return;
+    pick(themes[next].id);
+  };
+
+  const label =
+    appearance === "light" ? "Light theme" : appearance === "dark" ? "Dark theme" : "Theme";
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      onKeyDown={onKeyDown}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(190px, 1fr))",
+        gap: 10,
+        width: "100%",
+      }}
+    >
+      {themes.map((theme) => (
+        <ThemeCard
+          key={theme.id}
+          theme={theme}
+          selected={theme.id === selectedId}
+          onPick={() => pick(theme.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ThemeCard({
+  theme,
+  selected,
+  onPick,
+}: {
+  theme: ThemeDef;
+  selected: boolean;
+  onPick: () => void;
+}) {
+  const isBuiltin = !!theme.builtin;
+
+  const onExport = async () => {
+    try {
+      const path = await exportThemeToFile(theme.id);
+      if (path) pgFlash(`Exported to ${path}`);
+    } catch (err) {
+      pgFlash(`Export failed: ${appErrorMessage(err)}`);
+    }
+  };
+
+  const onDelete = async () => {
+    if (
+      !(await pgConfirm({
+        title: `Delete theme “${theme.name}”?`,
+        body: "Custom themes aren't recoverable unless you exported the file.",
+        danger: true,
+        confirmLabel: "Delete theme",
+      }))
+    )
+      return;
+    useSettingsStore.getState().deleteTheme(theme.id);
+  };
+
+  return (
+    <div
+      role="radio"
+      aria-checked={selected}
+      aria-label={theme.name}
+      tabIndex={selected ? 0 : -1}
+      onClick={onPick}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        padding: 6,
+        cursor: "pointer",
+        borderRadius: "var(--r-4)",
+        background: selected ? "var(--bg-2)" : "var(--bg-1)",
+        border: selected ? "2px solid var(--accent)" : "1px solid var(--border-1)",
+        // Keep the box the same size selected or not, so the grid does not
+        // reflow as the selection moves.
+        margin: selected ? 0 : 1,
+      }}
+    >
+      <ThemePreview theme={theme} size="card" title={theme.name} />
+      <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+        {selected && (
+          <PGIcon name="check" size={12} style={{ color: "var(--accent)" }} />
+        )}
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: "var(--fs-12)",
+            color: "var(--fg-0)",
+            fontWeight: selected ? 600 : 400,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {theme.name}
+        </span>
+        <span
+          style={{
+            fontSize: "var(--fs-10)",
+            fontFamily: "var(--font-mono)",
+            color: "var(--fg-3)",
+            flexShrink: 0,
+          }}
+        >
+          {isBuiltin ? "Built-in" : "Custom"}
+        </span>
+      </div>
+      <div style={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        {/* Every action stops the click reaching the card, which would
+            re-activate the theme as a side effect of pressing Delete. */}
+        {!isBuiltin && (
+          <CardAction
+            icon="edit"
+            label={`Edit ${theme.name}`}
+            text="Edit"
+            onClick={() => useThemeEditorStore.getState().openEdit(theme)}
+          />
+        )}
+        <CardAction
+          icon="copy"
+          label={`Duplicate ${theme.name}`}
+          text="Duplicate"
+          onClick={() => useThemeEditorStore.getState().openNew(theme)}
+        />
+        <CardAction
+          icon="download"
+          label={`Export ${theme.name}`}
+          text="Export…"
+          onClick={() => void onExport()}
+        />
+        {!isBuiltin && (
+          <CardAction
+            icon="trash"
+            label={`Delete ${theme.name}`}
+            text="Delete"
+            danger
+            onClick={() => void onDelete()}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CardAction({
+  icon,
+  label,
+  text,
+  danger,
+  onClick,
+}: {
+  icon: "edit" | "copy" | "download" | "trash";
+  label: string;
+  text: string;
+  danger?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 3,
+        padding: "2px 5px",
+        background: "transparent",
+        border: "1px solid var(--border-0)",
+        borderRadius: "var(--r-2)",
+        cursor: "pointer",
+        color: danger ? "var(--git-removed)" : "var(--fg-2)",
+        fontSize: "var(--fs-10)",
+      }}
+    >
+      <PGIcon name={icon} size={10} />
+      {text}
+    </button>
+  );
+}

--- a/src/features/settings/theme/ThemePreview.test.tsx
+++ b/src/features/settings/theme/ThemePreview.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+
+import { ThemePreview } from "./ThemePreview";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("ThemePreview", () => {
+  it("paints from the theme it was handed, not from :root", () => {
+    // The whole reason this component exists: a card on a dark page has to be
+    // able to show a light theme. If it read :root vars it would show the page.
+    document.documentElement.style.setProperty("--bg-0", "#ff00ff");
+    const { container } = render(<ThemePreview theme={light} size="card" />);
+    const root = container.querySelector("[data-testid='theme-preview']") as HTMLElement;
+    expect(root.style.getPropertyValue("--bg-0")).toBe(light.colors.bg0);
+    expect(root.style.getPropertyValue("--bg-0")).not.toBe("#ff00ff");
+  });
+
+  it("carries the mode-calibrated semantic tokens", () => {
+    const { container } = render(<ThemePreview theme={dark} size="card" />);
+    const root = container.querySelector("[data-testid='theme-preview']") as HTMLElement;
+    expect(root.style.getPropertyValue("--git-added")).toBeTruthy();
+    expect(root.style.getPropertyValue("--accent")).toBe(dark.colors.accent);
+  });
+
+  it("gives a light theme a different diff palette from a dark one", () => {
+    const a = render(<ThemePreview theme={dark} size="card" />);
+    const darkAdded = (
+      a.container.querySelector("[data-testid='theme-preview']") as HTMLElement
+    ).style.getPropertyValue("--git-added");
+    a.unmount();
+    const b = render(<ThemePreview theme={light} size="card" />);
+    const lightAdded = (
+      b.container.querySelector("[data-testid='theme-preview']") as HTMLElement
+    ).style.getPropertyValue("--git-added");
+    expect(lightAdded).not.toBe(darkAdded);
+  });
+
+  it("shows the surfaces a palette is actually judged on", () => {
+    render(<ThemePreview theme={dark} size="pane" />);
+    expect(screen.getByTestId("theme-preview-titlebar")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-history")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-diff")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-preview-button")).toBeInTheDocument();
+  });
+
+  it("renders both sizes from one tree", () => {
+    const card = render(<ThemePreview theme={dark} size="card" />);
+    expect(card.getByTestId("theme-preview").dataset.size).toBe("card");
+    card.unmount();
+    const pane = render(<ThemePreview theme={dark} size="pane" />);
+    expect(pane.getByTestId("theme-preview").dataset.size).toBe("pane");
+  });
+
+  it("is a picture, not a control", () => {
+    // Nothing inside may take focus or a click: a card that is itself a radio
+    // has to keep its own semantics, and the preview's text must not become
+    // part of the card's accessible name.
+    render(<ThemePreview theme={dark} size="card" />);
+    const root = screen.getByTestId("theme-preview");
+    expect(root.style.pointerEvents).toBe("none");
+    expect(root.getAttribute("aria-hidden")).toBe("true");
+    expect(root.querySelectorAll("button, a, input, select")).toHaveLength(0);
+  });
+
+  it("does not stamp data-theme, which belongs to the document", () => {
+    render(<ThemePreview theme={light} size="card" />);
+    const root = screen.getByTestId("theme-preview");
+    expect(root.dataset.theme).toBeUndefined();
+  });
+
+  it("survives a theme missing the logo slots", () => {
+    const legacy = {
+      ...dark,
+      colors: { ...dark.colors, logo: undefined, logo2: undefined },
+    } as unknown as typeof dark;
+    expect(() => render(<ThemePreview theme={legacy} size="card" />)).not.toThrow();
+  });
+});

--- a/src/features/settings/theme/ThemePreview.tsx
+++ b/src/features/settings/theme/ThemePreview.tsx
@@ -1,0 +1,343 @@
+import React from "react";
+
+import {
+  themeVars,
+  type ThemeColors,
+  type ThemeDef,
+} from "@/features/settings/useSettingsStore";
+
+/**
+ * A miniature of the real app, painted in ANY theme.
+ *
+ * A palette is judged on composed surfaces — a history row, a diff hunk, a
+ * button — not on eighteen swatches. Before this the only way to see a theme
+ * was to apply it, which is why picking one meant applying it to find out.
+ *
+ * **Everything inside paints through `var(--…)`, one scope down.** The root
+ * element carries `themeVars(theme)` as inline custom properties and the tree
+ * below reads only those vars — never `props.theme` directly, and never a
+ * `:root` var. That is what makes the preview honest: it renders through the
+ * same variables the app does, so it cannot disagree with the live window, and
+ * a light theme's card stays light on a dark page.
+ */
+export type ThemePreviewTheme = {
+  name?: string;
+  mode: "dark" | "light";
+  colors: ThemeColors;
+};
+
+/** Type-scale and spacing per size. One tree, two calibrations — not two trees. */
+const SCALE = {
+  card: { fs: 8, gap: 2, row: 11, pad: 4, chrome: 12, minHeight: 104 },
+  pane: { fs: 11, gap: 5, row: 18, pad: 8, chrome: 20, minHeight: 260 },
+} as const;
+
+export function ThemePreview({
+  theme,
+  size,
+  title,
+}: {
+  theme: ThemePreviewTheme;
+  size: "card" | "pane";
+  title?: string;
+}) {
+  const s = SCALE[size];
+  // `themeVars` wants a ThemeDef; the id and name are only used for the
+  // `data-theme` stamps that `applyTheme` writes, which a preview must not
+  // claim — so a local id is right here.
+  const vars = themeVars({
+    id: "__preview__",
+    name: theme.name ?? "Preview",
+    mode: theme.mode,
+    colors: theme.colors,
+  } as ThemeDef);
+
+  return (
+    <div
+      data-testid="theme-preview"
+      data-size={size}
+      title={title}
+      aria-hidden
+      style={
+        {
+          ...vars,
+          // A picture, not a control: nothing inside takes focus or a click, so
+          // a card that is itself a radio keeps its own semantics.
+          pointerEvents: "none",
+          userSelect: "none",
+          width: "100%",
+          minHeight: s.minHeight,
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+          borderRadius: "var(--r-3)",
+          border: "1px solid var(--border-1)",
+          background: "var(--bg-0)",
+          fontSize: s.fs,
+          lineHeight: 1.35,
+        } as React.CSSProperties
+      }
+    >
+      <Titlebar s={s} />
+      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+        <Sidebar s={s} />
+        <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
+          <History s={s} />
+          <Diff s={s} />
+        </div>
+      </div>
+      <StatusBar s={s} />
+    </div>
+  );
+}
+
+type S = (typeof SCALE)[keyof typeof SCALE];
+
+function Titlebar({ s }: { s: S }) {
+  return (
+    <div
+      data-testid="theme-preview-titlebar"
+      style={{
+        height: s.chrome,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: s.gap,
+        padding: `0 ${s.pad}px`,
+        background: "var(--bg-titlebar)",
+        borderBottom: "1px solid var(--border-0)",
+      }}
+    >
+      {/* The logo mark, as two shapes rather than the real SVG: the preview
+          needs the two brand slots to be visible, not the artwork. */}
+      <div
+        style={{
+          width: s.fs,
+          height: s.fs,
+          borderRadius: "50%",
+          background: "var(--logo)",
+          flexShrink: 0,
+        }}
+      />
+      <div
+        style={{
+          width: s.fs * 0.6,
+          height: s.fs * 0.4,
+          borderRadius: 2,
+          background: "var(--logo-2)",
+          flexShrink: 0,
+        }}
+      />
+      <div style={{ color: "var(--fg-1)", marginLeft: s.gap }}>platypusgit</div>
+      <div style={{ flex: 1 }} />
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          style={{
+            width: s.fs * 0.5,
+            height: s.fs * 0.5,
+            borderRadius: "50%",
+            background: "var(--fg-3)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Sidebar({ s }: { s: S }) {
+  const rows = ["History", "Changes", "Branches"];
+  return (
+    <div
+      data-testid="theme-preview-sidebar"
+      style={{
+        // 6.5em, not 5: at 5 the longest label ("Branches") was clipped
+        // mid-word at both sizes, which read as a rendering bug rather than a
+        // narrow sidebar.
+        width: `${s.fs * 6.5}px`,
+        flexShrink: 0,
+        background: "var(--bg-1)",
+        borderRight: "1px solid var(--border-0)",
+        padding: `${s.pad}px 0`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      {rows.map((row, i) => (
+        <div
+          key={row}
+          style={{
+            height: s.row,
+            display: "flex",
+            alignItems: "center",
+            paddingLeft: s.pad,
+            color: i === 0 ? "var(--fg-0)" : "var(--fg-2)",
+            background: i === 0 ? "var(--bg-4)" : "transparent",
+            borderLeft: `2px solid ${i === 0 ? "var(--accent)" : "transparent"}`,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {row}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function History({ s }: { s: S }) {
+  const commits = [
+    { subject: "feat(diff): word-level highlight", meta: "2h", selected: true },
+    { subject: "fix(status): stale index", meta: "5h", selected: false },
+  ];
+  return (
+    <div
+      data-testid="theme-preview-history"
+      style={{
+        background: "var(--bg-0)",
+        padding: `${s.pad}px 0`,
+        borderBottom: "1px solid var(--border-0)",
+      }}
+    >
+      {commits.map((c) => (
+        <div
+          key={c.subject}
+          style={{
+            height: s.row,
+            display: "flex",
+            alignItems: "center",
+            gap: s.gap,
+            padding: `0 ${s.pad}px`,
+            background: c.selected ? "var(--bg-selection)" : "transparent",
+          }}
+        >
+          {/* Graph dot + edge, in the graph palette rather than the accent —
+              the two are calibrated separately and both belong in the picture. */}
+          <div
+            style={{
+              width: s.fs * 0.55,
+              height: s.fs * 0.55,
+              borderRadius: "50%",
+              background: "var(--graph-1)",
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              color: "var(--fg-0)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {c.subject}
+          </div>
+          <div style={{ color: "var(--fg-2)", flexShrink: 0 }}>{c.meta}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Diff({ s }: { s: S }) {
+  const lines = [
+    { n: "12", text: "  const theme = resolve(pref);", kind: "ctx" as const },
+    { n: "13", text: "  applyTheme(theme);", kind: "add" as const },
+    { n: "14", text: "  applyLegacy(theme);", kind: "del" as const },
+    { n: "15", text: "  return theme;", kind: "ctx" as const },
+    { n: "16", text: "}", kind: "ctx" as const },
+  ];
+  const bg = { ctx: "transparent", add: "var(--git-added-bg)", del: "var(--git-removed-bg)" };
+  const mark = { ctx: " ", add: "+", del: "−" };
+  const markFg = { ctx: "var(--fg-3)", add: "var(--git-added)", del: "var(--git-removed)" };
+
+  return (
+    <div data-testid="theme-preview-diff" style={{ flex: 1, minHeight: 0, background: "var(--bg-0)" }}>
+      <div
+        style={{
+          height: s.row,
+          display: "flex",
+          alignItems: "center",
+          padding: `0 ${s.pad}px`,
+          background: "var(--bg-1)",
+          borderBottom: "1px solid var(--border-0)",
+          color: "var(--fg-1)",
+          gap: s.gap,
+        }}
+      >
+        <span style={{ color: "var(--git-modified)" }}>M</span>
+        <span>useSettingsStore.ts</span>
+      </div>
+      {lines.map((l) => (
+        <div
+          key={l.n}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: s.gap,
+            padding: `0 ${s.pad}px`,
+            height: s.row,
+            background: bg[l.kind],
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          <span style={{ color: "var(--fg-3)", width: s.fs * 1.4, flexShrink: 0 }}>{l.n}</span>
+          <span style={{ color: markFg[l.kind], width: s.fs * 0.7, flexShrink: 0 }}>
+            {mark[l.kind]}
+          </span>
+          <span
+            style={{
+              color: "var(--fg-1)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {l.text}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatusBar({ s }: { s: S }) {
+  return (
+    <div
+      style={{
+        height: s.chrome,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: s.gap,
+        padding: `0 ${s.pad}px`,
+        background: "var(--bg-2)",
+        borderTop: "1px solid var(--border-0)",
+        color: "var(--fg-2)",
+      }}
+    >
+      <span>main</span>
+      <div style={{ flex: 1 }} />
+      {/* The accent / accent-ink pair, which is exactly what the contrast
+          warning is about — so it has to be visible in the picture. */}
+      <div
+        data-testid="theme-preview-button"
+        style={{
+          padding: `0 ${s.pad}px`,
+          height: s.chrome - s.gap * 2,
+          display: "flex",
+          alignItems: "center",
+          borderRadius: 2,
+          background: "var(--accent)",
+          color: "var(--accent-ink)",
+          fontWeight: 600,
+        }}
+      >
+        Commit
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/theme/contrast.test.ts
+++ b/src/features/settings/theme/contrast.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+
+import { contrastRatio, contrastReport } from "./contrast";
+
+describe("contrastRatio", () => {
+  it("is 21 for black on white", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1);
+  });
+
+  it("is 1 for a colour on itself", () => {
+    expect(contrastRatio("#5aa8e8", "#5aa8e8")).toBeCloseTo(1, 5);
+  });
+
+  it("is symmetric", () => {
+    expect(contrastRatio("#1a1d24", "#eef1f5")).toBeCloseTo(
+      contrastRatio("#eef1f5", "#1a1d24"),
+      5,
+    );
+  });
+
+  it("matches a known WCAG value", () => {
+    // #767676 on white is the canonical 4.54:1 boundary case from the WCAG
+    // techniques — if the luminance curve is wrong, this is what shows it.
+    expect(contrastRatio("#767676", "#ffffff")).toBeCloseTo(4.54, 1);
+  });
+
+  it("accepts short hex and a missing hash", () => {
+    expect(contrastRatio("000", "fff")).toBeCloseTo(21, 1);
+  });
+
+  it("is NaN when either side cannot be parsed", () => {
+    // A half-typed hex is not a finding.
+    expect(contrastRatio("#12", "#ffffff")).toBeNaN();
+  });
+});
+
+describe("contrastReport", () => {
+  it("finds nothing to warn about in the built-in themes", () => {
+    // A built-in theme that trips our own warning would mean the thresholds are
+    // miscalibrated, not that the theme is bad.
+    for (const theme of BUILTIN_THEMES) {
+      expect(
+        contrastReport(theme.colors).filter((f) => f.level === "bad"),
+        `${theme.name} trips a hard contrast warning`,
+      ).toEqual([]);
+    }
+  });
+
+  it("reports primary text that cannot be read on the canvas", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const report = contrastReport({ ...base, fg0: base.bg0 });
+    const finding = report.find((f) => f.a === "fg0" && f.b === "bg0");
+    expect(finding?.level).toBe("bad");
+    expect(finding?.ratio).toBeCloseTo(1, 3);
+  });
+
+  it("reports unreadable ink on the accent", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const report = contrastReport({ ...base, accentInk: base.accent });
+    expect(report.some((f) => f.a === "accentInk" && f.b === "accent")).toBe(true);
+  });
+
+  it("describes a finding in prose, never as a colour-slot key", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    const finding = contrastReport({ ...base, fg0: base.bg0 })[0];
+    expect(finding.what).toMatch(/primary text/i);
+    expect(finding.what).not.toMatch(/fg0|bg0/);
+  });
+
+  it("separates a merely-low pair from an unreadable one, worst first", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    // Measured against dark-cool's bg1 (#1e222a): #767d8a is 3.85:1 — under
+    // AA's 4.5 for body text but over the 3.0 floor, which is exactly the
+    // "low, not bad" band. Guessing at this is how the first version of this
+    // test asserted nothing: setting fg2 to fg1 RAISED the contrast.
+    const report = contrastReport({
+      ...base,
+      fg0: base.bg0, // ratio 1 — unreadable
+      fg2: "#767d8a", // 3.85 — low
+    });
+    expect(report).toHaveLength(2);
+    expect(report[0]).toMatchObject({ a: "fg0", level: "bad" });
+    expect(report[1]).toMatchObject({ a: "fg2", level: "low" });
+    expect(report[1].ratio).toBeCloseTo(3.85, 1);
+    expect(report[0].ratio).toBeLessThanOrEqual(report[1].ratio);
+  });
+
+  it("says nothing about a pair it cannot parse", () => {
+    const base = BUILTIN_THEMES[0].colors;
+    expect(() => contrastReport({ ...base, fg0: "not-a-colour" })).not.toThrow();
+    expect(
+      contrastReport({ ...base, fg0: "not-a-colour" }).some((f) => f.a === "fg0"),
+    ).toBe(false);
+  });
+});

--- a/src/features/settings/theme/contrast.ts
+++ b/src/features/settings/theme/contrast.ts
@@ -1,0 +1,90 @@
+import type { ThemeColors } from "@/features/settings/useSettingsStore";
+
+import { normalizeHex } from "./ColorEditor";
+
+/**
+ * WCAG contrast, for the four pairs that decide whether the app is readable.
+ *
+ * The editor let you build a theme with white text on a white canvas and said
+ * nothing. That is the worst thing about it: a colour picker with no feedback
+ * is a colour picker that lets you break your own app and then wonder why.
+ *
+ * So the editor warns — and only warns. A deliberately low-contrast theme is
+ * the user's own choice, Save is never disabled by a finding, and nothing here
+ * refuses a colour.
+ */
+
+/** sRGB channel → linear, per WCAG 2.x relative luminance. */
+function channel(v: number): number {
+  const s = v / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function luminance(hex: string): number | null {
+  const norm = normalizeHex(hex);
+  if (!norm) return null;
+  const r = parseInt(norm.slice(1, 3), 16);
+  const g = parseInt(norm.slice(3, 5), 16);
+  const b = parseInt(norm.slice(5, 7), 16);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/**
+ * Contrast ratio between two hex colours, 1 to 21. Returns `NaN` when either
+ * side cannot be parsed — a half-typed hex is not a finding.
+ */
+export function contrastRatio(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  if (la === null || lb === null) return NaN;
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+export type ContrastLevel = "ok" | "low" | "bad";
+
+export type ContrastFinding = {
+  a: keyof ThemeColors;
+  b: keyof ThemeColors;
+  /** User-facing prose. A user never reads a colour-slot key. */
+  what: string;
+  ratio: number;
+  level: ContrastLevel;
+};
+
+/**
+ * The pairs worth checking. Not every combination — a report with twenty
+ * findings is a report nobody reads. These four are the ones that make the app
+ * unusable when they fail.
+ */
+export const CONTRAST_PAIRS: {
+  a: keyof ThemeColors;
+  b: keyof ThemeColors;
+  what: string;
+}[] = [
+  { a: "fg0", b: "bg0", what: "Primary text on the app canvas" },
+  { a: "fg1", b: "bg1", what: "Secondary text on a panel" },
+  { a: "fg2", b: "bg1", what: "Muted text on a panel" },
+  { a: "accentInk", b: "accent", what: "Button text on the accent" },
+];
+
+/** WCAG AA for body text. Below this, warn. */
+const AA_TEXT = 4.5;
+/** WCAG AA for large text and UI. Below this, warn harder. */
+const AA_LARGE = 3;
+
+function level(ratio: number): ContrastLevel {
+  if (ratio < AA_LARGE) return "bad";
+  if (ratio < AA_TEXT) return "low";
+  return "ok";
+}
+
+/** Every pair that falls short, worst first. Empty when the theme is fine. */
+export function contrastReport(colors: ThemeColors): ContrastFinding[] {
+  return CONTRAST_PAIRS.map(({ a, b, what }) => {
+    const ratio = contrastRatio(colors[a] ?? "", colors[b] ?? "");
+    return { a, b, what, ratio, level: level(ratio) };
+  })
+    .filter((f) => Number.isFinite(f.ratio) && f.level !== "ok")
+    .sort((x, y) => x.ratio - y.ratio);
+}

--- a/src/features/settings/theme/deriveTheme.test.ts
+++ b/src/features/settings/theme/deriveTheme.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES, THEME_COLOR_FIELDS } from "@/features/settings/useSettingsStore";
+
+import { contrastRatio } from "./contrast";
+import { deriveTheme } from "./deriveTheme";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("deriveTheme", () => {
+  it("puts the chosen accent in the accent slot", () => {
+    expect(deriveTheme(dark, "#ff8800").accent).toBe("#ff8800");
+  });
+
+  it("leaves every other slot alone", () => {
+    const derived = deriveTheme(dark, "#ff8800");
+    for (const field of THEME_COLOR_FIELDS) {
+      if (field.key === "accent" || field.key === "accentInk") continue;
+      expect(derived[field.key], `${field.key} should be untouched`).toBe(
+        dark.colors[field.key],
+      );
+    }
+  });
+
+  it("picks an ink that can actually be read on the accent", () => {
+    // A mid-grey accent is the case that bites: neither of a theme's own
+    // extremes may clear the bar, so the fallback to a pure extreme matters.
+    for (const accent of ["#ffee00", "#0b1020", "#5aa8e8", "#7a7a7a", "#808080"]) {
+      const derived = deriveTheme(dark, accent);
+      expect(
+        contrastRatio(derived.accentInk, derived.accent),
+        `unreadable ink on ${accent}`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("flips the ink across the light/dark crossover", () => {
+    const onPale = deriveTheme(dark, "#ffee00").accentInk;
+    const onDeep = deriveTheme(dark, "#101830").accentInk;
+    expect(onPale).not.toBe(onDeep);
+    // A pale accent takes the dark ink, a deep accent the light one.
+    expect(contrastRatio(onPale, "#ffee00")).toBeGreaterThan(
+      contrastRatio(onDeep, "#ffee00"),
+    );
+  });
+
+  it("works from a light base too", () => {
+    const derived = deriveTheme(light, "#8844cc");
+    expect(derived.accent).toBe("#8844cc");
+    expect(derived.bg0).toBe(light.colors.bg0);
+    expect(contrastRatio(derived.accentInk, derived.accent)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("normalizes a short hex and a missing hash", () => {
+    expect(deriveTheme(dark, "f80").accent).toBe("#ff8800");
+  });
+
+  it("keeps the base accent when the input cannot be parsed", () => {
+    expect(deriveTheme(dark, "nonsense").accent).toBe(dark.colors.accent);
+    expect(deriveTheme(dark, "").accentInk).toBe(dark.colors.accentInk);
+  });
+
+  it("prefers the base's own inks when they are readable enough", () => {
+    // Staying in the base's family is the point — jumping to pure black or
+    // pure white on every derive would make every custom theme look the same.
+    const derived = deriveTheme(dark, "#101830");
+    expect(derived.accentInk).toBe(dark.colors.fg0);
+  });
+});

--- a/src/features/settings/theme/deriveTheme.ts
+++ b/src/features/settings/theme/deriveTheme.ts
@@ -1,0 +1,48 @@
+import type { ThemeColors, ThemeDef } from "@/features/settings/useSettingsStore";
+
+import { normalizeHex } from "./ColorEditor";
+import { contrastRatio } from "./contrast";
+
+/**
+ * The guided start: a base theme plus an accent.
+ *
+ * Deliberately NOT a palette generator. Forking a built-in theme and then
+ * hunting for the one slot that makes a button look right is the current
+ * two-minute task; swapping the accent and fixing the ink is the two-click
+ * version of it. Hue-shifting the greys as well would produce palettes the
+ * user can neither predict nor correct, and every one of the 18 slots stays
+ * editable underneath — so cleverness here buys nothing and costs
+ * predictability.
+ *
+ * `accentInk` is the one slot that CANNOT be left to the user: it is the text
+ * drawn on the accent, so a bright accent with the base's dark ink is fine and
+ * a bright accent with the base's light ink is an unreadable button.
+ */
+
+/** WCAG AA for large text / UI, the bar a button label has to clear. */
+const READABLE = 4.5;
+
+/**
+ * Pick the ink for `accent`, preferring the base theme's own extremes.
+ *
+ * Staying in the base's family is the point: jumping to pure black or pure
+ * white on every derive would make every custom theme's buttons look the same.
+ * The pure extremes are the fallback for a mid-tone accent, where neither of
+ * the base's own inks clears the bar.
+ */
+function inkFor(base: ThemeColors, accent: string): string {
+  const candidates = [base.fg0, base.bg0, "#ffffff", "#000000"];
+  const readable = candidates.find((ink) => contrastRatio(ink, accent) >= READABLE);
+  if (readable) return readable;
+  // Nothing clears AA — take whatever reads best rather than refusing. The
+  // editor's contrast warning is what tells the user; this never blocks.
+  return candidates.reduce((best, ink) =>
+    contrastRatio(ink, accent) > contrastRatio(best, accent) ? ink : best,
+  );
+}
+
+export function deriveTheme(base: ThemeDef, accent: string): ThemeColors {
+  const norm = normalizeHex(accent);
+  if (!norm) return { ...base.colors };
+  return { ...base.colors, accent: norm, accentInk: inkFor(base.colors, norm) };
+}

--- a/src/features/settings/theme/themeVars.test.ts
+++ b/src/features/settings/theme/themeVars.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILTIN_THEMES,
+  THEME_COLOR_FIELDS,
+  applyTheme,
+  themeVars,
+} from "@/features/settings/useSettingsStore";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+describe("themeVars", () => {
+  it("carries every editable colour slot", () => {
+    const vars = themeVars(dark);
+    const values = new Set(Object.values(vars));
+    for (const field of THEME_COLOR_FIELDS) {
+      expect(
+        values.has(dark.colors[field.key]!),
+        `no CSS var carries ${field.key}`,
+      ).toBe(true);
+    }
+  });
+
+  it("maps the slots onto the vars the app actually reads", () => {
+    const vars = themeVars(dark);
+    expect(vars["--bg-0"]).toBe(dark.colors.bg0);
+    expect(vars["--bg-titlebar"]).toBe(dark.colors.titlebar);
+    expect(vars["--fg-0"]).toBe(dark.colors.fg0);
+    expect(vars["--border-1"]).toBe(dark.colors.border1);
+    expect(vars["--accent"]).toBe(dark.colors.accent);
+    expect(vars["--accent-ink"]).toBe(dark.colors.accentInk);
+  });
+
+  it("calibrates the semantic tokens per MODE, not per theme", () => {
+    expect(themeVars(dark)["--git-added"]).not.toBe(themeVars(light)["--git-added"]);
+    const otherDark = BUILTIN_THEMES.find((t) => t.id === "dark-warm")!;
+    expect(themeVars(otherDark)["--git-added"]).toBe(themeVars(dark)["--git-added"]);
+  });
+
+  it("fills the logo slots for a theme persisted before they existed", () => {
+    // The double cast is the honest spelling: `ThemeColors.logo` is typed
+    // `string`, but a theme persisted before the slots existed has neither, and
+    // `themeVars` falls back to the brand palette rather than painting
+    // `undefined`. The type is a white lie about localStorage's contents.
+    const legacy = {
+      ...dark,
+      colors: { ...dark.colors, logo: undefined, logo2: undefined },
+    } as unknown as typeof dark;
+    const vars = themeVars(legacy);
+    expect(vars["--logo"]).toBeTruthy();
+    expect(vars["--logo-2"]).toBeTruthy();
+  });
+
+  it("is exactly what applyTheme writes to :root", () => {
+    // The whole point of the extraction: a preview painted from this map and
+    // the live app painted by applyTheme cannot drift, because there is one
+    // map. If someone adds a setProperty call to applyTheme without adding it
+    // here, this fails.
+    document.documentElement.style.cssText = "";
+    applyTheme(light);
+    const root = document.documentElement.style;
+    const vars = themeVars(light);
+    expect(Object.keys(vars).length).toBeGreaterThan(0);
+    for (const [name, value] of Object.entries(vars)) {
+      expect(root.getPropertyValue(name), `applyTheme did not write ${name}`).toBe(value);
+    }
+    expect(root.length).toBe(Object.keys(vars).length);
+  });
+});

--- a/src/features/settings/theme/useThemeEditorStore.test.ts
+++ b/src/features/settings/theme/useThemeEditorStore.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+
+const rootVar = (name: string) =>
+  document.documentElement.style.getPropertyValue(name);
+
+const ed = () => useThemeEditorStore.getState();
+
+describe("useThemeEditorStore", () => {
+  beforeEach(() => {
+    useThemeEditorStore.getState().close();
+    useSettingsStore.getState().reset();
+  });
+
+  it("opens a new draft seeded from the source theme, with a distinct name", () => {
+    ed().openNew(dark);
+    expect(ed().open?.mode).toBe("new");
+    expect(ed().colors).toEqual(dark.colors);
+    expect(ed().themeMode).toBe("dark");
+    expect(ed().name).not.toBe(dark.name);
+    expect(ed().name).toContain(dark.name);
+  });
+
+  it("previews the draft on :root as it is edited", () => {
+    ed().openNew(dark);
+    ed().patchColors({ bg0: "#123456" });
+    expect(rootVar("--bg-0")).toBe("#123456");
+  });
+
+  it("does not claim to BE a theme while previewing a draft", () => {
+    ed().openNew(dark);
+    ed().patchColors({ bg0: "#123456" });
+    // An unsaved draft stamping `data-theme=dark-cool` would let anything
+    // keyed off the active theme mistake it for the saved one.
+    expect(document.documentElement.dataset.theme).toBe("__draft__");
+  });
+
+  it("restores the theme that was live when it opened, on close", () => {
+    useSettingsStore.getState().setActiveThemeId("light");
+    const before = rootVar("--bg-0");
+    ed().openNew(light);
+    ed().patchColors({ bg0: "#123456" });
+    expect(rootVar("--bg-0")).toBe("#123456");
+
+    ed().close();
+
+    expect(rootVar("--bg-0")).toBe(before);
+    expect(ed().open).toBeNull();
+  });
+
+  it("close is a no-op when nothing is open", () => {
+    useSettingsStore.getState().setActiveThemeId("nord");
+    const before = rootVar("--bg-0");
+    ed().close();
+    ed().close();
+    expect(rootVar("--bg-0")).toBe(before);
+  });
+
+  it("saves a new theme, activates it, and leaves the editor", () => {
+    ed().openNew(dark);
+    ed().setName("My theme");
+    ed().patchColors({ accent: "#ff8800" });
+
+    const saved = ed().save();
+
+    expect(saved?.name).toBe("My theme");
+    expect(saved?.colors.accent).toBe("#ff8800");
+    const store = useSettingsStore.getState();
+    expect(store.customThemes.some((t) => t.id === saved!.id)).toBe(true);
+    expect(store.getActiveTheme().id).toBe(saved!.id);
+    expect(ed().open).toBeNull();
+    // The saved theme stays on screen — save() must NOT restore.
+    expect(rootVar("--accent")).toBe("#ff8800");
+  });
+
+  it("a close after a save cannot undo it", () => {
+    ed().openNew(dark);
+    ed().setName("My theme");
+    ed().patchColors({ accent: "#ff8800" });
+    ed().save();
+    ed().close();
+    expect(rootVar("--accent")).toBe("#ff8800");
+  });
+
+  it("refuses to save an empty name, staying open", () => {
+    ed().openNew(dark);
+    ed().setName("   ");
+    expect(ed().save()).toBeNull();
+    expect(ed().open).not.toBeNull();
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("saves the draft's own mode, not the source's", () => {
+    // The mode decides which half of the light/dark pairing this theme is, so
+    // a draft flipped to light must not be saved as dark.
+    ed().openNew(dark);
+    ed().setName("Mine");
+    ed().setThemeMode("light");
+    const saved = ed().save();
+    expect(saved?.mode).toBe("light");
+    expect(useSettingsStore.getState().customThemes[0].mode).toBe("light");
+  });
+
+  it("edits an existing custom theme in place rather than adding one", () => {
+    ed().openNew(dark);
+    ed().setName("Mine");
+    const created = ed().save()!;
+
+    ed().openEdit(
+      useSettingsStore.getState().customThemes.find((t) => t.id === created.id)!,
+    );
+    ed().patchColors({ accent: "#00ddaa" });
+    ed().save();
+
+    const customs = useSettingsStore.getState().customThemes;
+    expect(customs).toHaveLength(1);
+    expect(customs[0].colors.accent).toBe("#00ddaa");
+  });
+
+  it("applyBase swaps the whole palette and fixes the ink", () => {
+    ed().openNew(dark);
+    ed().applyBase("light", "#8844cc");
+    expect(ed().colors.bg0).toBe(light.colors.bg0);
+    expect(ed().colors.accent).toBe("#8844cc");
+    expect(ed().themeMode).toBe("light");
+    expect(ed().baseId).toBe("light");
+  });
+
+  it("applyBase ignores a theme id that does not exist", () => {
+    ed().openNew(dark);
+    ed().applyBase("no-such-theme", "#8844cc");
+    expect(ed().colors).toEqual(dark.colors);
+  });
+
+  it("revert returns the draft to the source it opened from", () => {
+    ed().openNew(dark);
+    ed().patchColors({ bg0: "#123456" });
+    ed().setThemeMode("light");
+    ed().revert();
+    expect(ed().colors).toEqual(dark.colors);
+    expect(ed().themeMode).toBe("dark");
+    expect(rootVar("--bg-0")).toBe(dark.colors.bg0);
+  });
+});

--- a/src/features/settings/theme/useThemeEditorStore.ts
+++ b/src/features/settings/theme/useThemeEditorStore.ts
@@ -1,0 +1,213 @@
+import { create } from "zustand";
+
+import {
+  BUILTIN_THEMES,
+  applyTheme,
+  useSettingsStore,
+  type ThemeColors,
+  type ThemeDef,
+} from "@/features/settings/useSettingsStore";
+
+import { deriveTheme } from "./deriveTheme";
+
+/**
+ * The theme editor's draft, in a store rather than in the component.
+ *
+ * Two reasons, and the first is not cosmetic:
+ *
+ *  - **`app.closeOverlay` reads stores.** Its chain in
+ *    `features/keymap/actions.ts` walks `useCreateStore`, `useCreateTagStore`,
+ *    `useReportStore` and so on, because a handler registered from a component
+ *    runs BEFORE the default runner and would take Escape ahead of the
+ *    credential prompt. Local React state cannot join that chain — which is
+ *    exactly why the old dialog grew a `window.addEventListener("keydown")` of
+ *    its own, the anti-pattern `design/modal.tsx` documents.
+ *  - **Closing must RESTORE.** `close()` re-applies the theme that was live
+ *    when the editor opened, so Escape, the backdrop click and Cancel are one
+ *    path. An Escape that only unmounted the dialog would leave the abandoned
+ *    draft painted on the app.
+ *
+ * `save()` is the one exit that does NOT restore: the theme just saved is what
+ * should stay on screen.
+ */
+export type ThemeEditorState = {
+  /** `null` when the editor is closed. */
+  open: null | { mode: "new" | "edit"; sourceTheme: ThemeDef };
+  name: string;
+  themeMode: "dark" | "light";
+  colors: ThemeColors;
+  /** The theme that was live when the editor opened; restored by `close`. */
+  originalTheme: ThemeDef | null;
+  /** Which theme the guided "Start from" picker is pointing at. */
+  baseId: string;
+
+  openNew: (source: ThemeDef) => void;
+  openEdit: (theme: ThemeDef) => void;
+  /** Dismiss WITHOUT saving, restoring the theme that was live on open. */
+  close: () => void;
+  setName: (name: string) => void;
+  setThemeMode: (mode: "dark" | "light") => void;
+  patchColors: (patch: Partial<ThemeColors>) => void;
+  setColors: (colors: ThemeColors) => void;
+  /** The guided start: take a base theme's palette, keep an accent. */
+  applyBase: (baseId: string, accent?: string) => void;
+  /** Back to the theme this draft was opened from. */
+  revert: () => void;
+  /** Persist and leave. Returns the saved theme, or `null` for an empty name. */
+  save: () => ThemeDef | null;
+};
+
+/** Every theme the "Start from" picker can name. */
+function allThemes(): ThemeDef[] {
+  return [...BUILTIN_THEMES, ...useSettingsStore.getState().customThemes];
+}
+
+const EMPTY_DRAFT = {
+  open: null,
+  name: "",
+  themeMode: "dark" as const,
+  colors: BUILTIN_THEMES[0].colors,
+  originalTheme: null,
+  baseId: BUILTIN_THEMES[0].id,
+};
+
+export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
+  /**
+   * Paint the current draft on the live window.
+   *
+   * `"__draft__"` is a deliberate non-id: it stamps `data-theme` with something
+   * no theme claims, so nothing downstream mistakes an unsaved draft for a
+   * saved theme.
+   */
+  const preview = () => {
+    const s = get();
+    if (!s.open) return;
+    applyTheme({
+      id: "__draft__",
+      name: s.name,
+      mode: s.themeMode,
+      colors: s.colors,
+    });
+  };
+
+  return {
+    ...EMPTY_DRAFT,
+
+    openNew(source) {
+      set({
+        open: { mode: "new", sourceTheme: source },
+        name: `${source.name} (custom)`,
+        themeMode: source.mode,
+        colors: { ...source.colors },
+        baseId: source.id,
+        // Read BEFORE anything is applied, or the "original" is already the draft.
+        originalTheme: useSettingsStore.getState().getActiveTheme(),
+      });
+      preview();
+    },
+
+    openEdit(theme) {
+      set({
+        open: { mode: "edit", sourceTheme: theme },
+        name: theme.name,
+        themeMode: theme.mode,
+        colors: { ...theme.colors },
+        baseId: theme.id,
+        originalTheme: useSettingsStore.getState().getActiveTheme(),
+      });
+      preview();
+    },
+
+    close() {
+      const orig = get().originalTheme;
+      // A no-op when already closed, so `app.closeOverlay` can call it
+      // defensively without repainting anything.
+      if (!get().open) return;
+      if (orig) applyTheme(orig);
+      set({ ...EMPTY_DRAFT });
+    },
+
+    setName(name) {
+      set({ name });
+      preview();
+    },
+
+    setThemeMode(themeMode) {
+      set({ themeMode });
+      preview();
+    },
+
+    patchColors(patch) {
+      set((s) => ({ colors: { ...s.colors, ...patch } }));
+      preview();
+    },
+
+    setColors(colors) {
+      set({ colors: { ...colors } });
+      preview();
+    },
+
+    applyBase(baseId, accent) {
+      const base = allThemes().find((t) => t.id === baseId);
+      if (!base) return;
+      set({
+        baseId,
+        themeMode: base.mode,
+        colors: deriveTheme(base, accent ?? base.colors.accent),
+      });
+      preview();
+    },
+
+    revert() {
+      const open = get().open;
+      if (!open) return;
+      set({
+        name: open.mode === "new" ? `${open.sourceTheme.name} (custom)` : open.sourceTheme.name,
+        themeMode: open.sourceTheme.mode,
+        colors: { ...open.sourceTheme.colors },
+        baseId: open.sourceTheme.id,
+      });
+      preview();
+    },
+
+    save() {
+      const s = get();
+      if (!s.open) return null;
+      const trimmed = s.name.trim();
+      // The dialog is what tells the user; the store stays free of the design
+      // system so it can be tested without rendering.
+      if (!trimmed) return null;
+
+      const store = useSettingsStore.getState();
+      const patch = { name: trimmed, mode: s.themeMode, colors: { ...s.colors } };
+
+      let saved: ThemeDef;
+      if (s.open.mode === "new") {
+        const created = store.saveAsNewTheme(trimmed);
+        useSettingsStore.setState((st) => ({
+          customThemes: st.customThemes.map((t) =>
+            t.id === created.id ? { ...t, ...patch } : t,
+          ),
+        }));
+        saved = { ...created, ...patch };
+      } else {
+        const id = s.open.sourceTheme.id;
+        useSettingsStore.setState((st) => ({
+          customThemes: st.customThemes.map((t) => (t.id === id ? { ...t, ...patch } : t)),
+        }));
+        saved = { ...s.open.sourceTheme, ...patch };
+      }
+
+      // Through the store, not just `setState`: the draft's dark/light toggle
+      // may have flipped the mode the theme inherited, and in "follow the
+      // system" mode that decides WHICH half of the pairing this theme is.
+      useSettingsStore.getState().setActiveThemeId(saved.id);
+      // Leave WITHOUT restoring — the theme just saved is what should stay on
+      // screen. Clearing `originalTheme` first makes that impossible to get
+      // wrong if `close()` is called afterwards.
+      set({ ...EMPTY_DRAFT });
+      applyTheme(saved);
+      return saved;
+    },
+  };
+});

--- a/src/features/settings/themeFiles.test.ts
+++ b/src/features/settings/themeFiles.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { lastDialogSaveOptions, mockDialogOpen, mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+import { useSettingsStore } from "./useSettingsStore";
+import {
+  exportSettingsToFile,
+  exportThemeToFile,
+  importThemeFromFile,
+  readSettingsFile,
+  themeFileName,
+} from "./themeFiles";
+
+describe("themeFileName", () => {
+  it("slugs the theme name and keeps the double extension", () => {
+    expect(themeFileName("My Cool Theme")).toBe("my-cool-theme.pgtheme.json");
+  });
+
+  it("collapses punctuation and trims the edges", () => {
+    expect(themeFileName("  Dark · Cool!!  ")).toBe("dark-cool.pgtheme.json");
+  });
+
+  it("falls back to a usable name when the slug empties out", () => {
+    expect(themeFileName("···")).toBe("theme.pgtheme.json");
+  });
+});
+
+describe("exportThemeToFile", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+  });
+
+  it("offers the slugged filename and writes the exported JSON", async () => {
+    mockDialogSave("/home/you/dark-cool.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    const path = await exportThemeToFile("dark-cool");
+
+    expect(path).toBe("/home/you/dark-cool.pgtheme.json");
+    expect(lastDialogSaveOptions()).toMatchObject({
+      defaultPath: "dark-cool.pgtheme.json",
+    });
+    const call = getInvokeCalls().find((c) => c.cmd === "write_user_file");
+    const written = JSON.parse((call?.args as { contents: string }).contents);
+    expect(written.name).toBe("Dark · Cool");
+    expect(written.colors.accent).toBe("#5aa8e8");
+  });
+
+  it("returns null and writes nothing when the user cancels", async () => {
+    mockDialogSave(null);
+    expect(await exportThemeToFile("dark-cool")).toBeNull();
+    expect(getInvokeCalls().some((c) => c.cmd === "write_user_file")).toBe(false);
+  });
+
+  it("exports a custom theme by its own name", async () => {
+    const created = useSettingsStore.getState().duplicateTheme("nord", "My Nord");
+    mockDialogSave("/home/you/my-nord.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    await exportThemeToFile(created.id);
+
+    expect(lastDialogSaveOptions()).toMatchObject({
+      defaultPath: "my-nord.pgtheme.json",
+    });
+  });
+});
+
+describe("exportSettingsToFile", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+  });
+
+  it("offers a dated filename and writes the whole bundle", async () => {
+    mockDialogSave("/home/you/platypusgit-settings-2026-09-09.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    const path = await exportSettingsToFile();
+
+    expect(path).toBe("/home/you/platypusgit-settings-2026-09-09.json");
+    // Date, not timestamp: this is a file people keep and re-read, so a name
+    // they can recognise beats a name that is unique.
+    expect((lastDialogSaveOptions() as { defaultPath: string }).defaultPath).toMatch(
+      /^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/,
+    );
+    const call = getInvokeCalls().find((c) => c.cmd === "write_user_file");
+    const written = JSON.parse((call?.args as { contents: string }).contents);
+    expect(written.settings).toBeTruthy();
+    expect(written.settings.customThemes).toEqual([]);
+  });
+
+  it("returns null and writes nothing when the user cancels", async () => {
+    mockDialogSave(null);
+    expect(await exportSettingsToFile()).toBeNull();
+    expect(getInvokeCalls().some((c) => c.cmd === "write_user_file")).toBe(false);
+  });
+});
+
+describe("readSettingsFile", () => {
+  it("hands back the path and contents WITHOUT applying them", async () => {
+    useSettingsStore.getState().reset();
+    mockDialogOpen("/home/you/settings.json");
+    mockInvoke("read_user_file", () => '{"settings":{"uiDensity":"comfortable"}}');
+
+    const picked = await readSettingsFile();
+
+    expect(picked?.path).toBe("/home/you/settings.json");
+    // Read, not applied: the Backup page confirms first, so nothing may change
+    // before the user has answered.
+    expect(useSettingsStore.getState().uiDensity).toBe("compact");
+  });
+
+  it("returns null when the user cancels", async () => {
+    mockDialogOpen(null);
+    expect(await readSettingsFile()).toBeNull();
+  });
+});
+
+describe("importThemeFromFile", () => {
+  beforeEach(() => {
+    useSettingsStore.getState().reset();
+  });
+
+  it("adds the theme in the file to the store and returns it", async () => {
+    const colors = { ...useSettingsStore.getState().getActiveTheme().colors };
+    mockDialogOpen("/home/you/from-disk.pgtheme.json");
+    mockInvoke("read_user_file", () =>
+      JSON.stringify({ version: 1, name: "From disk", mode: "dark", colors }),
+    );
+
+    const theme = await importThemeFromFile();
+
+    expect(theme?.name).toBe("From disk");
+    expect(
+      useSettingsStore.getState().customThemes.some((t) => t.name === "From disk"),
+    ).toBe(true);
+  });
+
+  it("returns null when the user cancels, leaving the store alone", async () => {
+    mockDialogOpen(null);
+    expect(await importThemeFromFile()).toBeNull();
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+
+  it("throws a readable message for a file that is not a theme", async () => {
+    mockDialogOpen("/home/you/not-a-theme.json");
+    mockInvoke("read_user_file", () => '{"hello":"world"}');
+    await expect(importThemeFromFile()).rejects.toThrow(/colors/i);
+    expect(useSettingsStore.getState().customThemes).toEqual([]);
+  });
+});

--- a/src/features/settings/themeFiles.ts
+++ b/src/features/settings/themeFiles.ts
@@ -1,0 +1,120 @@
+import {
+  SETTINGS_FILE_FILTERS,
+  THEME_FILE_FILTERS,
+  openTextFile,
+  saveTextFile,
+} from "@/lib/userFile";
+
+import {
+  BUILTIN_THEMES,
+  parseThemeJson,
+  useSettingsStore,
+  type SettingsExportOptions,
+  type ThemeColors,
+  type ThemeDef,
+} from "./useSettingsStore";
+
+/**
+ * The side-effecting half of theme and settings export (#435).
+ *
+ * The store keeps the PURE serialisers — `exportTheme`, `exportSettings` — and
+ * this module owns the dialogs and the bytes. Same split `features/report/`
+ * makes between `report.ts` and `fileReport.ts`, and for the same reason: a
+ * pure function is what the tests can assert on cheaply, and the file path is
+ * what changes per platform.
+ *
+ * `downloadTheme` and `downloadSettings` used to live on the store and wrote
+ * their file with an `<a download>` click that WebKitGTK ignores. They are
+ * REMOVED rather than kept as aliases: a working export and a broken one under
+ * two names is worse than either.
+ */
+
+/** `My Cool Theme` → `my-cool-theme.pgtheme.json`. */
+export function themeFileName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return `${slug || "theme"}.pgtheme.json`;
+}
+
+/** Export a saved theme. Resolves to the path written, or `null` on cancel. */
+export async function exportThemeToFile(id: string): Promise<string | null> {
+  const store = useSettingsStore.getState();
+  const contents = store.exportTheme(id);
+  const theme = [...BUILTIN_THEMES, ...store.customThemes].find((t) => t.id === id);
+  return saveTextFile({
+    defaultName: themeFileName(theme?.name ?? "theme"),
+    contents,
+    filters: THEME_FILE_FILTERS,
+  });
+}
+
+/**
+ * Export the editor's UNSAVED draft — the round trip through an external editor
+ * that #435's reporter was trying to make.
+ */
+export async function exportThemeDraftToFile(draft: {
+  name: string;
+  mode: "dark" | "light";
+  colors: ThemeColors;
+}): Promise<string | null> {
+  const contents = JSON.stringify(
+    {
+      $schema: "https://platypusgit.dev/theme.schema.json",
+      version: 1,
+      name: draft.name,
+      mode: draft.mode,
+      colors: draft.colors,
+    },
+    null,
+    2,
+  );
+  return saveTextFile({
+    defaultName: themeFileName(draft.name),
+    contents,
+    filters: THEME_FILE_FILTERS,
+  });
+}
+
+/** Import a theme file into the store. `null` on cancel; throws on bad JSON. */
+export async function importThemeFromFile(): Promise<ThemeDef | null> {
+  const picked = await openTextFile({ filters: THEME_FILE_FILTERS });
+  if (!picked) return null;
+  return useSettingsStore.getState().importThemeJson(picked.contents);
+}
+
+/**
+ * Read a theme file WITHOUT adding it to the store — for loading one into the
+ * editor's draft, where the user has not decided to keep it yet.
+ */
+export async function readThemeFromFile(): Promise<ThemeDef | null> {
+  const picked = await openTextFile({ filters: THEME_FILE_FILTERS });
+  if (!picked) return null;
+  return parseThemeJson(picked.contents);
+}
+
+/** Export the whole settings bundle. `null` on cancel. */
+export async function exportSettingsToFile(
+  opts?: SettingsExportOptions,
+): Promise<string | null> {
+  const contents = useSettingsStore.getState().exportSettings(opts);
+  const stamp = new Date().toISOString().slice(0, 10);
+  return saveTextFile({
+    defaultName: `platypusgit-settings-${stamp}.json`,
+    contents,
+    filters: SETTINGS_FILE_FILTERS,
+  });
+}
+
+/**
+ * Pick a settings bundle and read it, WITHOUT applying it. `null` on cancel.
+ *
+ * Read-then-confirm rather than a one-shot import, because an import replaces
+ * every preference at once and the Backup page asks before applying — the file
+ * is the one thing the user can still recognise at that point. The page calls
+ * `importSettings` itself once the answer is yes.
+ */
+export async function readSettingsFile(): Promise<{ path: string; contents: string } | null> {
+  return openTextFile({ filters: SETTINGS_FILE_FILTERS });
+}

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -683,39 +683,6 @@ describe("schema version", () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════════════
-// DOWNLOAD
-// ═════════════════════════════════════════════════════════════════════════════
-
-describe("downloadSettings", () => {
-  it("names the file it wrote, so the UI can say where it went", async () => {
-    const store = await freshStore();
-    const hrefs: string[] = [];
-    const names: string[] = [];
-    const origCreate = URL.createObjectURL;
-    const origRevoke = URL.revokeObjectURL;
-    const origClick = HTMLAnchorElement.prototype.click;
-    URL.createObjectURL = vi.fn(() => "blob:settings") as typeof URL.createObjectURL;
-    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
-    HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
-      names.push(this.download);
-      hrefs.push(this.href);
-    };
-    try {
-      const name = store.useSettingsStore.getState().downloadSettings();
-      expect(name).toMatch(/^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/);
-      expect(names).toEqual([name]);
-      expect(hrefs).toEqual(["blob:settings"]);
-      // No anchor left behind in the document.
-      expect(document.querySelectorAll("a")).toHaveLength(0);
-    } finally {
-      HTMLAnchorElement.prototype.click = origClick;
-      URL.createObjectURL = origCreate;
-      URL.revokeObjectURL = origRevoke;
-    }
-  });
-});
-
-// ═════════════════════════════════════════════════════════════════════════════
 // SETTINGS PAGE (#settings-nav)
 // ═════════════════════════════════════════════════════════════════════════════
 

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -484,43 +484,64 @@ const SYNTAX_TOKENS: Record<"dark" | "light", Record<string, string>> = {
   },
 };
 
-/** Apply theme by writing every color slot to CSS vars on :root. */
+/**
+ * Every CSS var a theme sets, as a plain map.
+ *
+ * Extracted out of `applyTheme` so a theme can be painted somewhere OTHER than
+ * `:root` — a gallery card, the editor's preview pane — without a second copy
+ * of the slot-to-var mapping. Before this, nothing could render a theme except
+ * the active one, which is why there had never been a swatch or a preview
+ * anywhere in Settings.
+ *
+ * `themeVars.test.ts` asserts this map is exactly what `applyTheme` writes, so
+ * the two cannot drift: a new colour slot or a new derived token lands here and
+ * every surface gets it.
+ */
+export function themeVars(theme: ThemeDef): Record<string, string> {
+  const c = theme.colors;
+  // Mode-calibrated semantics + accent-derived selection tints. Part of the map
+  // on every apply (not only on a mode change) so switching dark → light →
+  // dark can't leave a stale calibration behind.
+  const mode = theme.mode === "light" ? "light" : "dark";
+  return {
+    "--bg-0": c.bg0,
+    "--bg-1": c.bg1,
+    "--bg-2": c.bg2,
+    "--bg-3": c.bg3,
+    "--bg-4": c.bg4,
+    "--bg-titlebar": c.titlebar,
+    "--fg-0": c.fg0,
+    "--fg-1": c.fg1,
+    "--fg-2": c.fg2,
+    "--fg-3": c.fg3,
+    "--fg-4": c.fg4,
+    "--border-0": c.border0,
+    "--border-1": c.border1,
+    "--border-2": c.border2,
+    "--accent": c.accent,
+    "--accent-ink": c.accentInk,
+    // logo colors fall back to the brand palette for themes persisted before
+    // the logo slots existed.
+    "--logo": c.logo ?? LOGO_PRIMARY,
+    "--logo-2": c.logo2 ?? LOGO_SECONDARY,
+    "--ring": `0 0 0 2px ${c.accent}80`,
+    ...SEMANTIC_TOKENS[mode],
+    ...SELECTION_TOKENS[mode],
+    ...SYNTAX_TOKENS[mode],
+  };
+}
+
+/**
+ * Apply a theme by writing every CSS var it sets to `:root`.
+ *
+ * The `data-theme` / `data-theme-mode` stamps stay here rather than in
+ * `themeVars`: they are the document's IDENTITY, not paint, and a preview
+ * rendering some other theme inside this one must not claim to be it.
+ */
 export function applyTheme(theme: ThemeDef) {
   const root = document.documentElement;
-  const c = theme.colors;
-  root.style.setProperty("--bg-0", c.bg0);
-  root.style.setProperty("--bg-1", c.bg1);
-  root.style.setProperty("--bg-2", c.bg2);
-  root.style.setProperty("--bg-3", c.bg3);
-  root.style.setProperty("--bg-4", c.bg4);
-  root.style.setProperty("--bg-titlebar", c.titlebar);
-  root.style.setProperty("--fg-0", c.fg0);
-  root.style.setProperty("--fg-1", c.fg1);
-  root.style.setProperty("--fg-2", c.fg2);
-  root.style.setProperty("--fg-3", c.fg3);
-  root.style.setProperty("--fg-4", c.fg4);
-  root.style.setProperty("--border-0", c.border0);
-  root.style.setProperty("--border-1", c.border1);
-  root.style.setProperty("--border-2", c.border2);
-  root.style.setProperty("--accent", c.accent);
-  root.style.setProperty("--accent-ink", c.accentInk);
-  // logo colors fall back to the brand palette for themes persisted before the
-  // logo slots existed.
-  root.style.setProperty("--logo", c.logo ?? LOGO_PRIMARY);
-  root.style.setProperty("--logo-2", c.logo2 ?? LOGO_SECONDARY);
-  root.style.setProperty("--ring", `0 0 0 2px ${c.accent}80`);
-  // Mode-calibrated semantics + accent-derived selection tints. Written on
-  // every apply (not only on a mode change) so switching dark → light → dark
-  // can't leave a stale calibration behind.
-  const mode = theme.mode === "light" ? "light" : "dark";
-  for (const [token, value] of Object.entries(SEMANTIC_TOKENS[mode])) {
-    root.style.setProperty(token, value);
-  }
-  for (const [token, value] of Object.entries(SELECTION_TOKENS[mode])) {
-    root.style.setProperty(token, value);
-  }
-  for (const [token, value] of Object.entries(SYNTAX_TOKENS[mode])) {
-    root.style.setProperty(token, value);
+  for (const [name, value] of Object.entries(themeVars(theme))) {
+    root.style.setProperty(name, value);
   }
   root.dataset.theme = theme.id;
   root.dataset.themeMode = theme.mode;

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1025,7 +1025,6 @@ export interface SettingsState extends PersistedState {
   deleteTheme: (id: string) => void;
   duplicateTheme: (id: string, newName?: string) => ThemeDef;
   exportTheme: (id: string) => string;
-  downloadTheme: (id: string) => void;
   importThemeJson: (json: string) => ThemeDef;
   /**
    * Serialise every portable setting to one versioned JSON string (#254).
@@ -1033,11 +1032,6 @@ export interface SettingsState extends PersistedState {
    * writes; machine-specific keys (`NON_PORTABLE_KEYS`) do not.
    */
   exportSettings: (opts?: SettingsExportOptions) => string;
-  /**
-   * `exportSettings` plus the download. Returns the filename, because "your
-   * settings were exported" is useless without saying to what.
-   */
-  downloadSettings: (opts?: SettingsExportOptions) => string;
   /**
    * Apply a settings file and report what it changed — an import that replaces
    * every preference silently is indistinguishable from one that did nothing.
@@ -1648,6 +1642,17 @@ function validateTheme(obj: unknown): ThemeDef {
   };
 }
 
+/**
+ * Validate a theme file WITHOUT adding it to the store.
+ *
+ * `importThemeJson` is the store's version and it keeps the theme; this is for
+ * loading a file into the editor's DRAFT, where the user has not decided to
+ * keep it yet. Pure on purpose — same validation, no side effect.
+ */
+export function parseThemeJson(json: string): ThemeDef {
+  return validateTheme(JSON.parse(json));
+}
+
 const initial = load();
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
@@ -1840,24 +1845,6 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     return JSON.stringify(payload, null, 2);
   },
 
-  downloadTheme(id) {
-    const json = get().exportTheme(id);
-    const theme = findTheme(get(), id);
-    const slug = (theme?.name ?? "theme")
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "");
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${slug || "theme"}.pgtheme.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  },
-
   importThemeJson(json) {
     const parsed = JSON.parse(json);
     const theme = validateTheme(parsed);
@@ -1899,25 +1886,6 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       null,
       2,
     );
-  },
-
-  downloadSettings(opts) {
-    const json = get().exportSettings(opts);
-    // Date, not timestamp: this is a file people keep and re-read, so a name
-    // they can recognise beats a name that is unique.
-    const filename = `platypusgit-settings-${new Date()
-      .toISOString()
-      .slice(0, 10)}.json`;
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    return filename;
   },
 
   importSettings(json) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1535,6 +1535,22 @@ export async function revealLogFile(): Promise<void> {
   return invoke<void>("reveal_log_file");
 }
 
+/**
+ * Read a file the user picked in a native open dialog.
+ *
+ * Capped at 4 MiB by the backend, and a folder is a refusal — see
+ * `commands/userfile.rs`. Go through `lib/userFile.ts` rather than calling this
+ * directly: the path has to come from a dialog.
+ */
+export async function readUserFile(path: string): Promise<string> {
+  return invoke<string>("read_user_file", { path });
+}
+
+/** Write a file to the path the user picked in a native save dialog. */
+export async function writeUserFile(path: string, contents: string): Promise<void> {
+  return invoke<void>("write_user_file", { path, contents });
+}
+
 export function checkForUpdate(channel: UpdateChannel): Promise<UpdateInfo> {
   return invoke<UpdateInfo>("check_for_update", { channel });
 }

--- a/src/lib/userFile.test.ts
+++ b/src/lib/userFile.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { lastDialogSaveOptions, mockDialogOpen, mockDialogSave } from "@/test/dialogMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+import { openTextFile, saveTextFile, THEME_FILE_FILTERS } from "./userFile";
+
+describe("saveTextFile", () => {
+  beforeEach(() => {
+    mockDialogSave(null);
+  });
+
+  it("returns null and writes nothing when the user cancels", async () => {
+    mockDialogSave(null);
+    const path = await saveTextFile({
+      defaultName: "my-theme.pgtheme.json",
+      contents: "{}",
+    });
+    expect(path).toBeNull();
+    expect(getInvokeCalls().some((c) => c.cmd === "write_user_file")).toBe(false);
+  });
+
+  it("writes the contents to the chosen path and returns it", async () => {
+    mockDialogSave("/home/you/my-theme.pgtheme.json");
+    mockInvoke("write_user_file", () => undefined);
+
+    const path = await saveTextFile({
+      defaultName: "my-theme.pgtheme.json",
+      contents: '{"name":"My theme"}',
+      filters: THEME_FILE_FILTERS,
+    });
+
+    expect(path).toBe("/home/you/my-theme.pgtheme.json");
+    const call = getInvokeCalls().find((c) => c.cmd === "write_user_file");
+    expect(call?.args).toEqual({
+      path: "/home/you/my-theme.pgtheme.json",
+      contents: '{"name":"My theme"}',
+    });
+  });
+
+  it("offers the default name to the dialog", async () => {
+    mockDialogSave("/home/you/x.json");
+    mockInvoke("write_user_file", () => undefined);
+    await saveTextFile({ defaultName: "dark-cool.pgtheme.json", contents: "{}" });
+    expect(lastDialogSaveOptions()).toMatchObject({
+      defaultPath: "dark-cool.pgtheme.json",
+    });
+  });
+});
+
+describe("openTextFile", () => {
+  it("returns null when the user cancels", async () => {
+    mockDialogOpen(null);
+    expect(await openTextFile()).toBeNull();
+  });
+
+  it("reads the chosen file and returns its path and contents", async () => {
+    mockDialogOpen("/home/you/theme.pgtheme.json");
+    mockInvoke("read_user_file", () => '{"name":"From disk"}');
+
+    const got = await openTextFile({ filters: THEME_FILE_FILTERS });
+
+    expect(got).toEqual({
+      path: "/home/you/theme.pgtheme.json",
+      contents: '{"name":"From disk"}',
+    });
+  });
+
+  it("takes the first path when the dialog answers with an array", async () => {
+    // `open()` returns string[] when multiple:true. We never ask for multiple,
+    // but the plugin's type admits it, and reading [0] is cheaper than
+    // trusting a cast.
+    mockDialogOpen(["/home/you/a.json", "/home/you/b.json"]);
+    mockInvoke("read_user_file", () => "{}");
+
+    const got = await openTextFile();
+    expect(got?.path).toBe("/home/you/a.json");
+  });
+});

--- a/src/lib/userFile.ts
+++ b/src/lib/userFile.ts
@@ -1,0 +1,67 @@
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+
+import { readUserFile, writeUserFile } from "./tauri";
+
+/**
+ * The ONE way this app puts a file on disk or reads one back (#435).
+ *
+ * Export used to be a `Blob`, an `<a download>` and a synthetic click, and
+ * import a hidden `<input type="file">`. The download attribute is ignored by
+ * WebKitGTK, so on Linux every export button did nothing at all — silently,
+ * with no error to report. Both are browser affordances in an app that has
+ * native dialogs, so both are gone; `test/fileSave.test.ts` fails the build if
+ * either comes back.
+ *
+ * A cancelled dialog resolves to `null`, never a throw: a dismissal is "no
+ * answer", the same reading `pgConfirm` and `pgPrompt` give it. Every save
+ * returns the PATH, because "your settings were exported" is useless without
+ * saying to what.
+ */
+export type FileFilter = { name: string; extensions: string[] };
+
+/** Single-theme files. The double extension is what the app has always written. */
+export const THEME_FILE_FILTERS: FileFilter[] = [
+  { name: "PlatypusGit theme", extensions: ["pgtheme.json", "json"] },
+];
+
+/** Whole-settings bundles (#254). */
+export const SETTINGS_FILE_FILTERS: FileFilter[] = [
+  { name: "PlatypusGit settings", extensions: ["json"] },
+];
+
+/**
+ * Ask where to put a text file, then write it. Resolves to the chosen path, or
+ * `null` when the user cancelled.
+ */
+export async function saveTextFile(opts: {
+  defaultName: string;
+  contents: string;
+  filters?: FileFilter[];
+}): Promise<string | null> {
+  const path = await saveDialog({
+    defaultPath: opts.defaultName,
+    filters: opts.filters,
+  });
+  if (!path) return null;
+  await writeUserFile(path, opts.contents);
+  return path;
+}
+
+/**
+ * Ask for a text file, then read it. Resolves to `null` when the user
+ * cancelled.
+ */
+export async function openTextFile(opts?: {
+  filters?: FileFilter[];
+}): Promise<{ path: string; contents: string } | null> {
+  const picked = await openDialog({
+    multiple: false,
+    directory: false,
+    filters: opts?.filters,
+  });
+  // `open()`'s type admits string[] (multiple: true). We never ask for it, but
+  // reading [0] is cheaper than trusting the cast.
+  const path = Array.isArray(picked) ? picked[0] : picked;
+  if (!path) return null;
+  return { path, contents: await readUserFile(path) };
+}

--- a/src/lib/userFile.ts
+++ b/src/lib/userFile.ts
@@ -6,11 +6,11 @@ import { readUserFile, writeUserFile } from "./tauri";
  * The ONE way this app puts a file on disk or reads one back (#435).
  *
  * Export used to be a `Blob`, an `<a download>` and a synthetic click, and
- * import a hidden `<input type="file">`. The download attribute is ignored by
- * WebKitGTK, so on Linux every export button did nothing at all — silently,
- * with no error to report. Both are browser affordances in an app that has
- * native dialogs, so both are gone; `test/fileSave.test.ts` fails the build if
- * either comes back.
+ * import a hidden file input. The download attribute is ignored by WebKitGTK,
+ * so on Linux every export button did nothing at all — silently, with no error
+ * to report. Both are browser affordances in an app that has native dialogs,
+ * so both are gone; `test/fileSave.test.ts` fails the build if either comes
+ * back. (That guard greps for the literals, so this comment names neither.)
  *
  * A cancelled dialog resolves to `null`, never a throw: a dismissal is "no
  * answer", the same reading `pgConfirm` and `pgPrompt` give it. Every save

--- a/src/screens/Settings.appearance.test.tsx
+++ b/src/screens/Settings.appearance.test.tsx
@@ -5,7 +5,6 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { WithDialogs, resetDialogs } from "@/test/dialog";
-import { pgPickOption, pgSelectTrigger, pgSelectValues } from "@/test/select";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { AppearancePage } from "@/features/settings/pages/appearance";
 
@@ -58,25 +57,34 @@ describe("the Appearance control", () => {
   it("offers only light themes as the light half, and only dark as the dark", () => {
     useSettingsStore.getState().setThemeFollowMode("system");
     renderSettings();
-    const light = pgSelectValues(pgSelectTrigger(row("Light theme")));
-    const dark = pgSelectValues(pgSelectTrigger(row("Dark theme")));
+    const named = (el: HTMLElement) =>
+      within(el)
+        .getAllByRole("radio")
+        .map((card) => card.getAttribute("aria-label"));
+    const light = named(row("Light theme"));
+    const dark = named(row("Dark theme"));
     // A pairing whose halves are the same mode never switches — the control
     // must make that unrepresentable rather than validating it after the fact.
-    expect(light).toEqual(["light", "github-light"]);
-    expect(dark).toContain("dark-cool");
-    expect(dark).not.toContain("light");
-    expect(light).not.toContain("nord");
+    // The picker is a gallery of cards now, but the rule is the same one.
+    expect(light).toEqual(["Light", "GitHub Light"]);
+    expect(dark).toContain("Dark · Cool");
+    expect(dark).not.toContain("Light");
+    expect(light).not.toContain("Nord");
   });
 
   it("applies the pick that matches the current OS appearance", () => {
     useSettingsStore.getState().setThemeFollowMode("system");
     renderSettings();
-    pgPickOption(pgSelectTrigger(row("Dark theme")), "dracula");
+    fireEvent.click(
+      within(row("Dark theme")).getByRole("radio", { name: "Dracula" }),
+    );
     expect(useSettingsStore.getState().themePreference.darkId).toBe("dracula");
     expect(document.documentElement.dataset.theme).toBe("dracula");
 
     // …and stores the other half without touching the screen.
-    pgPickOption(pgSelectTrigger(row("Light theme")), "github-light");
+    fireEvent.click(
+      within(row("Light theme")).getByRole("radio", { name: "GitHub Light" }),
+    );
     expect(useSettingsStore.getState().themePreference.lightId).toBe("github-light");
     expect(document.documentElement.dataset.theme).toBe("dracula");
   });

--- a/src/screens/Settings.export.test.tsx
+++ b/src/screens/Settings.export.test.tsx
@@ -8,27 +8,18 @@
 //     every preference silently.
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
 
-import { mockInvoke } from "@/test/invokeMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import {
+  lastDialogSaveOptions,
+  mockDialogOpen,
+  mockDialogSave,
+} from "@/test/dialogMock";
 import { WithDialogs, acceptDialog, dismissDialog, resetDialogs } from "@/test/dialog";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useKeymapStore } from "@/features/keymap";
 import { BackupPage } from "@/features/settings/pages/backup";
-
-// jsdom's Blob has no `text()`, and both file-import paths in Settings read the
-// picked file with `file.text()` (the real WKWebView/WebKitGTK/WebView2 all have
-// it). FileReader IS implemented, so bridge the two.
-if (typeof Blob.prototype.text !== "function") {
-  Blob.prototype.text = function (this: Blob) {
-    return new Promise<string>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(String(reader.result));
-      reader.onerror = () => reject(reader.error);
-      reader.readAsText(this);
-    });
-  };
-}
 
 /** BackupPage's Diagnostics card loads too; give it what it asks for. */
 function mockRestOfSettings() {
@@ -41,73 +32,71 @@ function mockRestOfSettings() {
   }));
 }
 
-let downloads: string[];
-let origClick: () => void;
-let origCreate: typeof URL.createObjectURL;
-let origRevoke: typeof URL.revokeObjectURL;
+/** Where the native save dialog pretends the user chose to put the file. */
+const SAVED_TO = "/home/you/platypusgit-settings-2026-09-09.json";
 
 beforeEach(() => {
   localStorage.clear();
   resetDialogs();
   mockRestOfSettings();
   useSettingsStore.getState().reset();
-  downloads = [];
-  origClick = HTMLAnchorElement.prototype.click;
-  origCreate = URL.createObjectURL;
-  origRevoke = URL.revokeObjectURL;
-  // jsdom has no blob-URL plumbing and no downloads; record what the anchor was
-  // told to save instead.
-  URL.createObjectURL = vi.fn(
-    () => "blob:settings",
-  ) as unknown as typeof URL.createObjectURL;
-  URL.revokeObjectURL = vi.fn() as unknown as typeof URL.revokeObjectURL;
-  HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
-    downloads.push(this.download);
-  };
+  // Export goes through a native save dialog and a backend write (#435), not a
+  // blob URL and an anchor click - WebKitGTK ignores the latter, which is why
+  // this whole path was replaced.
+  mockDialogSave(SAVED_TO);
+  mockInvoke("write_user_file", () => undefined);
 });
 
 afterEach(() => {
-  HTMLAnchorElement.prototype.click = origClick;
-  URL.createObjectURL = origCreate;
-  URL.revokeObjectURL = origRevoke;
   resetDialogs();
 });
+
+/** What the backend was actually told to write, if anything. */
+const written = () => getInvokeCalls().filter((c) => c.cmd === "write_user_file");
 
 // Deliberately distinct from Appearance's theme "Export" / "Import…" pair —
 // two buttons called Import… on one screen is ambiguous for a user and
 // ambiguous for a query.
 const exportButton = () =>
-  screen.getByRole("button", { name: /^export settings$/i });
+  screen.getByRole("button", { name: /^export settings…$/i });
 const importButton = () =>
   screen.getByRole("button", { name: /^import settings…$/i });
-const importInput = () =>
-  screen.getByTestId("settings-import-input") as HTMLInputElement;
 
 /**
- * Feed the hidden file input. `userEvent.upload` clicks the element first, and
- * this input is `display: none` (the visible control is the Import… button), so
- * the change event is dispatched directly.
+ * Answer the native open dialog with `json`, then click Import…
+ *
+ * There is no hidden `<input type="file">` any more: the path comes from
+ * `@tauri-apps/plugin-dialog` and the bytes from `read_user_file`, so the mock
+ * seam is the dialog plus the command rather than a change event on an input.
  */
 async function pickFile(json: string, name = "platypusgit-settings.json") {
-  const file = new File([json], name, { type: "application/json" });
+  mockDialogOpen(`/home/you/${name}`);
+  mockInvoke("read_user_file", () => json);
   await act(async () => {
-    fireEvent.change(importInput(), { target: { files: [file] } });
+    fireEvent.click(importButton());
   });
 }
 
 describe("Settings → Settings file: export", () => {
-  it("offers both halves as buttons, with the file picker behind Import…", async () => {
+  it("offers both halves as buttons that open a native dialog", async () => {
     render(
       <WithDialogs>
         <BackupPage />
       </WithDialogs>,
     );
     expect(exportButton()).toBeTruthy();
-    // The visible control is a button; the <input type="file"> is hidden behind
-    // it, so the section reads like the rest of Settings.
     expect(importButton()).toBeTruthy();
-    expect(importInput().style.display).toBe("none");
-    await userEvent.click(importButton());
+    // Both are plain buttons now. The hidden <input type="file"> they used to
+    // stand in front of is gone, along with the anchor-click export beside it -
+    // `test/fileSave.test.ts` fails the build if either comes back.
+    expect(screen.queryByTestId("settings-import-input")).toBeNull();
+    // Cancelling says nothing and changes nothing.
+    mockDialogOpen(null);
+    await act(async () => {
+      fireEvent.click(importButton());
+    });
+    expect(screen.queryByTestId("settings-import-report")).toBeNull();
+    expect(screen.queryByTestId("settings-import-error")).toBeNull();
   });
 
   it("names the file it wrote", async () => {
@@ -118,11 +107,26 @@ describe("Settings → Settings file: export", () => {
     );
     await userEvent.click(exportButton());
     const said = await screen.findByTestId("settings-export-result");
-    expect(downloads).toHaveLength(1);
-    // The filename on screen is the filename the browser was given — a message
-    // that says "exported" without saying to what is not an answer.
-    expect(said.textContent).toContain(downloads[0]);
-    expect(downloads[0]).toMatch(/^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(written()).toHaveLength(1);
+    // The PATH on screen is the path the file actually went to - a message that
+    // says "exported" without saying to what is not an answer, and the old copy
+    // guessed at a "downloads folder" the app never chose.
+    expect(said.textContent).toContain(SAVED_TO);
+    expect((lastDialogSaveOptions() as { defaultPath: string }).defaultPath).toMatch(
+      /^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/,
+    );
+  });
+
+  it("writes nothing when the save dialog is cancelled", async () => {
+    mockDialogSave(null);
+    render(
+      <WithDialogs>
+        <BackupPage />
+      </WithDialogs>,
+    );
+    await userEvent.click(exportButton());
+    expect(written()).toHaveLength(0);
+    expect(screen.queryByTestId("settings-export-result")).toBeNull();
   });
 
   it("puts the active keymap preset in the file", async () => {

--- a/src/test/dialogMock.ts
+++ b/src/test/dialogMock.ts
@@ -1,23 +1,39 @@
-// Tauri dialog plugin mock. Each test sets the result `open()` should return.
+// Tauri dialog plugin mock. Each test sets the result `open()` or `save()`
+// should return.
 
 type OpenResult = string | string[] | null;
 
 let openResult: OpenResult = null;
+let saveResult: string | null = null;
+let lastSaveOptions: unknown = null;
 
 export function mockDialogOpen(result: OpenResult): void {
   openResult = result;
 }
 
+/** The path the native save dialog should pretend the user chose. */
+export function mockDialogSave(result: string | null): void {
+  saveResult = result;
+}
+
+/** What `save()` was last called with, so a test can assert the default name. */
+export function lastDialogSaveOptions(): unknown {
+  return lastSaveOptions;
+}
+
 export function resetDialogMock(): void {
   openResult = null;
+  saveResult = null;
+  lastSaveOptions = null;
 }
 
 export async function open(): Promise<OpenResult> {
   return openResult;
 }
 
-export async function save(): Promise<string | null> {
-  return null;
+export async function save(options?: unknown): Promise<string | null> {
+  lastSaveOptions = options ?? null;
+  return saveResult;
 }
 
 export async function ask(): Promise<boolean> {

--- a/test/fileSave.test.ts
+++ b/test/fileSave.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * One file save/open path (#435).
+ *
+ * Theme and settings export used to write its file with a `Blob`, an
+ * `<a download>` and a synthetic click; import used a hidden
+ * `<input type="file">`. WebKitGTK ignores the download attribute, so on Linux
+ * every export button did nothing — silently, which is why the bug survived a
+ * release.
+ *
+ * Both are browser affordances in an app that has native dialogs, so this is a
+ * guard in the same family as the `Command::new` and native `<select>` guards:
+ * the rule is only as good as the test that fails the build for breaking it.
+ */
+
+const SRC = join(process.cwd(), "src");
+
+/** Every shipped `.ts`/`.tsx` under `src/`, tests and the test harness excluded. */
+function shippedFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      // `src/test/` is the unit suite's own harness, not shipped code.
+      if (entry === "test") continue;
+      shippedFiles(path, out);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry)) continue;
+    if (/\.test\.tsx?$/.test(entry)) continue;
+    out.push(path);
+  }
+  return out;
+}
+
+const rel = (f: string) => f.slice(process.cwd().length + 1);
+
+const FORBIDDEN: { pattern: RegExp; what: string }[] = [
+  {
+    pattern: /URL\.createObjectURL/,
+    what: "a blob URL for a download — WebKitGTK ignores <a download>",
+  },
+  {
+    pattern: /\.download\s*=/,
+    what: "an <a download> assignment — use saveTextFile from @/lib/userFile",
+  },
+  {
+    pattern: /type=["']file["']/,
+    what: 'an <input type="file"> — use openTextFile from @/lib/userFile',
+  },
+];
+
+describe("one file save/open path", () => {
+  const files = shippedFiles(SRC);
+
+  it("finds shipped source to check", () => {
+    // A traversal bug that returned [] would make every assertion below pass
+    // while asserting nothing.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  for (const { pattern, what } of FORBIDDEN) {
+    it(`no shipped file under src/ uses ${what}`, () => {
+      const offenders = files.filter((f) => pattern.test(readFileSync(f, "utf8")));
+      expect(
+        offenders.map(rel),
+        "Use src/lib/userFile.ts (saveTextFile / openTextFile) instead. See docs/dev/frontend.md.",
+      ).toEqual([]);
+    });
+  }
+
+  it("lib/userFile.ts is the only module that imports the dialog plugin's save()", () => {
+    // The IMPORT CLAUSE, not the whole file: `createPatch.ts` legitimately
+    // imports `open` for a directory picker and says "Save patch to" in the
+    // dialog's title, and a body-wide search for the word reads that as a
+    // violation.
+    const clause = /import\s*\{([^}]*)\}\s*from\s*["']@tauri-apps\/plugin-dialog["']/;
+    const importers = files.filter((f) => {
+      const m = clause.exec(readFileSync(f, "utf8"));
+      if (!m) return false;
+      return m[1]
+        .split(",")
+        .map((part) => part.trim().split(/\s+as\s+/)[0].trim())
+        .includes("save");
+    });
+    expect(importers.map(rel)).toEqual(["src/lib/userFile.ts"]);
+  });
+});


### PR DESCRIPTION
Fixes #435.

## The bug

Every export in the app wrote its file the way a web page would — a `Blob`, an `<a download>` and a synthetic click:

```ts
const url = URL.createObjectURL(blob);
const a = document.createElement("a");
a.download = `${slug}.pgtheme.json`;
a.click();
```

**WebKitGTK ignores the `download` attribute on a blob URL**, so on Linux the click was a no-op with no file, no error and no log line — exactly the report. Three call sites did it: `downloadTheme`, `downloadSettings`, and the editor's inline "Export draft" handler. A **second, independent** cause sat underneath: only `dialog:allow-open` was granted in `capabilities/default.json`, so even a correct save dialog would have been denied at runtime.

A webview is not a browser, and nothing about `<a download>` is contracted to work in one — so this replaces the mechanism rather than patching the click.

## What changed

**One native file path.** New `commands/userfile.rs` (`read_user_file` / `write_user_file`, `AppError::Io` + `InvalidPath` — no new error variant, so the TS union is untouched) behind one frontend helper, `lib/userFile.ts`. All six callers moved onto it; the blob code and both hidden file inputs are gone. Every save returns the **path**, so surfaces say *Saved to `/home/you/x.json`* instead of guessing at a downloads folder the app never chose, and a cancelled dialog is `null`, never a throw. `dialog:allow-save` is now granted. Reads are capped at 4 MiB and a folder is a refusal, because the path comes from a file picker.

The settings-backup export/import is fixed by the same change — it was broken by the identical mechanism, and fixing it once while leaving a second caller on the broken one is how this comes back.

**One theme renderer.** `themeVars(theme)` is extracted out of `applyTheme`, which becomes one writer of that map. Nothing could previously render a theme except the active one, which is why Settings had never had a swatch or a preview. `ThemePreview` writes the same map into its own subtree and reads no `:root` var, so a light theme's card stays light on a dark page — and a test asserts the map is exactly what `applyTheme` writes, so the two cannot drift.

**Gallery instead of a dropdown.** The picker was a `PGSelect` of names with a `★` in front of the custom ones, so choosing a theme meant applying it to find out. Cards now carry a real preview plus their own Edit / Duplicate / Export / Delete, next to the theme they act on (`duplicateTheme` had existed in the store with no UI). It is a `radiogroup` where arrow keys activate as they move. Following the system shows two mode-filtered galleries — the rule the old `pairOptions` enforced. Row ids stay `appearance.theme` / `.light` / `.dark` so Settings search keeps matching.

**Rebuilt editor.** Now a `PGModal` with an inline preview of the real UI beside the controls, so a palette is no longer judged through a dimmed backdrop over the 10% of the app the dialog did not cover. Adds a guided start (base + accent, with the button ink recalculated) and advisory WCAG contrast warnings on the four pairs that decide readability — **Save is never disabled by a finding**; a low-contrast theme is the user's own call. Import into the draft is new: round-tripping a theme through an external editor is what the reporter was trying to do.

**The draft moved into a store.** Two reasons, and the first is not cosmetic: `app.closeOverlay`'s chain reads *stores*, so local React state could not join it — which is why the dialog had grown the `window.addEventListener("keydown")` that `design/modal.tsx` names as an anti-pattern. And closing must **restore**: `close()` re-applies the pre-draft theme, so Escape, the backdrop and Cancel are one path. An Escape that only unmounted would leave the abandoned draft painted on the app.

## Verification

`pnpm test` 3903 ✓ · `cargo test` 95 binaries, 0 failures · both `tsc` gates clean · `pnpm test:e2e:docker full --spec e2e/specs/settings.e2e.ts` 12 ✓ on real WebKitGTK.

**Three guards were proven by planting the violation, not by passing:**

| Planted | Caught by | Note |
|---|---|---|
| `a.download =` in `revealWindow.tsx` | `test/fileSave.test.ts`, naming the file | |
| Theme-editor branch above the auth branch in `closeOverlay` | `actions.test.ts` precedence case | |
| Renamed the `contents` arg on `write_user_file` | the **e2e IPC test only** | the Rust suite stayed **8/8 green** — it calls the fn positionally |

That last row is why the e2e IPC test earns its place: it drives the real commands over real IPC on the platform that reported the bug, covering registration, argument names, the capability grant and an actual Linux disk write with a byte-for-byte read-back. The permission identifier is machine-checked too — a bogus one fails `tauri-build`.

**What is not verified.** The native save/open dialog itself is an OS modal that WebDriver cannot drive, so no automated test clicks it; that half rests on the component tests against the mocked plugin. And the fix was **not exercised by hand on Linux/WebKitGTK** — the platform in the report. Everything either side of the dialog is covered there by the e2e IPC test. Worth asking @davidsmorais to confirm on 26.04.

Design doc and plan are on the branch: `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md`, `docs/superpowers/plans/2026-09-09-theme-editor-revamp.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
