### PR TITLE
fix(history): give a tag pill a tag icon, not a branch's

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -1392,6 +1392,33 @@ ops behind the history-arrowing ladder in #400. Every other read-only op —
 still exclusive. Not because it must be, but because each needs its own proof it
 writes nothing, and moving one is a one-word change.
 
+## What decorates a log row, and which KIND of ref it is
+
+`collect_ref_map` (`libgit2.rs`) scans every ref once per log call and hands the
+walk a `Vec<RefInfo>` per commit — `{ name, kind }`, where `kind` is
+`Branch` / `Remote` / `Tag` / `Other` (`git/types.rs`).
+
+- **The kind is decided here because only here is it free and exact.** git is
+  asked (`is_tag` → `is_remote` → `is_branch`), and the answer travels. What
+  travels is the SHORTHAND (`main`, `origin/main`, `v1.0.0`, `bisect/bad`), and
+  a shorthand cannot be re-classified downstream: tags and branches share one
+  namespace of display names, so `v1.0` says nothing about which it is, and a
+  `/` says nothing either — `feat/x` is a local branch, `origin/x` a
+  remote-tracking one, `release/1.0` an ordinary tag. The frontend used to guess
+  with `name.includes("/")` and got three things wrong at once; see
+  `docs/dev/frontend.md`, "The ref pills on a log row".
+- **`is_branch` is `refs/heads/*` only**, hence a real `Other` arm rather than a
+  `_ => Branch` default. `refs/bisect/*` (while a bisect runs) and a fetched
+  `refs/pull/N/head` point at commits IN the walk, so they DO reach a row.
+  Naming them as themselves is the point — anything called a branch turns up on
+  menus that would move it.
+- **Only tags are peeled.** An annotated tag points at a tag object, so it
+  reaches its commit through `peel`; a branch or remote ref's target already IS
+  the commit oid, and peeling costs an object read per ref — thousands of them,
+  per page, on a repo with many remote branches.
+- `src-tauri/tests/log_decoration.rs` pins all of it, including a tag and a
+  branch of the same name staying two distinct decorations.
+
 ## Reading the log (#274)
 
 Where it is — `tauri_plugin_log`'s `LogDir` target, i.e. Tauri's `app_log_dir`:

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -845,6 +845,33 @@ therefore belongs in `features/`, not `design/`.
   `MAX_BARREN_PAGES`, or it walks the whole repository. New client-side log
   filters inherit that trap.
 
