### PR TITLE
fix(deps): close the extract-zip advisory by pruning it from the tree

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -349,11 +349,39 @@ Two entries have a story worth recording so they are not re-litigated:
   matching override key** in `test/depOverrides.test.ts`, so a `vite` pin or
   downgrade that re-introduces 0.27.x fails the build instead of silently
   re-opening GHSA-g7r4-m6w7-qqqr.
-- **`extract-zip` has no patched version at all**, and is dismissed as
-  tolerable risk. It arrives via `@puppeteer/browsers` ← `@wdio/utils` — a
-  Chrome/Edge downloader this repo never invokes, because `e2e/wdio.conf.ts`
-  sets `browserName: "tauri"`. Pruning that subtree would take `ip-address`
-  with it; worth measuring, not yet done.
+- **`extract-zip` has no patched version at all**, so it is the one entry fixed
+  by **deletion rather than by a floor** (Dependabot alert 66 — an alert
+  number, not an issue; `#66` is an unrelated PR). 2.0.1 is the latest release,
+  from 2023, and the upstream fix (PR 160) was never published — there is no
+  number to bump or floor to. It arrived via `@puppeteer/browsers` ←
+  `@wdio/utils`, a Chrome/Edge downloader this repo never invokes because
+  `e2e/wdio.conf.ts` sets `browserName: "tauri"`, which is why it sat open as
+  tolerated risk for a while. `@puppeteer/browsers` **3.x dropped the
+  dependency outright**, so `pnpm.overrides` forces that major across
+  `@wdio/utils`'s own `^2.2.0` request and the whole subtree leaves the
+  lockfile. Measured: `pnpm audit` goes from 4 advisories to 2, both remaining
+  ones (`deepmerge-ts`, `smol-toml`) pre-existing and untouched.
+
+  Three things about that override are load-bearing:
+
+  - It is guarded by **absence**, not by a floor —
+    `test/depOverrides.test.ts`'s third `describe` asserts `extract-zip`
+    resolves nowhere. A floor entry would be worse than nothing here: floors
+    are keyed by major, so a dropped override letting 2.13.2 back in would
+    pass a 3.x floor *vacuously* and re-open the advisory in silence.
+  - Pruning took **`ip-address` out with it** (via `proxy-agent`), along with
+    `socks`, the `pac-*` chain, `progress`, `get-stream` and `yauzl`'s old
+    route in. Its override key and floor entry are deliberately **kept**: they
+    cost nothing while the package is absent and are what catches it arriving
+    by another route. Same for the `ip-address` floor now passing vacuously —
+    that is annotated in the test, not silently tolerated.
+  - 3.x is **ESM-only** and wants **Node >= 22.12.0**, and it demotes
+    `proxy-agent` and `yauzl` to *optional* peers. All fine here, and each was
+    checked rather than assumed: the sole consumer (`@wdio/utils`) imports it
+    as ESM with no CJS `require` anywhere in the tree, CI and `Dockerfile.e2e`
+    both track latest Node 22.x, `yauzl` still resolves for the optional peer,
+    and `proxy-agent` going uninstalled only removes proxy support from the
+    downloader this repo never calls.
 
 **The trap:** a Dependabot npm PR regenerates the lockfile and drops the whole
 `pnpm.overrides` block. Restore it before merging any such PR, or the merge
@@ -367,8 +395,8 @@ trace back to an override or to one of its own dependencies — anything else is
 opportunistic drift that does not belong in a security commit.
 
 And because these packages ARE the e2e runner (`ws`, `undici`,
-`serialize-javascript`, `js-yaml`, `fast-xml-parser`), a change here is not
-proven by `pnpm test`. It needs a real Docker e2e run.
+`serialize-javascript`, `js-yaml`, `fast-xml-parser`, `@puppeteer/browsers`), a
+change here is not proven by `pnpm test`. It needs a real Docker e2e run.
 
 ## `test/` at the repo root — doc invariants (#147, #150)
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "overrides": {
       "@wdio/native-utils": "2.5.0",
       "@babel/core": "^7.29.6",
+      "@puppeteer/browsers": "^3.2.2",
       "brace-expansion@1": "^1.1.16",
       "brace-expansion@2": "^2.1.2",
       "browserslist": "^4.28.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@wdio/native-utils': 2.5.0
   '@babel/core': ^7.29.6
+  '@puppeteer/browsers': ^3.2.2
   brace-expansion@1: ^1.1.16
   brace-expansion@2: ^2.1.2
   browserslist: ^4.28.7
@@ -110,19 +111,19 @@ importers:
         version: 5.2.0(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.13)(yaml@2.9.0))
       '@wdio/cli':
         specifier: ^9.31.4
