### PR TITLE
fix(settings): let settings and forge account rows follow UI density

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1484,6 +1484,13 @@ a result is the actual control, never a copy of it that could drift — see
   takes `gates: Record<SettingRowGate, boolean>` for this reason: widening
   `SettingRowGate` is a compile error until `useSettingsIndex` answers the new
   member, where a per-gate equality test would have made it silently "always".
+- **Both settings row helpers read `--row-step`, and they move together.**
+  `SettingsRow` and `ForgeSettings`' local `ForgeRow` are separate components
+  by design (one is a fixed setting with a `data-setting-id`, the other a row
+  over account data), but they sit in the same panel, so density has to reach
+  both or neither: giving it to one leaves a forge account row a different
+  height from the setting directly above it. The card HEADER keeps its fixed
+  padding, per the density rule's chrome exemption.
 - **`data-setting-id` is selected exactly, never with `*=`, in both specs and
   e2e.** These are dotted, two-part ids (`card.row`), and one is a genuine
   substring of another today — `commit.sign` is a literal prefix of

--- a/src/features/forge/ForgeSettings.test.tsx
+++ b/src/features/forge/ForgeSettings.test.tsx
@@ -219,6 +219,17 @@ describe("ForgeSettings — several accounts on one host (#233)", () => {
     ).toBeInTheDocument();
   });
 
+  // An account row is a list row in the same panel as its `SettingsRow`
+  // siblings, so it reads `--row-step` like they do. Fixed padding here left
+  // it a different height from every row above it once density changed.
+  it("sizes an account row with UI density", () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    render(<ForgeSettings />);
+    expect(
+      screen.getByTestId("forge-account-github.com-acc-work").style.padding,
+    ).toContain("var(--row-step)");
+  });
+
   it("marks which account the host actually uses", () => {
     useForgeStore.setState({ accounts: twoAccounts, detection: GH });
     render(<ForgeSettings />);

--- a/src/features/forge/ForgeSettings.tsx
+++ b/src/features/forge/ForgeSettings.tsx
@@ -429,7 +429,9 @@ function ForgeRow({
         display: "flex",
         alignItems: "flex-start",
         gap: 16,
-        padding: "12px 16px",
+        // Same density opt-in as `SettingsRow` (#70). These rows sit in the
+        // same panel as their siblings, so they have to scale with them.
+        padding: "calc(12px + var(--row-step) / 2) 16px",
         borderBottom: "1px solid var(--border-0)",
       }}
     >

--- a/src/features/settings/layout/SettingsCard.test.tsx
+++ b/src/features/settings/layout/SettingsCard.test.tsx
@@ -22,6 +22,23 @@ describe("SettingsCard / SettingsRow", () => {
     expect(screen.getByText("Layout")).toBeTruthy();
   });
 
+  // Every settings row is a list-row surface, so it opts into UI density
+  // (#70) rather than keeping one fixed height while the rest of the app
+  // scales. The card header is deliberately excluded: it is chrome.
+  it("sizes a row with UI density, and leaves the header fixed", () => {
+    render(
+      <SettingsCard id="diff" title="Diff">
+        <SettingsRow id="diff.layout" label="Layout" control={<span>ctl</span>} />
+      </SettingsCard>,
+    );
+    const row = document.querySelector<HTMLElement>('[data-setting-id="diff.layout"]');
+    expect(row?.style.padding).toContain("var(--row-step)");
+    const header = document.querySelector<HTMLElement>(
+      '[data-settings-card="diff"] > header',
+    );
+    expect(header?.style.padding).not.toContain("var(--row-step)");
+  });
+
   it("renders everything when no filter is active", () => {
     render(
       <SettingsFilterProvider visibleRowIds={null}>

--- a/src/features/settings/layout/SettingsCard.tsx
+++ b/src/features/settings/layout/SettingsCard.tsx
@@ -106,7 +106,9 @@ export function SettingsRow({
         flexDirection: stacked ? "column" : "row",
         alignItems: stacked ? "stretch" : "flex-start",
         gap: stacked ? 10 : 16,
-        padding: "12px 16px",
+        // A list-row surface, so it opts into UI density (#70). The card's
+        // header above stays fixed: that is chrome, not a row.
+        padding: "calc(12px + var(--row-step) / 2) 16px",
         borderBottom: "1px solid var(--border-0)",
       }}
     >


### PR DESCRIPTION
The second of the two items left open in #233, from your 2026-09-03 comment: the account rows and their `SettingsRow` siblings do not opt into `var(--row-step)`, and making only the forge rows density-aware would leave them a different height from their siblings in the same panel. Your conclusion was that it "belongs on both helpers at once, or neither". This does both at once.

## The problem

`SettingsRow` (`features/settings/layout/SettingsCard.tsx`) and `ForgeSettings`' local `ForgeRow` both carry `padding: "12px 16px"`. Neither reads `--row-step`, so the whole Settings screen keeps one fixed row height while every other list surface in the app scales with the UI density setting. The settings side menu beside them already scales: `PGSidebarRow` became density-aware in #415, on the reasoning recorded in `2026-09-04-settings-navigation-spec.md` that there was no reason to withhold density from settings once no other sidebar's geometry was at risk. The rows in the panel it navigates never followed.

## The change

Both helpers now use `padding: "calc(12px + var(--row-step) / 2) 16px"`, the padding-sized form of the density opt-in that `frontend.md` documents and that `PGRebaseRow` and friends already use. Two style lines.

`SettingsCard`'s header keeps its fixed padding on purpose: it is chrome, which the density rule exempts.

The two components stay separate, per the comment above `ForgeRow` explaining why an account row is not a `SettingsRow`. Only the geometry is shared, so the two cannot drift apart on height again without a test failing.

## Tests

- `SettingsCard.test.tsx`: a row's padding reads `var(--row-step)`, and the card header's does not, so the chrome exemption is pinned rather than left as a comment.
- `ForgeSettings.test.tsx`: an account row's padding reads `var(--row-step)`.

Both were confirmed failing before the fix by reverting only the two style lines and rerunning: `expected '12px 16px' to contain 'var(--row-step)'`, twice, with the other 23 tests in those files still passing.

## Checks

- `pnpm vitest run`: 394 files / 3928 tests, all passing
- `pnpm tsc --noEmit`: clean
- `pnpm vite build`: clean
- `cargo check --manifest-path src-tauri/Cargo.toml`: clean
- `cargo test --manifest-path src-tauri/Cargo.toml`: 384 lib tests pass. 3 tests in `tests/amend_message.rs` fail here (`a_commit_msg_hook_can_refuse_the_reword`, `a_commit_msg_hook_can_rewrite_the_message`, `a_head_move_during_the_hook_window_is_refused`). No Rust is touched by this PR, and they fail because this sandbox does not let the test's `commit-msg` hook script take effect. Flagging them in case they are news to you.

`docs/dev/frontend.md` gains a bullet under the Settings section recording that the two row helpers move together and why the header does not.

No e2e run. This changes row padding only, and the e2e specs select rows by `data-setting-id` rather than by geometry.

No closing keyword on purpose: #233 stays open for the first item in that comment, a saved identity referencing a forge account.