+## The ref pills on a log row
+
+`mapCommitRefs` (`lib/derive.ts`) turns the `RefInfo[]` the backend put on a
+commit into pills; `PGCommitRow` hands each one to `PGBranchPill`.
+
+- **Tone and glyph come off `kind`, never off the name.** A tag gets amber and
+  the `tag` glyph — the same pair the tag badge beside it already uses — because
+  a tag is a ref but not a branch: it does not move, and nothing in its name is
+  a remote prefix. Only `Remote` splits `<remote>/<name>`. `Other`
+  (`bisect/bad`, a fetched `pull/1/head`) is shown whole with a neutral glyph.
+- **Guessing from the string broke three things at once**, which is why the kind
+  is on the wire (`docs/dev/backend.md`, "What decorates a log row"): every tag
+  wore a branch icon; `release/1.0` (a tag) and `feat/x` (a local branch) were
+  each split into a remote that does not exist; and "Local labels" — which drops
+  whatever carries a `remote` — then hid both.
+- **The HEAD arrow belongs to the BRANCH.** `git tag main` is legal, so the
+  `HEAD→` prefix is gated on `kind === "Branch"` as well as the name.
+- **`ref` is the name git knows** (#91), carried beside the lossy display name
+  because that is what a drag names. A pill's `data-pg-ref` is the drag payload
+  and the drop target, so a tag pill drags: `git merge v1.0` and `git rebase
+  onto v1.0` are both things git does, and `resolveGraphDrop` needs no kind.
+- What an OP is named with still comes off the store, not off these pills —
+  `branchesAtCommit` in `design/context-menu.tsx` says why.
+- `lib/derive.refs.test.ts` pins the mapping; `screens/History.refs.test.tsx`
+  pins the glyph that actually renders, because it travels three hops each of
+  which defaults to `branch`.
+
 ## Navigating from the History menu
 
 Two entries that read the repository and change nothing, so neither goes near

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -33,6 +33,7 @@ use super::{
         LogFilter, LogPage,
         OversizedBlob,
         RebaseAction, RebaseProgress, RebaseProgressSink, RebaseStatus, RebaseStep, RebaseSummary,
+        RefInfo, RefKind,
         ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, ShallowInfo, StashInfo, StashSaveOptions,
         StatusFlag,
@@ -2700,35 +2701,50 @@ fn push_page_start(
 }
 
 /// Map git2's per-ref lookup by target OID. Scans once per log call.
-fn collect_ref_map(repo: &Repository) -> HashMap<git2::Oid, Vec<String>> {
+fn collect_ref_map(repo: &Repository) -> HashMap<git2::Oid, Vec<RefInfo>> {
     // A map, not a list: every log walk decorates each of its rows from this,
     // and a linear scan per row was O(refs x rows) with a clone per hit.
-    let mut out: HashMap<git2::Oid, Vec<String>> = HashMap::new();
+    let mut out: HashMap<git2::Oid, Vec<RefInfo>> = HashMap::new();
     if let Ok(refs) = repo.references() {
         for r in refs.flatten() {
             let name = match r.shorthand() {
                 Ok(n) => n.to_string(),
                 Err(_) => continue,
             };
+            // Ask git which kind of ref this is, here, where the answer is free
+            // and exact. The name that travels cannot be re-classified later:
+            // a tag and a branch share one namespace, so the frontend used to
+            // guess and got every tag wrong. `is_branch` is refs/heads only,
+            // hence the explicit Other arm rather than a `_ => Branch` default.
+            let kind = if r.is_tag() {
+                RefKind::Tag
+            } else if r.is_remote() {
+                RefKind::Remote
+            } else if r.is_branch() {
+                RefKind::Branch
+            } else {
+                RefKind::Other
+            };
+            let info = RefInfo { name, kind };
             // Peel annotated tags to the commit they point at. Only TAGS: a
             // branch or remote ref's target already IS the commit oid, and
             // peeling costs an object read per ref — thousands, on a repo with
             // many remote branches, on every page fetch.
-            if r.is_tag() {
+            if kind == RefKind::Tag {
                 if let Ok(peeled) = r.peel(git2::ObjectType::Commit) {
                     if let Some(c) = peeled.as_commit() {
-                        out.entry(c.id()).or_default().push(name);
+                        out.entry(c.id()).or_default().push(info);
                         continue;
                     }
                 }
             }
             if let Some(oid) = r.target() {
-                out.entry(oid).or_default().push(name);
+                out.entry(oid).or_default().push(info);
             } else if let Ok(peeled) = r.peel(git2::ObjectType::Commit) {
                 // Symbolic refs (origin/HEAD) have no direct target; resolve
                 // them the way the old always-peel did so their pill survives.
                 if let Some(c) = peeled.as_commit() {
-                    out.entry(c.id()).or_default().push(name);
+                    out.entry(c.id()).or_default().push(info);
                 }
             }
         }
@@ -3554,7 +3570,7 @@ impl GitBackend for Libgit2Backend {
             for oid in walk.by_ref().take(limit) {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
+                let refs: Vec<RefInfo> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 frontier.visit(oid, commit.parent_ids());
@@ -3726,7 +3742,7 @@ impl GitBackend for Libgit2Backend {
                     }
                 }
 
-                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
+                let refs: Vec<RefInfo> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);
@@ -3773,7 +3789,7 @@ impl GitBackend for Libgit2Backend {
             for oid in walk {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
+                let refs: Vec<RefInfo> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);
@@ -3810,7 +3826,7 @@ impl GitBackend for Libgit2Backend {
                 }
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
+                let refs: Vec<RefInfo> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -149,6 +149,40 @@ pub struct DeleteFailure {
     pub reason: String,
 }
 
+/// What kind of ref one of a commit's decorations names.
+///
+/// The KIND comes from the backend because a shorthand cannot carry it. Tags
+/// and branches share one namespace of display names, so `v1.0` says nothing
+/// about which it is; and a slash means nothing either — `feat/x` is a local
+/// branch, `origin/x` a remote-tracking one, `release/1.0` a perfectly ordinary
+/// tag. Guessing from the string is what put a branch icon on every tag and
+/// split `release/1.0` into a remote called `release`.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum RefKind {
+    /// `refs/heads/*`.
+    Branch,
+    /// `refs/remotes/*` — the name is `<remote>/<branch>`.
+    Remote,
+    /// `refs/tags/*`, lightweight or annotated alike.
+    Tag,
+    /// Any other ref pointing at a commit in the walk: `refs/bisect/*` while a
+    /// bisect is running, a fetched `refs/pull/N/head`. Named as what it is
+    /// rather than dressed up as a branch.
+    Other,
+}
+
+/// One ref pointing at a commit — what decorates a log row.
+///
+/// `name` is git's own shorthand (`main`, `origin/main`, `v1.0.0`,
+/// `bisect/bad`), which is what an op can be named with; the display string a
+/// pill shows is derived from it in the frontend and is lossy on purpose.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefInfo {
+    pub name: String,
+    pub kind: RefKind,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitInfo {
@@ -161,7 +195,7 @@ pub struct CommitInfo {
     /// Unix timestamp, seconds.
     pub timestamp: i64,
     pub parents: Vec<String>,
-    pub refs: Vec<String>,
+    pub refs: Vec<RefInfo>,
 }
 
 /// Filter applied to the commit log walk. All fields are ANDed together;

--- a/src-tauri/tests/log_decoration.rs
+++ b/src-tauri/tests/log_decoration.rs
@@ -1,0 +1,131 @@
+//! What decorates a log row, and WHICH KIND OF REF each decoration is.
+//!
+//! The kind is answered here, at the walk, because a shorthand cannot carry it:
+//! a tag and a branch share one namespace of display names, and a `/` means
+//! nothing — `feat/x` is a local branch, `origin/x` a remote-tracking one,
+//! `release/1.0` an ordinary tag. The frontend used to guess from the string,
+//! which drew a branch icon on every tag and read `release/1.0` as a remote
+//! called `release`.
+
+mod support;
+
+use platypusgit_lib::git::types::{CommitInfo, RefKind};
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// The kind the walk reported for one ref name, across the whole log.
+fn kind_of(commits: &[CommitInfo], name: &str) -> Option<RefKind> {
+    commits
+        .iter()
+        .flat_map(|c| c.refs.iter())
+        .find(|r| r.name == name)
+        .map(|r| r.kind)
+}
+
+/// Every ref name the walk put on the row for `summary`.
+fn refs_on(commits: &[CommitInfo], summary: &str) -> Vec<String> {
+    commits
+        .iter()
+        .find(|c| c.summary == summary)
+        .map(|c| c.refs.iter().map(|r| r.name.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// A lightweight tag is a tag, not a branch.
+#[test]
+fn a_lightweight_tag_is_reported_as_a_tag() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo
+        .tag_lightweight("v1.0.0", head.as_object(), false)
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    assert_eq!(kind_of(&out, "v1.0.0"), Some(RefKind::Tag));
+    assert_eq!(refs_on(&out, "initial"), vec!["main", "v1.0.0"]);
+}
+
+/// An annotated tag points at a TAG object, so it only lands on the row at all
+/// by being peeled — and it must survive that peel as a tag.
+#[test]
+fn an_annotated_tag_is_reported_as_a_tag_on_the_commit_it_peels_to() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let sig = git2::Signature::now("Test User", "test@example.com").unwrap();
+    tr.repo
+        .tag("v2.0.0", head.as_object(), &sig, "release two", false)
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    assert_eq!(kind_of(&out, "v2.0.0"), Some(RefKind::Tag));
+}
+
+/// The name is not the evidence: a slash makes neither a remote nor a branch.
+#[test]
+fn slashes_do_not_decide_the_kind() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo
+        .tag_lightweight("release/1.0", head.as_object(), false)
+        .unwrap();
+    tr.repo.branch("feat/x", &head, false).unwrap();
+    tr.repo
+        .reference(
+            "refs/remotes/origin/main",
+            head.id(),
+            false,
+            "test remote-tracking ref",
+        )
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    assert_eq!(kind_of(&out, "release/1.0"), Some(RefKind::Tag));
+    assert_eq!(kind_of(&out, "feat/x"), Some(RefKind::Branch));
+    assert_eq!(kind_of(&out, "origin/main"), Some(RefKind::Remote));
+}
+
+/// `git tag main` is legal — tags and branches are different namespaces — and
+/// the two decorations must not collapse into one another.
+#[test]
+fn a_tag_and_a_branch_of_the_same_name_stay_distinct() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo
+        .tag_lightweight("main", head.as_object(), false)
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    let mut kinds: Vec<RefKind> = out
+        .iter()
+        .flat_map(|c| c.refs.iter())
+        .filter(|r| r.name == "main")
+        .map(|r| r.kind)
+        .collect();
+    kinds.sort_by_key(|k| format!("{k:?}"));
+    assert_eq!(kinds, vec![RefKind::Branch, RefKind::Tag]);
+}
+
+/// A ref that is neither branch, remote-tracking nor tag is named as itself.
+/// `refs/bisect/*` is the everyday case: it points at commits in the walk for
+/// as long as a bisect runs.
+#[test]
+fn an_unclassified_ref_is_reported_as_other() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo
+        .reference("refs/bisect/bad", head.id(), false, "test bisect ref")
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    assert_eq!(kind_of(&out, "bisect/bad"), Some(RefKind::Other));
+}

--- a/src/AppShell.navroutes.test.tsx
+++ b/src/AppShell.navroutes.test.tsx
@@ -48,7 +48,7 @@ const COMMITS: CommitInfo[] = [OID, OID2].map((oid, i) => ({
   email: "dev@example.com",
   timestamp: 1_700_000_000 - i,
   parents: i === 0 ? [OID2] : [],
-  refs: i === 0 ? ["refs/heads/main"] : [],
+  refs: i === 0 ? [{ name: "main", kind: "Branch" as const }] : [],
 }));
 
 const DIFF: FileDiff = {

--- a/src/AppShell.screens.test.tsx
+++ b/src/AppShell.screens.test.tsx
@@ -29,7 +29,7 @@ const COMMITS: CommitInfo[] = Array.from({ length: 3 }, (_, i) => ({
   email: "dev@example.com",
   timestamp: 1_700_000_000 - i * 3600,
   parents: i < 2 ? [`${i + 1}`.repeat(40)] : [],
-  refs: i === 0 ? ["refs/heads/main"] : [],
+  refs: i === 0 ? [{ name: "main", kind: "Branch" as const }] : [],
 }));
 
 const STATUS: FileStatus[] = [

--- a/src/lib/derive.refs.test.ts
+++ b/src/lib/derive.refs.test.ts
@@ -1,0 +1,92 @@
+// Which pill a log row wears is decided by `RefInfo.kind` and nothing else.
+//
+// The name cannot answer it: a tag and a branch are both just `v1.0` or `main`,
+// and a `/` belongs to plenty of names that are not remote-tracking ones. This
+// used to be guessed from the string, which got three things wrong at once —
+// every tag wore a branch icon, a slashed tag or local branch was split into a
+// remote that does not exist, and History's "Local labels" filter (which drops
+// whatever carries a `remote`) then hid both.
+import { describe, expect, it } from "vitest";
+
+import { mapCommitRefs } from "./derive";
+import type { RefInfo } from "./types";
+
+const ref = (name: string, kind: RefInfo["kind"]): RefInfo => ({ name, kind });
+
+describe("mapCommitRefs", () => {
+  it("gives a tag the tag glyph, not a branch's", () => {
+    expect(mapCommitRefs([ref("v1.0.0", "Tag")], "main")).toEqual([
+      { name: "v1.0.0", tone: "amber", icon: "tag", ref: "v1.0.0" },
+    ]);
+  });
+
+  it("keeps a slashed tag whole rather than reading `release` as a remote", () => {
+    const [pill] = mapCommitRefs([ref("release/1.0", "Tag")], "main");
+    expect(pill.name).toBe("release/1.0");
+    expect(pill.icon).toBe("tag");
+    expect(pill.remote).toBeUndefined();
+  });
+
+  it("keeps a slashed local branch local", () => {
+    // `feat/x` is the shape half this project's own branches have. Carrying a
+    // `remote` here is what made them disappear under "Local labels".
+    expect(mapCommitRefs([ref("feat/x", "Branch")], "main")).toEqual([
+      { name: "feat/x", tone: "green", icon: "branch", ref: "feat/x" },
+    ]);
+  });
+
+  it("splits a remote-tracking branch into remote and name", () => {
+    expect(mapCommitRefs([ref("origin/feat/x", "Remote")], "main")).toEqual([
+      {
+        name: "feat/x",
+        tone: "violet",
+        icon: "branch",
+        remote: "origin",
+        ref: "origin/feat/x",
+      },
+    ]);
+  });
+
+  it("leaves a remote-tracking ref with no branch half readable", () => {
+    // `refs/remotes/foo` is hand-made, never something git writes — but
+    // splitting it blindly is an empty pill, which reads as nothing at all.
+    const [pill] = mapCommitRefs([ref("foo", "Remote")], "main");
+    expect(pill.name).toBe("foo");
+    expect(pill.remote).toBeUndefined();
+  });
+
+  it("marks the branch HEAD points at", () => {
+    expect(mapCommitRefs([ref("main", "Branch")], "main")).toEqual([
+      { name: "HEAD→main", tone: "accent", icon: "branch", ref: "main" },
+    ]);
+  });
+
+  it("does not hand the HEAD arrow to a tag that shares the branch's name", () => {
+    // `git tag main` is legal and the two live in different namespaces. Only
+    // the branch is where HEAD is.
+    expect(mapCommitRefs([ref("main", "Tag")], "main")).toEqual([
+      { name: "main", tone: "amber", icon: "tag", ref: "main" },
+    ]);
+  });
+
+  it("names an odd ref as itself instead of dressing it as a branch", () => {
+    // `refs/bisect/bad` points at a commit in the walk while a bisect runs.
+    const [pill] = mapCommitRefs([ref("bisect/bad", "Other")], "main");
+    expect(pill.name).toBe("bisect/bad");
+    expect(pill.icon).toBe("link");
+    expect(pill.remote).toBeUndefined();
+  });
+
+  it("carries git's own name for every kind, which is what an op is named with", () => {
+    const names = mapCommitRefs(
+      [
+        ref("main", "Branch"),
+        ref("origin/main", "Remote"),
+        ref("v1.0.0", "Tag"),
+        ref("bisect/bad", "Other"),
+      ],
+      "main",
+    ).map((p) => p.ref);
+    expect(names).toEqual(["main", "origin/main", "v1.0.0", "bisect/bad"]);
+  });
+});

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -4,6 +4,7 @@ import type {
   CommitInfo,
   FileDiff,
   FileStatus,
+  RefInfo,
   StatusFlag,
 } from "./types";
 
@@ -195,30 +196,73 @@ export function remoteBranches(branches: BranchInfo[]): BranchInfo[] {
 }
 
 /**
- * Convert a commit's ref list into the pill-shaped ref objects the
- * UI expects. First HEAD-pointing local branch gets the accent tone.
+ * Convert a commit's ref list into the pill-shaped ref objects the UI expects.
+ * The branch HEAD points at gets the accent tone and the arrow.
+ *
+ * Tone AND glyph come off `RefInfo.kind`, never off the name. The name cannot
+ * answer the question — a tag and a branch are both just `v1.0` or `main`, and
+ * a `/` belongs to plenty of names that are not remote-tracking ones — so this
+ * used to guess with `r.includes("/")` and got three things wrong at once:
+ * every tag wore a branch icon, `release/1.0` (a tag) and `feat/x` (a local
+ * branch) were split into a remote called `release`/`feat`, and History's
+ * "Local labels" filter then hid both, since it hides whatever has a `remote`.
  */
 export function mapCommitRefs(
-  refs: string[],
+  refs: RefInfo[],
   headBranch: string | null,
 ): {
   name: string;
   tone: "accent" | "violet" | "green" | "amber";
+  icon: "branch" | "tag" | "link";
   remote?: string;
   ref: string;
 }[] {
   // `ref` is the name git knows, carried alongside the display name because the
   // display name is lossy: HEAD's pill reads "HEAD→main", and a remote ref is
   // split into name + remote. A drag or any other op needs the original (#91).
-  return refs.map((r) => {
-    if (r.startsWith("origin/") || r.includes("/")) {
-      const [remote, ...rest] = r.split("/");
-      return { name: rest.join("/"), tone: "violet" as const, remote, ref: r };
+  return refs.map(({ name, kind }) => {
+    switch (kind) {
+      case "Tag":
+        // Amber and a tag glyph — the pair the tag badge beside it already
+        // uses. A tag IS a ref, but it is not a branch: it does not move, and
+        // nothing about its name is a remote prefix.
+        return { name, tone: "amber" as const, icon: "tag" as const, ref: name };
+      case "Remote": {
+        const [prefix, ...rest] = name.split("/");
+        // A remote-tracking ref is `<remote>/<branch>` — except for a
+        // hand-made `refs/remotes/foo`, which has no branch half. Splitting
+        // that one blindly leaves an EMPTY pill, so it keeps its name and
+        // simply has no remote to dim.
+        return rest.length === 0
+          ? { name, tone: "violet" as const, icon: "branch" as const, ref: name }
+          : {
+              name: rest.join("/"),
+              tone: "violet" as const,
+              icon: "branch" as const,
+              remote: prefix,
+              ref: name,
+            };
+      }
+      case "Other":
+        // `refs/bisect/*` mid-bisect, a fetched `refs/pull/N/head`. Shown
+        // whole and with a neutral glyph: these are real refs on the row, but
+        // calling them branches is how one ends up on a menu that would move
+        // it.
+        return { name, tone: "violet" as const, icon: "link" as const, ref: name };
+      case "Branch":
+      default:
+        // `default` is the wire's, not the union's: an older frontend against
+        // a newer backend must still draw the pill, and a branch is the safe
+        // reading of an unknown ref kind.
+        return name === headBranch
+          ? {
+              name: `HEAD→${name}`,
+              tone: "accent" as const,
+              icon: "branch" as const,
+              ref: name,
+            }
+          : { name, tone: "green" as const, icon: "branch" as const, ref: name };
     }
-    if (r === headBranch) {
-      return { name: `HEAD→${r}`, tone: "accent" as const, ref: r };
-    }
-    return { name: r, tone: "green" as const, ref: r };
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,6 +92,30 @@ export interface FileStatus {
   submodule?: boolean;
 }
 
+/**
+ * What kind of ref one of a commit's decorations names. Mirrors Rust `RefKind`.
+ *
+ * It arrives from the backend because the name cannot carry it: tags and
+ * branches share one namespace of shorthands, and a `/` says nothing either —
+ * `feat/x` is a local branch, `origin/x` a remote-tracking one, `release/1.0`
+ * an ordinary tag. Guessing from the string put a branch icon on every tag and
+ * read `release/1.0` as a remote called `release`.
+ */
+export type RefKind = "Branch" | "Remote" | "Tag" | "Other";
+
+/**
+ * One ref pointing at a commit — what decorates a log row. Mirrors Rust
+ * `RefInfo`.
+ *
+ * `name` is git's own shorthand (`main`, `origin/main`, `v1.0.0`,
+ * `bisect/bad`), so it is what an op may be named with; `mapCommitRefs` turns
+ * it into the pill's display string, which is lossy on purpose.
+ */
+export interface RefInfo {
+  name: string;
+  kind: RefKind;
+}
+
 export interface CommitInfo {
   oid: string;
   shortOid: string;
@@ -102,7 +126,7 @@ export interface CommitInfo {
   /** unix timestamp, seconds */
   timestamp: number;
   parents: string[];
-  refs: string[];
+  refs: RefInfo[];
 }
 
 /** One page of a resumable log walk (#68 G11). Mirrors Rust `LogPage`. */

--- a/src/screens/History.dnd.test.tsx
+++ b/src/screens/History.dnd.test.tsx
@@ -19,7 +19,12 @@ const HEAD_OID = "a".repeat(40);
 const FEATURE_OID = "b".repeat(40);
 const OLD_OID = "c".repeat(40);
 
-function makeCommit(oid: string, summary: string, parents: string[], refs: string[]): CommitInfo {
+function makeCommit(
+  oid: string,
+  summary: string,
+  parents: string[],
+  branches: string[],
+): CommitInfo {
   return {
     oid,
     shortOid: oid.slice(0, 7),
@@ -29,7 +34,9 @@ function makeCommit(oid: string, summary: string, parents: string[], refs: strin
     email: "dev@example.com",
     timestamp: 1_700_000_000,
     parents,
-    refs,
+    // Every ref this fixture puts on a row is a local branch —
+    // dragging one is what the suite is about.
+    refs: branches.map((name) => ({ name, kind: "Branch" as const })),
   };
 }
 

--- a/src/screens/History.hookorder.test.tsx
+++ b/src/screens/History.hookorder.test.tsx
@@ -25,7 +25,7 @@ const commit: CommitInfo = {
   email: "dev@example.com",
   timestamp: 1_700_000_000,
   parents: [],
-  refs: ["refs/heads/main"],
+  refs: [{ name: "main", kind: "Branch" }],
 };
 
 describe("History screen when the log arrives after mount", () => {

--- a/src/screens/History.refs.test.tsx
+++ b/src/screens/History.refs.test.tsx
@@ -1,0 +1,100 @@
+// A tag on a log row has to READ as a tag. git calls a branch and a tag both a
+// ref, and the row drew a branch icon for either, so `v1.0.0` looked like a
+// branch sitting next to `main` — the one thing a history view exists to tell
+// apart at a glance.
+//
+// Rendered rather than unit-tested because the glyph travels three hops from
+// the kind the backend sent — mapCommitRefs → PGCommitRow → PGBranchPill — and
+// each one has its own default of "branch".
+import { describe, expect, it, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import type { CommitInfo, RefInfo } from "@/lib/types";
+
+const oid = (label: string) => label.repeat(40).slice(0, 40);
+
+const mk = (label: string, refs: RefInfo[], parents: string[] = []): CommitInfo => ({
+  oid: oid(label),
+  shortOid: oid(label).slice(0, 7),
+  summary: `subject ${label}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs,
+});
+
+// Tip carries the branch HEAD is on and a release tag; its parent carries a
+// slashed tag, the shape that used to be split into a remote called `release`.
+const COMMITS = [
+  mk("a", [{ name: "main", kind: "Branch" }, { name: "v1.0.0", kind: "Tag" }], [oid("b")]),
+  mk("b", [{ name: "release/0.9", kind: "Tag" }]),
+];
+
+beforeEach(() => {
+  localStorage.clear();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    searchResults: null,
+    searching: false,
+    searchCommits: async () => {},
+    branches: [{ name: "main", isHead: true, isRemote: false, tip: oid("a") }],
+    status: [],
+    loading: false,
+  } as never);
+  useNavStore.setState({ intent: null });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+});
+
+/** The pill for one ref, found by the name git knows it as. */
+const pill = (c: HTMLElement, ref: string) =>
+  c.querySelector<HTMLElement>(`[data-pg-ref="${ref}"]`);
+
+/**
+ * Which glyph a pill drew. lucide names its own svg class after the icon, and
+ * `PGIcon` is the only file allowed to import lucide — so this is the one
+ * place that reads that class, and it is what makes "a tag icon, not a branch
+ * icon" an assertion rather than a screenshot.
+ */
+const glyph = (el: HTMLElement) =>
+  el.querySelector("svg")?.getAttribute("class") ?? "";
+
+describe("ref pills on a log row", () => {
+  it("draws a tag with the tag glyph", async () => {
+    const { container } = render(<HistoryScreen />);
+    await waitFor(() => expect(pill(container, "v1.0.0")).not.toBeNull());
+    expect(glyph(pill(container, "v1.0.0")!)).toContain("lucide-tag");
+  });
+
+  it("still draws a branch with the branch glyph", async () => {
+    const { container } = render(<HistoryScreen />);
+    await waitFor(() => expect(pill(container, "main")).not.toBeNull());
+    const drawn = glyph(pill(container, "main")!);
+    expect(drawn).not.toContain("lucide-tag");
+    expect(pill(container, "main")!.textContent).toBe("HEAD→main");
+  });
+
+  it("shows a slashed tag whole, not as a remote's branch", async () => {
+    const { container } = render(<HistoryScreen />);
+    await waitFor(() => expect(pill(container, "release/0.9")).not.toBeNull());
+    const el = pill(container, "release/0.9")!;
+    expect(el.textContent).toBe("release/0.9");
+    expect(glyph(el)).toContain("lucide-tag");
+    // The remote half of a remote pill is dimmed in its own span; a tag has no
+    // remote half at all, so the name is one run of text.
+    expect(el.querySelectorAll("span").length).toBe(1);
+  });
+});


### PR DESCRIPTION
A tag on a History row wore a **branch** icon, so `v1.0.0` looked like a branch sitting next to `main` — the one thing a history view exists to tell apart at a glance.

The cause was that a commit's decorations arrived as bare shorthands, leaving the pill to guess what each one was from its name. That guess (`name.includes("/")`) got three things wrong at once:

- every tag drew a branch glyph;
- `release/1.0` (a tag) and `feat/x` (a **local** branch) were each split into a remote that does not exist — so they rendered in the remote tone with a dimmed `release/` / `feat/` prefix;
- and "Local labels", which hides whatever carries a remote, then hid both of them.

## What changed

The log walk now sends the kind it already knew. `collect_ref_map` asks git (`is_tag` → `is_remote` → `is_branch`) and each row carries `RefInfo { name, kind }` — `Branch` / `Remote` / `Tag` / `Other`. `mapCommitRefs` reads tone **and** glyph off the kind:

- a tag gets the tag glyph and the amber tone the tag badge beside it already uses;
- only `Remote` splits `<remote>/<name>`;
- `Other` is a real arm, not a `_ => Branch` default: `refs/bisect/*` while a bisect runs and a fetched `refs/pull/N/head` both point at commits *in* the walk, so they reach a row. They are now named as themselves with a neutral glyph — calling them branches is how one ends up on a menu that would move them;
- the `HEAD→` arrow is gated on the branch kind as well as the name, because `git tag main` is legal.

The kind has to come from the backend: tags and branches share one namespace of display names, so `v1.0` says nothing about which it is, and a `/` says nothing either. Deciding it at the walk costs one `is_tag` call that was already being made. Dragging is unaffected — a pill still carries the name git knows (`data-pg-ref`), and `git merge v1.0` / `git rebase onto v1.0` are both things git does.

## Verification

- `src-tauri/tests/log_decoration.rs` (new, 5 tests) — lightweight and annotated tags come back as tags, slashes decide nothing, a tag and a branch of the same name stay two distinct decorations, an unclassified ref is `Other`.
- `src/lib/derive.refs.test.ts` (new, 9 tests) — the whole mapping.
- `src/screens/History.refs.test.tsx` (new, 3 tests) — the glyph that actually *renders*, because it travels three hops each of which defaults to `branch`.
- **Planted a violation on both sides** to prove the tests bite: `icon: "tag"` → `"branch"` in `derive.ts` failed 5 assertions; `is_tag()` → `RefKind::Branch` in `libgit2.rs` failed 4 of the 5 Rust tests.
- 3919 vitest, 96 Rust test binaries, both typecheck gates, and `e2e/specs/history-ops.e2e.ts` 9/9 against a freshly built snapshot — the e2e run is what proves the new serde shape survives real IPC.

Docs: new sections in `docs/dev/backend.md` ("What decorates a log row, and which KIND of ref it is") and `docs/dev/frontend.md` ("The ref pills on a log row").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