-        version: 9.31.5(@types/node@22.20.0)(expect-webdriverio@6.0.9)
+        version: 9.31.5(@types/node@22.20.0)(expect-webdriverio@6.0.9)(yauzl@2.10.0)
       '@wdio/globals':
         specifier: ^9.31.3
-        version: 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+        version: 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))
       '@wdio/local-runner':
         specifier: ^9.31.4
-        version: 9.31.5(@wdio/globals@9.31.3)(webdriverio@9.31.5)
+        version: 9.31.5(@wdio/globals@9.31.3)(webdriverio@9.31.5(yauzl@2.10.0))(yauzl@2.10.0)
       '@wdio/mocha-framework':
         specifier: ^9.31.2
-        version: 9.31.5
+        version: 9.31.5(yauzl@2.10.0)
       '@wdio/tauri-service':
         specifier: ^1.3.0
-        version: 1.3.0(expect-webdriverio@6.0.9)(tsx@4.23.13)(webdriverio@9.31.5)
+        version: 1.3.0(expect-webdriverio@6.0.9)(tsx@4.23.13)(webdriverio@9.31.5(yauzl@2.10.0))
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -683,10 +684,18 @@ packages:
   '@promptbook/utils@0.69.5':
     resolution: {integrity: sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==}
 
-  '@puppeteer/browsers@2.13.2':
-    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
-    engines: {node: '>=18'}
+  '@puppeteer/browsers@3.2.2':
+    resolution: {integrity: sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+      yauzl: ^2.10.0 || ^3.4.0
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
+      yauzl:
+        optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -1078,9 +1087,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1160,9 +1166,6 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1512,10 +1515,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
@@ -1582,10 +1581,6 @@ packages:
     resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   bidi-js@1.1.0:
     resolution: {integrity: sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==}
@@ -1686,6 +1681,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -1765,10 +1764,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1803,10 +1798,6 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
-
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1873,6 +1864,9 @@ packages:
   electron-to-chromium@1.5.420:
     resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1881,9 +1875,6 @@ packages:
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -1928,26 +1919,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -1983,11 +1956,6 @@ packages:
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
 
   fast-deep-equal@2.0.1:
     resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
@@ -2066,21 +2034,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-port@7.2.0:
     resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
     engines: {node: '>=16'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2185,10 +2149,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  ip-address@10.7.0:
-    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
-    engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -2457,10 +2417,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
   lucide-react@1.41.0:
     resolution: {integrity: sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==}
     peerDependencies:
@@ -2525,6 +2481,10 @@ packages:
     resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
     engines: {node: '>=18.0.0'}
 
+  modern-tar@0.8.5:
+    resolution: {integrity: sha512-snEhs+6G5Tjd4I7tLCDOaoln2RgE0bD19RzEKgvgK2hZ5VKy3MpLhLTZ2fWpXSTg4K2cyPwp+VHATFJhxfnOeA==}
+    engines: {node: '>=18.0.0'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2536,10 +2496,6 @@ packages:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
 
   node-diff3@3.2.1:
     resolution: {integrity: sha512-eKZcJ8RtMQ3cIaA15EgmtwG927fYnRlhtdA4Q9HAcCpAZPQhhU2XptnTH9GeAkMiX2bAXxlJSAFa9shFbztPgw==}
@@ -2599,14 +2555,6 @@ packages:
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2701,22 +2649,8 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
-
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2887,28 +2821,12 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
@@ -2957,6 +2875,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -3010,9 +2936,6 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
-
-  tar-fs@3.1.3:
-    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
@@ -3312,6 +3235,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3362,6 +3289,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -3373,6 +3304,10 @@ packages:
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -3904,20 +3839,12 @@ snapshots:
     dependencies:
       spacetrim: 0.11.59
 
-  '@puppeteer/browsers@2.13.2':
+  '@puppeteer/browsers@3.2.2(yauzl@2.10.0)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      extract-zip: 2.0.1
-      progress: 2.0.3
-      proxy-agent: 6.5.0
-      semver: 7.8.5
-      tar-fs: 3.1.3
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
+      modern-tar: 0.8.5
+      yargs: 18.1.0
+    optionalDependencies:
+      yauzl: 2.10.0
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -4223,8 +4150,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -4312,11 +4237,6 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 22.20.0
-    optional: true
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -4443,15 +4363,15 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@wdio/cli@9.31.5(@types/node@22.20.0)(expect-webdriverio@6.0.9)':
+  '@wdio/cli@9.31.5(@types/node@22.20.0)(expect-webdriverio@6.0.9)(yauzl@2.10.0)':
     dependencies:
       '@vitest/snapshot': 2.1.9
-      '@wdio/config': 9.31.5
-      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+      '@wdio/config': 9.31.5(yauzl@2.10.0)
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))
       '@wdio/logger': 9.29.1
       '@wdio/protocols': 9.31.5
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       async-exit-hook: 2.0.1
       chalk: 5.6.2
       chokidar: 4.0.3
@@ -4463,7 +4383,7 @@ snapshots:
       lodash.union: 4.6.0
       read-pkg-up: 10.1.0
       tsx: 4.23.13
-      webdriverio: 9.31.5
+      webdriverio: 9.31.5(yauzl@2.10.0)
       yargs: 17.7.3
     transitivePeerDependencies:
       - '@types/node'
@@ -4471,25 +4391,26 @@ snapshots:
       - bare-buffer
       - bufferutil
       - expect-webdriverio
+      - proxy-agent
       - puppeteer-core
       - react-native-b4a
       - supports-color
       - utf-8-validate
+      - yauzl
 
-  '@wdio/config@9.31.5':
+  '@wdio/config@9.31.5(yauzl@2.10.0)':
     dependencies:
       '@wdio/logger': 9.29.1
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       deepmerge-ts: 7.1.5
       glob: 10.5.0
       import-meta-resolve: 4.2.0
       jiti: 2.6.1
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
+      - proxy-agent
       - supports-color
+      - yauzl
 
   '@wdio/dot-reporter@9.31.2':
     dependencies:
@@ -4497,37 +4418,36 @@ snapshots:
       '@wdio/types': 9.31.2
       chalk: 5.6.2
 
-  '@wdio/globals@9.29.1(expect-webdriverio@6.0.9)(webdriverio@9.31.5)':
+  '@wdio/globals@9.29.1(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))':
     dependencies:
-      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5)
-      webdriverio: 9.31.5
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5(yauzl@2.10.0))
+      webdriverio: 9.31.5(yauzl@2.10.0)
 
