### PR TITLE
fix(commits): stop the log's narrow pane from eating the subject column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,15 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 - **The log is paged** — `s.commits` is a prefix of history, never the answer
   to "does X exist / is X an ancestor"; ask the backend.
   (`docs/dev/frontend.md`)
+- **A commit row's columns have a YIELD ORDER, and it is the template.** Every
+  track in `commitRowGrid` but the subject and the author is a fixed width, so
+  a new fixed column — or a wider one — comes straight out of the subject,
+  which is what collapsed it to 22px in a 420px pane. The subject keeps
+  `SUBJECT_MIN_W`, the author name yields to its avatar, and the sum of the
+  minimums must still fit `COMMIT_LIST_MIN_W` (`git-components.narrow.test.tsx`
+  fails the build otherwise). Anything that can fill its column keeps `COL_PAD`
+  clear on the right — header captions included — or it touches the column
+  beside it instead of truncating. (`docs/dev/frontend.md`)
 - **Drag and drop:** pointer events via `features/dnd`, never HTML5 dnd; every
   drag has a keyboard equivalent. (`docs/dev/frontend.md`)
 - **`git2::Repository` is `Send` not `Sync`** — wrap git2 work in

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1023,6 +1023,55 @@ version is that `commitMenuItems` cannot leave without also extracting the
   for the density reason one column over: `undefined` reaching the grid resolves
   every `Npx` template to `auto` and collapses the column on every row at once.
 
+## What yields when the commit list is narrow
+
+- **The subject has a FLOOR and the author name is what gives way.** Every
+  other track in `commitRowGrid` is a fixed pixel width, so before this the
+  subject's `1fr` was the only track that could yield — and it yielded
+  everything. Measured in Chrome at 420px (`COMMIT_LIST_MIN_W`, the narrowest
+  the list can be dragged), a five-lane row gave the subject **22px** while the
+  author name held a rigid 150. So the template now reads
+  `minmax(SUBJECT_MIN_W, 1fr)` for the subject and
+  `minmax(AUTHOR_MIN_W, AUTHOR_COL_W)` for the author: the name truncates, then
+  disappears, and the avatar still says who. Nothing about this is measured —
+  it is track sizing, so it holds in WebKitGTK, which has neither container
+  queries nor `ResizeObserver`.
+- **The order the `minmax()`es are written in is not free.** CSS grid grows a
+  track with a fixed maximum to that maximum BEFORE it hands anything to an
+  `fr` track, so between 420px and ~560px the author column fills to 150 first
+  and the subject sits at its floor. That is the accepted trade for a pure-CSS
+  fix: getting the subject to grow first needs a flexible author track (which
+  never stops growing) or `fit-content()` (which sizes each ROW to its own
+  author and un-aligns the columns from each other and from the header). A
+  future pass wanting subject-first growth needs a measured width, not a
+  cleverer template.
+- **The floors are only worth anything if they FIT**, so
+  `COMMIT_LIST_MIN_W` lives in `design/graph-geometry.ts` beside the widths it
+  is the sum of — `graphWidth(4) + SHA_COL_W + SUBJECT_MIN_W + AUTHOR_MIN_W +
+  DATE_COL_W.relative`, exactly 420 — and `git-components.narrow.test.tsx`
+  fails the build when a raised minimum (or a wider Date column) breaks the
+  arithmetic. Past that sum the grid overflows its pane instead of squeezing,
+  and what falls off the right edge is the DATE column. A repository whose
+  gutter is at `GRAPH_MAX_W` is over the sum by construction; the gutter is not
+  width-aware yet.
+- **Every cell clips, and clipping alone was not enough.** The subject cell's
+  pills and HEAD badge do not shrink (half a pill reads as a different branch
+  name), so past the floor they were painting over the author column, and the
+  author cell had neither a 0 minimum nor padding — "Gaurav Vijay Jadhav" ran
+  into the date at EVERY pane width, not just a narrow one. Hence `COL_PAD`:
+  one number for the gutter a full-width value truncates to clear, shared by
+  the subject cell, the author cell and History's header captions. Those
+  captions are plain spans in the same shrinking tracks, and two plain spans in
+  a too-narrow grid do not truncate, they overlap — the narrow log headed its
+  columns "SUBJECTAUTHOR", and with clipping but no padding, "AUTHORDATE".
+- **Reflog is the surface that needed this most**, and it is why the fix lives
+  in the shared template rather than in History: its list pane is 35% of the
+  window with a 280px floor, and the pre-fix row spent 310px of that on fixed
+  tracks — so its subject was under 100px below an ~1170px window and gone
+  entirely below ~890px. It still reserves the full author column for a value
+  it always passes as `""`; a content-aware column there would have to be
+  content-aware for the whole LIST, not per row.
+
 ## `git notes` in the commit detail panel (#253)
 
 - **Notes hang off the SELECTED commit, never the log page.** `CommitNotes`