-  '@wdio/globals@9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5)':
+  '@wdio/globals@9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))':
     dependencies:
-      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5)
-      webdriverio: 9.31.5
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5(yauzl@2.10.0))
+      webdriverio: 9.31.5(yauzl@2.10.0)
 
-  '@wdio/local-runner@9.31.5(@wdio/globals@9.31.3)(webdriverio@9.31.5)':
+  '@wdio/local-runner@9.31.5(@wdio/globals@9.31.3)(webdriverio@9.31.5(yauzl@2.10.0))(yauzl@2.10.0)':
     dependencies:
       '@types/node': 20.19.43
       '@wdio/logger': 9.29.1
       '@wdio/repl': 9.16.2
-      '@wdio/runner': 9.31.5(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+      '@wdio/runner': 9.31.5(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))(yauzl@2.10.0)
       '@wdio/types': 9.31.2
       '@wdio/xvfb': 9.31.2
       exit-hook: 4.0.0
-      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5)
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5(yauzl@2.10.0))
       split2: 4.2.0
       stream-buffers: 3.0.3
     transitivePeerDependencies:
       - '@wdio/globals'
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
-      - react-native-b4a
+      - proxy-agent
       - supports-color
       - utf-8-validate
       - webdriverio
+      - yauzl
 
   '@wdio/logger@9.18.0':
     dependencies:
@@ -4545,19 +4465,18 @@ snapshots:
       safe-regex2: 5.1.1
       strip-ansi: 7.2.0
 
-  '@wdio/mocha-framework@9.31.5':
+  '@wdio/mocha-framework@9.31.5(yauzl@2.10.0)':
     dependencies:
       '@types/mocha': 10.0.10
       '@types/node': 20.19.43
       '@wdio/logger': 9.29.1
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       mocha: 10.8.2
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
+      - proxy-agent
       - supports-color
+      - yauzl
 
   '@wdio/native-core@1.1.0(tsx@4.23.13)':
     dependencies:
@@ -4613,26 +4532,25 @@ snapshots:
       diff: 8.0.4
       object-inspect: 1.13.4
 
-  '@wdio/runner@9.31.5(expect-webdriverio@6.0.9)(webdriverio@9.31.5)':
+  '@wdio/runner@9.31.5(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))(yauzl@2.10.0)':
     dependencies:
       '@types/node': 20.19.43
-      '@wdio/config': 9.31.5
+      '@wdio/config': 9.31.5(yauzl@2.10.0)
       '@wdio/dot-reporter': 9.31.2
-      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))
       '@wdio/logger': 9.29.1
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       deepmerge-ts: 7.1.5
-      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5)
-      webdriver: 9.31.5
-      webdriverio: 9.31.5
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5(yauzl@2.10.0))
+      webdriver: 9.31.5(yauzl@2.10.0)
+      webdriverio: 9.31.5(yauzl@2.10.0)
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
-      - react-native-b4a
+      - proxy-agent
       - supports-color
       - utf-8-validate
+      - yauzl
 
   '@wdio/spec-reporter@9.29.1':
     dependencies:
@@ -4642,9 +4560,9 @@ snapshots:
       easy-table: 1.2.0
       pretty-ms: 9.3.0
 
-  '@wdio/tauri-service@1.3.0(expect-webdriverio@6.0.9)(tsx@4.23.13)(webdriverio@9.31.5)':
+  '@wdio/tauri-service@1.3.0(expect-webdriverio@6.0.9)(tsx@4.23.13)(webdriverio@9.31.5(yauzl@2.10.0))':
     dependencies:
-      '@wdio/globals': 9.29.1(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+      '@wdio/globals': 9.29.1(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))
       '@wdio/logger': 9.29.1
       '@wdio/native-core': 1.1.0(tsx@4.23.13)
       '@wdio/native-spy': 1.2.0
@@ -4655,7 +4573,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       get-port: 7.2.0
       tslib: 2.8.1
-      webdriverio: 9.31.5
+      webdriverio: 9.31.5(yauzl@2.10.0)
     transitivePeerDependencies:
       - expect-webdriverio
       - supports-color
@@ -4669,9 +4587,9 @@ snapshots:
     dependencies:
       '@types/node': 20.19.43
 
-  '@wdio/utils@9.31.5':
+  '@wdio/utils@9.31.5(yauzl@2.10.0)':
     dependencies:
-      '@puppeteer/browsers': 2.13.2
+      '@puppeteer/browsers': 3.2.2(yauzl@2.10.0)
       '@wdio/logger': 9.29.1
       '@wdio/types': 9.31.2
       decamelize: 6.0.1
@@ -4686,10 +4604,9 @@ snapshots:
       split2: 4.2.0
       wait-port: 1.1.0
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
+      - proxy-agent
       - supports-color
+      - yauzl
 
   '@wdio/xvfb@9.31.2':
     dependencies:
@@ -4760,10 +4677,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
   async-exit-hook@2.0.1: {}
 
   async@3.2.6: {}
@@ -4809,8 +4722,6 @@ snapshots:
 
   baseline-browser-mapping@2.11.20: {}
 
-  basic-ftp@5.3.1: {}
-
   bidi-js@1.1.0:
     dependencies:
       require-from-string: 2.0.2
@@ -4842,7 +4753,8 @@ snapshots:
       node-releases: 2.0.54
       update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
-  buffer-crc32@0.2.13: {}
+  buffer-crc32@0.2.13:
+    optional: true
 
   buffer-crc32@1.0.0: {}
 
@@ -4926,6 +4838,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clone@1.0.4:
     optional: true
@@ -5012,8 +4930,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-uri-to-buffer@6.0.2: {}
-
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -5041,12 +4957,6 @@ snapshots:
     dependencies:
       clone: 1.0.4
     optional: true
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   dequal@2.0.3: {}
 
@@ -5116,6 +5026,8 @@ snapshots:
 
   electron-to-chromium@1.5.420: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -5124,10 +5036,6 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -5183,23 +5091,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
-  esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
-
-  esutils@2.0.3: {}
 
   event-target-shim@5.0.1: {}
 
@@ -5230,15 +5124,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expect-webdriverio@6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5):
+  expect-webdriverio@6.0.9(@wdio/globals@9.31.3)(@wdio/logger@9.29.1)(webdriverio@9.31.5(yauzl@2.10.0)):
     dependencies:
       '@vitest/snapshot': 4.1.11
-      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5)
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9)(webdriverio@9.31.5(yauzl@2.10.0))
       '@wdio/logger': 9.29.1
       deep-eql: 5.0.2
       expect: 30.4.1
       jest-matcher-utils: 30.4.1
-      webdriverio: 9.31.5
+      webdriverio: 9.31.5(yauzl@2.10.0)
 
   expect@30.4.1:
     dependencies:
@@ -5248,16 +5142,6 @@ snapshots:
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@2.0.1: {}
 