--- a/e2e/specs/smoke.e2e.ts
+++ b/e2e/specs/smoke.e2e.ts
@@ -31,6 +31,24 @@ describe("smoke", () => {
       timeout: 20_000,
       timeoutMsg: "History showed no commit rows after opening the repo",
     });
+    // The row's columns are ONE CSS string (`commitRowGrid`), and the two
+    // `minmax()`es in it are the whole of what keeps the subject column from
+    // collapsing in a narrow pane. A webview that would not parse that value
+    // drops the WHOLE property and lays every row out as a single auto track —
+    // which reads as a styling nit and is actually the log losing its columns.
+    // No jsdom test can see it and Chrome cannot answer it for WebKitGTK, so
+    // the real webview is asked here: the property resolved, into five tracks.
+    const columns = await browser.execute(
+      () =>
+        getComputedStyle(document.querySelector('[data-testid="commit-row"]')!)
+          .gridTemplateColumns,
+    );
+    expect(columns).not.toBe("none");
+    // Either form is a pass: engines report the USED track widths here, but a
+    // specified `minmax(140px, 1fr)` carries a space of its own, so close it up
+    // before counting rather than assuming which one came back.
+    expect(columns.replace(/,\s+/g, ",").split(" ")).toHaveLength(5);
+
     // branch chip shows main
     await expect($('[data-testid="branch-chip"]')).toHaveText(
       expect.stringContaining("main"),

--- a/src/design/git-components.narrow.test.tsx
+++ b/src/design/git-components.narrow.test.tsx
@@ -1,0 +1,112 @@
+// What the commit row does when the pane it lives in is NARROW.
+//
+// Measured in Chrome (real layout, not jsdom) against the pre-fix template
+// `<graph>px 70px 1fr 150px 90px` in a 420px box — the narrowest the commit
+// list can be dragged to:
+//
+//     graph 88 | sha 70 | SUBJECT 22 | author 150 | date 90
+//
+// The subject — the one column anybody reads — was the ONLY track that could
+// yield, so it took every pixel of the shortfall and collapsed to 22px while
+// the author name kept a rigid 150. Its content (branch pills, the HEAD badge,
+// the subject text) then painted straight over the author cell, and History's
+// header read "SUBJECTAUTHOR".
+//
+// So the yield order is now written into the template: the subject has a FLOOR
+// and the author name is what gives way, down to the width of its avatar. Every
+// cell clips, so nothing can paint over the column to its right no matter how
+// far past the floor the pane goes.
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { PGCommitRow } from "./git-components";
+import {
+  AUTHOR_COL_W,
+  AUTHOR_MIN_W,
+  COL_PAD,
+  COMMIT_LIST_MIN_W,
+  DATE_COL_W,
+  SHA_COL_W,
+  SUBJECT_MIN_W,
+  commitRowGrid,
+  graphWidth,
+} from "./graph-geometry";
+
+describe("commitRowGrid yield order", () => {
+  it("floors the subject and lets the author name shrink to its avatar", () => {
+    expect(commitRowGrid(88, DATE_COL_W.relative)).toBe(
+      `88px ${SHA_COL_W}px minmax(${SUBJECT_MIN_W}px, 1fr) ` +
+        `minmax(${AUTHOR_MIN_W}px, ${AUTHOR_COL_W}px) ${DATE_COL_W.relative}px`,
+    );
+  });
+
+  // Reflog's rows, which draw no lanes. Same yield order, one track fewer —
+  // and Reflog is the surface that needs it most: its pane is 35% of the
+  // window, so its subject collapsed on any window under ~1200px.
+  it("drops the graph track without changing the yield order", () => {
+    expect(commitRowGrid(0, DATE_COL_W.relative)).toBe(
+      `${SHA_COL_W}px minmax(${SUBJECT_MIN_W}px, 1fr) ` +
+        `minmax(${AUTHOR_MIN_W}px, ${AUTHOR_COL_W}px) ${DATE_COL_W.relative}px`,
+    );
+  });
+
+  // The floors are only worth anything if they FIT. Past the sum of the
+  // minimum tracks the grid overflows its pane and the date falls off the
+  // right edge, so the narrowest pane the app can produce has to hold them:
+  // COMMIT_LIST_MIN_W is that pane. Raising a column's minimum — or the Date
+  // column's width — without checking this is how the row starts overflowing
+  // again at the bottom of the drag.
+  it("fits every minimum inside the narrowest commit list", () => {
+    const min =
+      graphWidth(4) + SHA_COL_W + SUBJECT_MIN_W + AUTHOR_MIN_W + DATE_COL_W.relative;
+    expect(min).toBeLessThanOrEqual(COMMIT_LIST_MIN_W);
+  });
+
+  // Avatar 16px, the flex gap after it, and COL_PAD: below that the "who" goes
+  // as well as the name — a column that costs space and says nothing — or the
+  // avatar ends up touching the date.
+  it("keeps the author's avatar inside the author minimum", () => {
+    expect(AUTHOR_MIN_W).toBeGreaterThanOrEqual(16 + 6 + COL_PAD);
+  });
+});
+
+describe("PGCommitRow cell clipping", () => {
+  function cells() {
+    const { container } = render(
+      <PGCommitRow
+        graphW={graphWidth(0)}
+        sha="abc1234"
+        message="feat(commits): a subject far too long for a narrow pane"
+        author="Gaurav Vijay Jadhav"
+        date="14 min ago"
+        refs={[{ name: "main", tone: "accent", icon: "branch" }]}
+      />,
+    );
+    const subject = container.querySelector<HTMLElement>(
+      '[data-testid="commit-subject"]',
+    )!;
+    const date = container.querySelector<HTMLElement>('[data-testid="commit-date"]')!;
+    return {
+      subject: subject.parentElement!,
+      author: date.previousElementSibling as HTMLElement,
+    };
+  }
+
+  // The pills and the HEAD badge do not shrink (a half-pill reads as a
+  // different branch name), so past the subject floor they have to be CUT
+  // rather than allowed to spill into the author column.
+  it("clips the subject cell", () => {
+    const { subject } = cells();
+    expect(subject.style.overflow).toBe("hidden");
+    // jsdom's CSSOM normalises the `minWidth: 0` React writes to "0px".
+    expect(subject.style.minWidth).toBe("0px");
+  });
+
+  // Not only a narrow-pane bug: "Gaurav Vijay Jadhav" ran over the date at
+  // EVERY width, because the author cell had neither a 0 minimum nor a clip.
+  it("clips the author cell", () => {
+    const { author } = cells();
+    expect(author.style.overflow).toBe("hidden");
+    expect(author.style.minWidth).toBe("0px");
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -22,7 +22,7 @@ import {
   type HeadDecor,
 } from "@/features/settings/headMarks";
 import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
-import { GRAPH_PAD, commitRowGrid, laneX } from "./graph-geometry";
+import { COL_PAD, GRAPH_PAD, commitRowGrid, laneX } from "./graph-geometry";
 import type { WindowRange } from "@/lib/useWindowedList";
 import type {
   RebaseAction,
@@ -1726,7 +1726,11 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           alignItems: "center",
           gap: 6,
           minWidth: 0,
-          paddingRight: 10,
+          paddingRight: COL_PAD,
+          // Below SUBJECT_MIN_W the cell is narrower than its contents, and the
+          // pills do not shrink (half a pill reads as a different branch), so
+          // without this they painted over the author column instead.
+          overflow: "hidden",
         }}
       >
         {/* Ahead of the branch pills: the one mark that says "you are here" in
@@ -1779,6 +1783,15 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           alignItems: "center",
           gap: 6,
           color: "var(--fg-2)",
+          // Not just a narrow-pane fix: the name's ellipsis is on the span, but
+          // the CELL had no 0 minimum and no padding, so a long author ("Gaurav
+          // Vijay Jadhav") grew the flex box past its track and ran into the
+          // date at ANY pane width. The avatar keeps its 16px (PGAvatar is
+          // flex-shrink: 0), so what gets cut is the name — and the padding is
+          // what the name is cut to CLEAR, which is why AUTHOR_MIN_W counts it.
+          minWidth: 0,
+          overflow: "hidden",
+          paddingRight: COL_PAD,
         }}
       >
         <PGAvatar name={author} size={16} />

--- a/src/design/graph-geometry.test.ts
+++ b/src/design/graph-geometry.test.ts
@@ -12,6 +12,12 @@ import {
   maxVisibleCol,
 } from "./graph-geometry";
 
+/**
+ * The template's tracks. Two of them are `minmax()`es carrying a comma and a
+ * space, so counting columns is no longer `split(" ")`.
+ */
+const tracks = (template: string) => template.replace(/,\s+/g, ",").split(" ");
+
 describe("graph geometry", () => {
   it("pins the lane constants", () => {
     // Literals, not derived: if any of these move, the SVG path math and the
@@ -55,12 +61,19 @@ describe("graph geometry", () => {
     expect(isGraphClamped(100)).toBe(true);
   });
 
+  // The subject's floor and the author's minimum are the row's yield order —
+  // see `git-components.narrow.test.tsx` for what they are for. Spelled out
+  // literally here, not composed from the constants, so that changing one of
+  // those numbers has to be a deliberate edit to a template somebody reads.
   it("builds a five-column grid with the graph, four without", () => {
-    expect(commitRowGrid(152)).toBe("152px 70px 1fr 150px 90px");
+    expect(commitRowGrid(152)).toBe(
+      "152px 70px minmax(140px, 1fr) minmax(32px, 150px) 90px",
+    );
     // graphW of 0 means "no graph column at all" (Reflog), which is NOT the
     // same as graphWidth(0)=24, a real one-lane log.
-    expect(commitRowGrid(0)).toBe("70px 1fr 150px 90px");
-    expect(commitRowGrid(0).split(" ")).toHaveLength(4);
+    expect(commitRowGrid(0)).toBe("70px minmax(140px, 1fr) minmax(32px, 150px) 90px");
+    expect(tracks(commitRowGrid(0))).toHaveLength(4);
+    expect(tracks(commitRowGrid(152))).toHaveLength(5);
   });
 
   // The Date column's width follows the user's date format (#354): a
@@ -76,9 +89,11 @@ describe("graph geometry", () => {
     expect(DATE_COL_W.absolute).toBeGreaterThan(DATE_COL_W.relative);
     expect(DATE_COL_W.both).toBeGreaterThan(DATE_COL_W.absolute);
     expect(commitRowGrid(152, DATE_COL_W.absolute)).toBe(
-      `152px 70px 1fr 150px ${DATE_COL_W.absolute}px`,
+      `152px 70px minmax(140px, 1fr) minmax(32px, 150px) ${DATE_COL_W.absolute}px`,
     );
-    expect(commitRowGrid(0, DATE_COL_W.both)).toBe(`70px 1fr 150px ${DATE_COL_W.both}px`);
+    expect(commitRowGrid(0, DATE_COL_W.both)).toBe(
+      `70px minmax(140px, 1fr) minmax(32px, 150px) ${DATE_COL_W.both}px`,
+    );
   });
 
   // Fixed-width monospace: the widest string the mode can produce has to fit,

--- a/src/design/graph-geometry.ts
+++ b/src/design/graph-geometry.ts
@@ -45,6 +45,54 @@ export const DATE_COL_W: Record<DateFormat, number> = {
   both: 200,
 };
 
+/** The short-oid column. Seven hex digits of monospace, plus the gap. */
+export const SHA_COL_W = 70;
+
+/**
+ * Gutter kept clear at the right of a column whose content can fill it — the
+ * subject cell, the author cell, and every caption in History's header.
+ *
+ * A shared number because it is load-bearing in two places at once: it is what
+ * makes a full-width value TRUNCATE instead of touching the column beside it
+ * (a 19-character author name ran into the date at every pane width, and the
+ * header captions read "AUTHORDATE"), and it is a term in `AUTHOR_MIN_W` — the
+ * avatar has to clear the date too.
+ */
+export const COL_PAD = 10;
+
+/**
+ * The narrowest the subject column may become, and the narrowest the author
+ * column may become — the row's YIELD ORDER, in two numbers.
+ *
+ * Every other track is fixed, so before these existed the subject was the only
+ * one that could give, and it gave everything: measured in Chrome at 420px, a
+ * five-lane row left the subject **22px** while the author name held a rigid
+ * 150. The subject is the column people read, so it is the column with a floor,
+ * and the author name is what yields instead — down to `AUTHOR_MIN_W`: the
+ * avatar (16px), the flex gap after it, and `COL_PAD`, so the narrowest author
+ * column is an avatar that still clears the date. The name truncates, then
+ * disappears, and the avatar still says who.
+ *
+ * Anything under the sum of these minimums overflows the pane rather than
+ * squeezing further, which drops the DATE column off the right edge — see
+ * `COMMIT_LIST_MIN_W`, and the guard in `git-components.narrow.test.tsx` that
+ * keeps the two in agreement.
+ */
+export const SUBJECT_MIN_W = 140;
+export const AUTHOR_COL_W = 150;
+export const AUTHOR_MIN_W = 16 + 6 + COL_PAD;
+
+/**
+ * Floor for what is left of the commit list when a detail panel is dragged
+ * open (#162), and therefore the narrowest row the columns above are designed
+ * for: exactly `graphWidth(4) + SHA + SUBJECT_MIN + AUTHOR_MIN + DATE`, the
+ * five-lane log at the relative date format.
+ *
+ * It lives here, beside the widths it is the sum of, because that is the only
+ * place the arithmetic can be checked.
+ */
+export const COMMIT_LIST_MIN_W = 420;
+
 /**
  * Grid template shared by PGCommitRow and History's column header, so the two
  * cannot drift. `graphW === 0` drops the graph column entirely — that is
@@ -56,6 +104,19 @@ export const DATE_COL_W: Record<DateFormat, number> = {
  * same number. It defaults to the relative width so a caller with no notion of
  * the setting (tests, any surface that only ever shows "3w ago") gets exactly
  * the old template.
+ *
+ * The two `minmax()`es are the whole of the narrow-pane behaviour, and the
+ * order they are written in is not free: CSS grid grows a track with a fixed
+ * maximum to that maximum BEFORE it hands anything to an `fr` track, so the
+ * author column fills to `AUTHOR_COL_W` first and only then does the subject
+ * grow past its floor. That is why the author's maximum stays a number rather
+ * than a second `fr` — a fractional author track never stops growing, and
+ * `fit-content()` sizes each ROW to its own author, which un-aligns the
+ * columns from each other and from the header.
  */
-export const commitRowGrid = (graphW: number, dateW: number = DATE_COL_W.relative): string =>
-  graphW > 0 ? `${graphW}px 70px 1fr 150px ${dateW}px` : `70px 1fr 150px ${dateW}px`;
+export const commitRowGrid = (graphW: number, dateW: number = DATE_COL_W.relative): string => {
+  const cols =
+    `${SHA_COL_W}px minmax(${SUBJECT_MIN_W}px, 1fr) ` +
+    `minmax(${AUTHOR_MIN_W}px, ${AUTHOR_COL_W}px) ${dateW}px`;
+  return graphW > 0 ? `${graphW}px ${cols}` : cols;
+};

--- a/src/screens/History.graph.test.tsx
+++ b/src/screens/History.graph.test.tsx
@@ -8,7 +8,7 @@ import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
-import { graphWidth } from "@/design/graph-geometry";
+import { COL_PAD, graphWidth } from "@/design/graph-geometry";
 import type { CommitInfo } from "@/lib/types";
 
 /** 40-char oids: History renders shortOid, and selection keys off the full oid. */
@@ -74,6 +74,25 @@ describe("History graph column", () => {
     const row = container.querySelector<HTMLElement>('[data-testid="commit-row"]')!;
     const header = container.querySelector<HTMLElement>('[data-testid="commit-header"]')!;
     expect(header.style.gridTemplateColumns).toBe(row.style.gridTemplateColumns);
+  });
+
+  // Sharing the template means sharing the SHRINKING: the author track is
+  // allowed to squeeze down to its avatar, which is narrower than the word
+  // "AUTHOR". Two plain spans in a too-narrow grid do not truncate, they
+  // overlap — a narrow log used to head its columns "SUBJECTAUTHOR". The
+  // padding is half the fix and not decoration: clipped but unpadded, "AUTHOR"
+  // came out flush against "DATE" instead of truncating clear of it.
+  it("clips and pads every header caption", async () => {
+    const { container } = render(<HistoryScreen />);
+    await waitFor(() => expect(rows(container).length).toBe(3));
+    const header = container.querySelector<HTMLElement>('[data-testid="commit-header"]')!;
+    const captions = [...header.children] as HTMLElement[];
+    expect(captions.length).toBe(5);
+    for (const c of captions) {
+      expect(c.style.overflow).toBe("hidden");
+      expect(c.style.textOverflow).toBe("ellipsis");
+      expect(c.style.paddingRight).toBe(`${COL_PAD}px`);
+    }
   });
 
   // The UNION is the point: searchResults has no intervening commits by

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -12,6 +12,8 @@ import {
   PGSelect,
   PGSkeleton,
   PGToolbar,
+  COL_PAD,
+  COMMIT_LIST_MIN_W,
   commitMenuItems,
   commitMultiMenuItems,
   COMMIT_ROW_BASE_H,
@@ -102,14 +104,31 @@ const MAX_BARREN_PAGES = 3;
 const INLINE_DIFF_DEBOUNCE_MS = 100;
 
 /**
- * Floors for what is left over when a detail panel is dragged open (#162). The
- * commit list is a graph plus a message column, so it needs real width; below
- * layout it only has to keep a few rows visible.
+ * Floor for what is left over when the detail panel is dragged open BELOW the
+ * list (#162) — it only has to keep a few rows visible. The width axis has the
+ * same floor, but it lives in `graph-geometry` beside the column minimums it
+ * is the sum of (`COMMIT_LIST_MIN_W`).
  */
-const COMMIT_LIST_MIN_W = 420;
 const COMMIT_LIST_MIN_H = 200;
 /** The diff beside the message inside the below-layout detail panel. */
 const DETAIL_DIFF_MIN_W = 320;
+
+/**
+ * One column caption in the header below. Clipped, and padded by the same
+ * `COL_PAD` the row's cells use, because the captions sit in the SAME tracks as
+ * those cells and those tracks shrink: an author column squeezed to its avatar
+ * is narrower than the word "AUTHOR", and two plain spans in a too-narrow grid
+ * do not truncate, they overlap — the narrow log read "SUBJECTAUTHOR" (see
+ * `SUBJECT_MIN_W`). Clipping alone still let "AUTHOR" run up against "DATE";
+ * the padding is what a caption truncates to clear, exactly as a long author
+ * name does one row below.
+ */
+const HEADER_LABEL: React.CSSProperties = {
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+  paddingRight: COL_PAD,
+};
 
 export function HistoryScreen() {
   const commits = useRepoStore((s) => s.commits);
@@ -861,11 +880,13 @@ export function HistoryScreen() {
             with SHA. The count of lanes that did not fit still belongs here,
             in text: the gutter is a decorative graphic, and Phase 3 (G8)
             marks it aria-hidden, so a fade alone would state this nowhere. */}
-        <span style={{ paddingLeft: 12 }}>{hiddenLanes > 0 ? `+${hiddenLanes}` : ""}</span>
-        <span>SHA</span>
-        <span>SUBJECT</span>
-        <span>AUTHOR</span>
-        <span>DATE</span>
+        <span style={{ ...HEADER_LABEL, paddingLeft: 12 }}>
+          {hiddenLanes > 0 ? `+${hiddenLanes}` : ""}
+        </span>
+        <span style={HEADER_LABEL}>SHA</span>
+        <span style={HEADER_LABEL}>SUBJECT</span>
+        <span style={HEADER_LABEL}>AUTHOR</span>
+        <span style={HEADER_LABEL}>DATE</span>
       </div>
       <FocusableScroll
         style={{ flex: 1 }}


### PR DESCRIPTION
Narrowing the History pane broke its columns: the subject vanished, the branch pills painted over the author, and the header read `SUBJECTAUTHOR`.

## Root cause

Every track in `commitRowGrid` but the subject was a rigid pixel width — `<graph>px 70px 1fr 150px <date>px` — so the subject's `1fr` was the only one that could yield, and it yielded everything. Measured in Chrome at 420px (`COMMIT_LIST_MIN_W`, the narrowest the commit list can be dragged), a five-lane row resolved to:

```
graph 88 | sha 70 | SUBJECT 22 | author 150 | date 90
```

22px of subject, against an author name holding its full 150. The subject cell's pills and HEAD badge do not shrink, and nothing clipped them, so they painted over the author column.

The same repro turned up two defects that were never about narrowness at all:

- a 19-character author name ran into the date at **any** pane width — that cell had neither a 0 minimum nor padding;
- the header captions had neither either, so even after clipping they read `AUTHORDATE`.

## What changed

The yield order now lives in the template: `minmax(SUBJECT_MIN_W, 1fr)` for the subject, `minmax(AUTHOR_MIN_W, AUTHOR_COL_W)` for the author. The name truncates, then disappears, and the avatar still says who — so what a narrow pane costs is the author's name rather than the one column anybody reads. Every cell clips, and one shared `COL_PAD` is the gutter a full-width value truncates to clear: subject cell, author cell, and every caption above them.

Reflog gets this for free, and needed it most — its list pane is 35% of the window, so its subject was under 100px below an ~1170px window and gone entirely below ~890px.

`COMMIT_LIST_MIN_W` moves next to the widths it is the sum of, so the arithmetic is checkable: a raised minimum (or a wider Date column) that no longer fits the narrowest pane now fails the build instead of silently pushing the date off the right edge.

## The trade, written down

No measurement: WebKitGTK has neither container queries nor `ResizeObserver`, so this is track sizing or nothing. The cost is that CSS grid fills a fixed-max track before an `fr` one, so between ~420 and ~560px the author column reaches 150 before the subject grows past its floor. Getting subject-first growth needs a measured width, not a cleverer template — that and the not-yet-width-aware graph gutter are recorded in `docs/dev/frontend.md` rather than worked around.

## Verification

- Real pixels at 330 / 430 / 560 / 900px via headless Chrome, before and after — the before-shot reproduces the report exactly.
- Ground truth on five candidate templates measured in Chrome before picking one; `fit-content()` was ruled out because it sizes each **row** to its own author and un-aligns the columns from each other and from the header.
- `pnpm test` 392 files / 3914 tests green; `pnpm tsc --noEmit` and `tsc -p e2e/tsconfig.json` clean.
- `pnpm test:e2e:docker full` — 32/32 spec files in 2:17, no retries.
- One new e2e assertion carries the thing only the real webview can answer: that WebKitGTK 605 parses the `minmax()` template at all. Had it rejected the value it would drop the whole property and lay every row out as a single auto track — invisible to jsdom, and Chrome cannot answer it for WebKitGTK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