@@ -5280,6 +5164,7 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+    optional: true
 
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
@@ -5336,24 +5221,14 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-port@7.2.0: {}
+  get-east-asian-width@1.6.0: {}
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
+  get-port@7.2.0: {}
 
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  get-uri@6.0.5:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   glob-parent@5.1.2:
     dependencies:
@@ -5477,8 +5352,6 @@ snapshots:
       rxjs: 7.8.2
     optionalDependencies:
       '@types/node': 22.20.0
-
-  ip-address@10.7.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -5725,8 +5598,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@7.18.3: {}
-
   lucide-react@1.41.0(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -5811,13 +5682,13 @@ snapshots:
 
   modern-tar@0.7.6: {}
 
+  modern-tar@0.8.5: {}
+
   ms@2.1.3: {}
 
   mute-stream@2.0.0: {}
 
   nanoid@3.3.18: {}
-
-  netmask@2.1.1: {}
 
   node-diff3@3.2.1: {}
 
@@ -5878,24 +5749,6 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
-  pac-proxy-agent@7.2.0:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
-
   package-json-from-dist@1.0.1: {}
 
   pako@1.0.11: {}
@@ -5946,7 +5799,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pend@1.2.0: {}
+  pend@1.2.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -5981,29 +5835,7 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress@2.0.3: {}
-
   property-information@7.2.0: {}
-
-  proxy-agent@6.5.0:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -6187,27 +6019,9 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smart-buffer@4.2.0: {}
-
   smol-toml@1.7.0: {}
 
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.7.0
-      smart-buffer: 4.2.0
-
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1:
-    optional: true
 
   space-separated-tokens@2.0.2: {}
 
@@ -6260,6 +6074,17 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -6308,18 +6133,6 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
-
-  tar-fs@3.1.3:
-    dependencies:
-      pump: 3.0.4
-      tar-stream: 3.2.0
-    optionalDependencies:
-      bare-fs: 4.7.2
-      bare-path: 3.0.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
 
   tar-stream@3.2.0:
     dependencies:
@@ -6538,37 +6351,36 @@ snapshots:
       defaults: 1.0.4
     optional: true
 
-  webdriver@9.31.5:
+  webdriver@9.31.5(yauzl@2.10.0):
     dependencies:
       '@types/node': 20.19.43
       '@types/ws': 8.18.1
-      '@wdio/config': 9.31.5
+      '@wdio/config': 9.31.5(yauzl@2.10.0)
       '@wdio/logger': 9.29.1
       '@wdio/protocols': 9.31.5
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
       undici: 6.28.0
       ws: 8.21.3
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
-      - react-native-b4a
+      - proxy-agent
       - supports-color
       - utf-8-validate
+      - yauzl
 
-  webdriverio@9.31.5:
+  webdriverio@9.31.5(yauzl@2.10.0):
     dependencies:
       '@types/node': 20.19.43
       '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.31.5
+      '@wdio/config': 9.31.5(yauzl@2.10.0)
       '@wdio/logger': 9.29.1
       '@wdio/protocols': 9.31.5
       '@wdio/repl': 9.16.2
       '@wdio/types': 9.31.2
-      '@wdio/utils': 9.31.5
+      '@wdio/utils': 9.31.5(yauzl@2.10.0)
       archiver: 7.0.1
       aria-query: 5.3.2
       cheerio: 1.2.0
@@ -6585,14 +6397,16 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
-      webdriver: 9.31.5
+      webdriver: 9.31.5(yauzl@2.10.0)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - bufferutil
+      - proxy-agent
       - react-native-b4a
       - supports-color
       - utf-8-validate
+      - yauzl
 
   webidl-conversions@8.0.1: {}
 
@@ -6653,6 +6467,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
@@ -6674,6 +6494,8 @@ snapshots:
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs-unparser@2.0.0:
     dependencies:
@@ -6702,10 +6524,20 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
   yauzl@2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/test/depOverrides.test.ts
+++ b/test/depOverrides.test.ts
@@ -13,20 +13,32 @@
 // with no test failing and nothing in the diff that looks like a security
 // change. That is the exact failure this file exists to make loud.
 //
-// It guards two things, because the block surviving is not the same as the fix
-// surviving:
+// It guards three things, because the block surviving is not the same as the
+// fix surviving:
 //
-//   1. every security override key is still present in `package.json`, and
+//   1. every security override key is still present in `package.json`,
 //   2. no version actually resolved in `pnpm-lock.yaml` is below the advisory's
 //      first patched version — which also catches a block that was kept but a
-//      lockfile that was never regenerated against it.
+//      lockfile that was never regenerated against it, and
+//   3. `extract-zip` resolves NOWHERE in the lockfile, which is the one fix
+//      here that a floor cannot express (see below).
 //
 // If this test fails, do NOT delete the entry to make it pass. Restore the
 // block (`git show origin/main:package.json`), re-run `pnpm install`, and check
-// the lockfile diff. The reasoning behind each entry, and the one advisory
-// deliberately left open (`extract-zip`, which has no patched version at all),
-// are in `docs/dev/testing.md`; the one shipped advisory we cannot fix
-// (`glib`) is in `docs/dev/distribution.md`.
+// the lockfile diff. The reasoning behind each entry is in
+// `docs/dev/testing.md`; the one shipped advisory we cannot fix (`glib`) is in
+// `docs/dev/distribution.md`.
+//
+// One entry is guarded by ABSENCE rather than by a floor, because a floor
+// cannot express it: `extract-zip` is unmaintained and has **no patched
+// version at all** (latest is 2.0.1, from 2023), so there is no number to sit
+// above. GHSA-7pqw-9j4j-h8q3 is fixed here by deleting the package from the
+// tree instead — `@puppeteer/browsers` 3.x dropped the dependency, so the
+// override forces that major and the whole subtree leaves. That is why the
+// third `describe` below asserts `extract-zip` resolves NOWHERE. A floor entry
+// would have been worse than nothing: it is keyed by major, so a dropped
+// override that let 2.13.2 back in would pass a `@puppeteer/browsers` 3.x
+// floor vacuously and re-open the advisory in silence.
 //
 // One entry in `FLOORS` has NO matching override key, on purpose: `esbuild`.
 // `vite` 7.3.6 widened its range to `^0.27.0 || ^0.28.0`, which deduped the
@@ -70,6 +82,11 @@ const FLOORS: Array<{
   { name: "esbuild", major: 0, min: "0.28.1", why: "GHSA-g7r4-m6w7-qqqr — dev-server arbitrary file read; deduped out by vite >= 7.3.6, not by an override" },
   { name: "fast-xml-parser", major: 5, min: "5.10.1", why: "GHSA-8r6m-32jq-jx6q — DOCTYPE resets entity expansion limits" },
   { name: "form-data", major: 4, min: "4.0.6", why: "GHSA-hmw2-7cc7-3qxx — CRLF injection in multipart field names" },
+  // Currently resolves NOWHERE, so this floor passes vacuously: `ip-address`
+  // reached the tree through `proxy-agent` <- `@puppeteer/browsers` 2.x, and
+  // the @puppeteer/browsers override took that subtree out. Kept anyway: the
+  // override key and this floor cost nothing while the package is absent, and
+  // they are what catches it arriving again by some other route.
   { name: "ip-address", major: 10, min: "10.3.1", why: "GHSA-mwp4-54f8-5fhr — leading-zero octets decoded as decimal, SSRF bypass" },
   { name: "js-yaml", major: 4, min: "4.3.1", why: "GHSA-5p4m-2wfm-xmqj — quadratic CPU in !!omap resolution" },
   { name: "serialize-javascript", major: 7, min: "7.0.5", why: "GHSA-5c6j-r48x-rmvq + GHSA-qj8w-gfj5-8c6v — RCE and CPU-exhaustion DoS" },
@@ -86,6 +103,10 @@ const FLOORS: Array<{
  *  — so the selector is not cosmetic and the key shape is part of the fix. */
 const REQUIRED_KEYS = [
   "@babel/core",
+  // Not a floor entry — see the absence guard below. This key is what forces
+  // `@puppeteer/browsers` across a major (`@wdio/utils` asks for `^2.2.0`),
+  // which is the only way `extract-zip` leaves the tree.
+  "@puppeteer/browsers",
   "brace-expansion@1",
   "brace-expansion@2",
   "browserslist",
@@ -152,25 +173,28 @@ describe("the pnpm.overrides security block survives (#346)", () => {
   });
 });
 
+const lock = read("pnpm-lock.yaml");
+
+/** Every version of `name` that the lockfile actually resolves. Reads the
+ *  `packages:`/`snapshots:` keys, which are the resolved versions — not the
+ *  requested ranges, which is what makes this an assertion about what gets
+ *  installed rather than about what someone asked for.
+ *
+ *  The full `major.minor.patch` shape is required, not a bare leading digit:
+ *  the lockfile also records the override table itself, where our own
+ *  `undici@6` / `brace-expansion@1` SELECTOR keys sit at the same
+ *  indentation. A looser pattern reads those selectors as versions and the
+ *  floor check then fails against "6".
+ *
+ *  Module scope on purpose: the floor check and the `extract-zip` absence
+ *  check below both need it, and two copies of this regex would drift. */
+function resolved(name: string): string[] {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^ {2}'?${escaped}@(\\d+\\.\\d+\\.\\d+[^:'(]*)`, "gm");
+  return [...lock.matchAll(re)].map((m) => m[1].trim());
+}
+
 describe("no resolved version sits below its advisory floor (#346)", () => {
-  const lock = read("pnpm-lock.yaml");
-
-  /** Every version of `name` that the lockfile actually resolves. Reads the
-   *  `packages:`/`snapshots:` keys, which are the resolved versions — not the
-   *  requested ranges, which is what makes this an assertion about what gets
-   *  installed rather than about what someone asked for.
-   *
-   *  The full `major.minor.patch` shape is required, not a bare leading digit:
-   *  the lockfile also records the override table itself, where our own
-   *  `undici@6` / `brace-expansion@1` SELECTOR keys sit at the same
-   *  indentation. A looser pattern reads those selectors as versions and the
-   *  floor check then fails against "6". */
-  function resolved(name: string): string[] {
-    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const re = new RegExp(`^ {2}'?${escaped}@(\\d+\\.\\d+\\.\\d+[^:'(]*)`, "gm");
-    return [...lock.matchAll(re)].map((m) => m[1].trim());
-  }
-
   it("finds the lockfile it is meant to be reading", () => {
     // Cheap canary: if the lockfile format changes shape, `resolved()` starts
     // returning [] for everything and every assertion below passes vacuously.
@@ -195,4 +219,49 @@ describe("no resolved version sits below its advisory floor (#346)", () => {
       ).toEqual([]);
     });
   }
+});
+
+describe("the extract-zip subtree stays pruned (#346)", () => {
+  // GHSA-7pqw-9j4j-h8q3 (high, CWE-22: an archive entry that is a symlink out
+  // of the destination, followed by a regular file of the same name, writes
+  // through the planted symlink) plus GHSA-jmr9-qjv8-65gv. `extract-zip` is
+  // unmaintained — 2.0.1 is the latest and the fix upstream (PR 160) was never
+  // released — so there is no version to bump or floor to. It arrived via
+  // `@puppeteer/browsers` <- `@wdio/utils`: a Chrome/Edge downloader this repo
+  // never invokes, because `e2e/wdio.conf.ts` sets `browserName: "tauri"`.
+  //
+  // `@puppeteer/browsers` 3.x dropped `extract-zip` outright, so the override
+  // deletes the package instead of patching it. Absence is the only assertable
+  // form of this fix, and it is strictly stronger than a floor: it fails for
+  // ANY route back into the tree, not just the one we know about.
+
+  it("resolves no extract-zip at all", () => {
+    expect(
+      resolved("extract-zip"),
+      `extract-zip is back in the lockfile. It has NO patched version, so ` +
+        `there is nothing to bump to — the fix is that it is absent. Either ` +
+        `pnpm.overrides["@puppeteer/browsers"] was dropped (restore it from ` +
+        `origin/main and re-run pnpm install), or something new pulls ` +
+        `extract-zip in and needs its own override. See docs/dev/testing.md.`,
+    ).toEqual([]);
+  });
+
+  it("resolves @puppeteer/browsers on 3.x or later", () => {
+    // The mechanism behind the assertion above, checked separately so a
+    // dropped override reads as "the override is gone" rather than leaving the
+    // absence failure to be diagnosed from scratch. `@wdio/utils` asks for
+    // `^2.2.0`, so without the override pnpm resolves 2.x and extract-zip
+    // returns.
+    const versions = resolved("@puppeteer/browsers");
+
+    expect(versions.length, "no @puppeteer/browsers in the lockfile at all — if the e2e runner no longer depends on it, delete this describe block and the override key.").toBeGreaterThan(0);
+
+    const stragglers = versions.filter((v) => Number.parseInt(v.split(".")[0], 10) < 3);
+    expect(
+      stragglers,
+      `@puppeteer/browsers@${stragglers.join(", ")} is below 3.x, which is ` +
+        `the major that dropped extract-zip. Restore ` +
+        `pnpm.overrides["@puppeteer/browsers"] and re-run pnpm install.`,
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes Dependabot **alert 66** — GHSA-7pqw-9j4j-h8q3 (high, CWE-22): `extract-zip` writes through a planted symlink, giving an arbitrary file write outside the destination.

> Heads up on the number: `66` is a Dependabot **alert** number, which is a different namespace from issues/PRs. `#66` is an unrelated closed PR, so nothing here references it. Part of the standing triage in #346.

## Why this one needed a different shape of fix

`extract-zip` has **no patched version**. 2.0.1 is the latest release, from 2023; the upstream fix ([PR 160](https://github.com/max-mapper/extract-zip/pull/160)) was never published, and Dependabot reports `first_patched_version: null`. There is no number to bump to and nothing to add to the `FLOORS` table, which is why `docs/dev/testing.md` had it recorded as tolerated risk with a standing lead: *"Pruning that subtree would take `ip-address` with it; worth measuring, not yet done."*

This measures it and does it. The package arrived as `@wdio/utils` → `@puppeteer/browsers@2.13.2` → `extract-zip` — a Chrome/Edge downloader this repo never invokes, since `e2e/wdio.conf.ts` sets `browserName: "tauri"`. **`@puppeteer/browsers` 3.x dropped the dependency outright**, so one `pnpm.overrides` entry forces that major across `@wdio/utils`'s own `^2.2.0` request and the whole subtree leaves the lockfile. Bumping wdio would not have worked: the latest 9.31.7 still asks for `^2.2.0`.

## Measured

`pnpm audit`, before → after: **4 advisories → 2**.

- Gone: both `extract-zip` advisories (GHSA-7pqw-9j4j-h8q3, GHSA-jmr9-qjv8-65gv).
- Remaining: `deepmerge-ts` (alert 35, already `auto_dismissed`) and `smol-toml` (no Dependabot alert) — both pre-existing, both reached through packages this PR does not touch, and neither is an open alert.
- No new advisory arrives with the 3.x subtree.

Net lockfile change is −167 lines. Pruning also removes `proxy-agent`, `ip-address`, `socks`, the `pac-*` chain, `progress` and `get-stream`. The `ip-address` override key and floor entry are **kept on purpose** — they cost nothing while the package is absent and are what catches it arriving by another route — and the floor is annotated as vacuous rather than left to look like an active check.

After this, the only open Dependabot alert left on the repo is #60 (`glib`), documented as unfixable in `docs/dev/distribution.md`.

## The 3.x major, checked rather than assumed

| Change in 3.x | Why it is safe here |
| --- | --- |
| ESM-only | The sole consumer (`@wdio/utils`) imports it as ESM; no CJS `require` of it anywhere in the tree. |
| Needs Node >= 22.12.0 | CI (`node-version: 22`) and `Dockerfile.e2e` (`setup_22.x`) both track latest 22.x. |
| `proxy-agent` → optional peer | Now uninstalled; only removes proxy support from the downloader this repo never calls. |
| `yauzl` → optional peer | Still resolves, with its own deps intact. |
| API surface | All seven names `@wdio/utils` imports (`install`, `canDownload`, `resolveBuildId`, `detectBrowserPlatform`, `Browser`, `ChromeReleaseChannel`, `computeExecutablePath`) plus the `InstallOptions` type are still exported, with identical signatures; `InstallOptions` is a strict superset of 2.x's. Both enums are byte-identical. |

## Guarded by absence, not by a floor

`test/depOverrides.test.ts` gains a third `describe` asserting `extract-zip` resolves **nowhere**, because a floor cannot express a fix that has no patched version. A floor entry would have been worse than nothing here: floors are keyed by major, so a dropped override letting 2.13.2 back in would pass a `@puppeteer/browsers` 3.x floor *vacuously* and re-open the advisory in silence.

The guard was proven by planting the violation — override deleted, `pnpm install` re-run, `extract-zip` back in the lockfile — and all three assertions failed with actionable messages before being restored:

```
× still overrides @puppeteer/browsers
× resolves no extract-zip at all              expected [ '2.0.1', '2.0.1' ] to deeply equal []
× resolves @puppeteer/browsers on 3.x or later expected [ '2.13.2', '2.13.2' ] to deeply equal []
```

The shared `resolved()` helper moved to module scope so the floor check and the absence check read the same lockfile regex instead of drifting apart.

## Verification

- `pnpm test` — 394 files, 3929 tests, all passing.
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — both clean. The e2e typecheck is the one that exercises `@wdio/utils`'s `InstallOptions` import against the new major.
- Docker e2e — snapshot rebuilt from this lockfile, then `smoke.e2e.ts` + `harness.e2e.ts`: **2 spec files, 10 tests passing** on WebKitGTK/linux. `docs/dev/testing.md` requires a real e2e run for any change to this block, since these packages *are* the e2e runner, and booting the wdio runner is exactly what exercises `@puppeteer/browsers`. Both `tests.yml` and `e2e.yml` path filters match `pnpm-lock.yaml`, so CI runs the full e2e suite here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
