### PR TITLE
feat(settings): a real colour picker for the theme editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,9 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   from `@/design`; every one of them reads a dismissal as "no answer", never as a
   choice. (`docs/dev/frontend.md`)
 - **No native `<select>`/`<option>` in shipped `src/`** — `PGSelect`; a guard
-  test enforces it. (`docs/dev/frontend.md`)
+  test enforces it. Same for `<input type="color">` — `PGColorSwatch`, whose
+  HSV state, held channel values and revert-on-dismiss are each a bug the
+  obvious version ships. (`docs/dev/frontend.md`)
 - **Design system lives in `src/design/`**, imported from `@/design`. Do NOT
   add `src/components/ui/`. Never hardcode the accent hue — CSS vars/theme
   tokens only. New list-row surfaces opt into UI density (`var(--row-step)`).

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -622,7 +622,11 @@ design/              In-house design system (NOT components/ui/), exported via
                      window), modal.tsx (PGModal), resizable.tsx (PGResizeHandle
                      + usePaneSize), paneSize.ts (pure clamp), ui-helpers.tsx
                      (pgFlash — ONE reused toast element — + PG_FLASH_MS),
-                     use-prevent-browser-context-menu.ts
+                     use-prevent-browser-context-menu.ts, color-picker.tsx
+                     (PGColorSwatch — the wheel/slider popover that replaced
+                     <input type="color">, never a native colour input) and
+                     colorWheel.ts (pure wheel + slider geometry, the reason
+                     jsdom can test any of it)
 
 screens/             One per activity-bar item + deep views: RepoBrowser,
                      CommitPanel, History, DiffViewer, Branches, Rebase, Remote,
@@ -716,7 +720,9 @@ features/            Components + Zustand store colocated per feature:
 │                    ThemeEditorDialog (a PGModal, no props: it reads
 │                    useThemeEditorStore so app.closeOverlay can close it),
 │                    useThemeEditorStore (the draft + the pre-draft theme
-│                    close() restores), ColorEditor (the 18 slots),
+│                    close() restores), ColorEditor (the 18 slots — each row is
+                    an inline hex field plus a PGColorSwatch carrying the
+                    draft's own palette and the slot's contrast partner),
 │                    contrast.ts (WCAG ratios for the four pairs that decide
 │                    readability — advisory, never blocking) and deriveTheme.ts
 │                    (base + accent → palette, with the ink recalculated)
@@ -854,7 +860,10 @@ lib/                 tauri.ts (typed invoke wrappers — frontend NEVER calls
                      usePrefetchSyntax.ts), diffRows.ts (flat DiffRow model:
                      line | fill | fold, + hunkAnchorRows), diffMinimap.ts (pure
                      minimap core), cssColor.ts (hex/rgb()/oklch() → sRGB — a
-                     canvas can't take CSS vars), wordDiff.ts,
+                     canvas can't take CSS vars — plus the OKLCh inverse and
+                     srgbChromaCeiling), color.ts (hex/HSV/HSL + the picker's
+                     HSV/HSL/RGB/OKLCH model registry and slider tracks; THE
+                     normalizeHex), wordDiff.ts,
                      pairChangedLines.ts (which rem pairs with which add — one
                      definition, three surfaces), lineSpans.ts (syntax ×
                      word-diff tiling, plus find marks), diffFind.ts (find in

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1981,6 +1981,44 @@ update checks back on for someone who turned them off.
   overwrites what the user typed, and an edit of an existing theme never
   renames it. Without that, "Add theme" left you saving a "Dracula (custom)"
   built entirely out of Solarized.
+- **One colour picker — `PGColorSwatch`** (`design/color-picker.tsx`), and a
+  guard test (`test/nativeColorInput.test.ts`) fails the build for a native
+  `<input type="color">` anywhere in shipped `src/`. The native control was
+  never a picker but a hand-off: an unstyled OS panel that offers hex and the
+  host's own colour model, nothing that helps build the RAMP a theme actually
+  is, untestable (the dialog is a host window, so it could stop working
+  entirely with the suite green), and of exactly the class that is silently
+  inert on WebKitGTK — see `<a download>` and #435. Four things about the
+  replacement are load-bearing:
+  - **HSV is the state; the hex is derived.** A grey has no hue and black has
+    neither hue nor saturation, so reading the state back out of the colour
+    teleports the wheel cursor to red the instant saturation reaches zero.
+    `hexToHsv(hex, prev)` carries the angle across, and a ref is what gives it
+    something to carry when the colour arrives from OUTSIDE the popover (a
+    palette swatch, the hex field, the editor's Revert).
+  - **The selected model's channel values are HELD, not re-derived per render.**
+    Re-deriving quantizes them and the error ACCUMULATES — ten presses of a
+    one-degree step moved the hue 10.14°, and the readout crept away from the
+    number it had just shown. The residual 0.14° in the stored hex is inherent:
+    a theme colour is eight bits a channel, which is why the draft and not the
+    hex is the source of truth.
+  - **The wheel paints once, at full brightness, and is dimmed by compositing
+    black.** Exact rather than approximate — HSV's value scales all three
+    channels linearly — so the brightness slider costs one composite instead of
+    re-running a 28k-pixel loop per frame. The geometry lives in a pure
+    `colorWheel.ts` for the reason `selectPos.ts` does: jsdom lays nothing out,
+    so a rendered wheel measures 0×0.
+  - **Escape and dismissal follow PGSelect exactly** — `app.closeOverlay`,
+    registered always and DECLINING while closed, so an open picker eats the
+    chord and the theme editor survives while a closed one hands it back. A
+    dismissal REVERTS (a dismissal is not an answer, the rule `pgConfirm` and
+    the editor's own `close()` both follow); a click away keeps and is the only
+    thing that reports to `recentColors`. The outside-press handler consults
+    `pressIsInsideMenu`, or the swatch's own portalled context menu closes the
+    popover on `mousedown` and lands its click on a detached node (#422).
+  `recentColors` is per-machine and **NON_PORTABLE** — an export is a file
+  people share, and one person's colour history describes nothing about how the
+  app behaves. It has no Settings row because it has no control.
 - **Contrast warnings advise, never block.** `theme/contrast.ts` measures the
   four pairs that decide whether the app is readable (primary text on the
   canvas, secondary and muted on a panel, button text on the accent) — not every

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -5,7 +5,7 @@ import {
 import {
   openRepo, reopenRepo, resetApp, stubNativeDialogs, confirmCallCount,
   openPalette, paletteDialog, paletteInput, switchScreen, stagedRow, changeRow,
-  executeOnce, openSettings,
+  executeOnce, openSettings, jsKey,
 } from "../support/app";
 
 async function clickPaletteRow(text: string): Promise<void> {
@@ -384,6 +384,123 @@ describe("settings", () => {
     const themeId = await browser.execute(() => document.documentElement.dataset.theme);
     expect(themeId).not.toBe("__draft__");
     expect(themeId).toMatch(/^custom-/);
+  });
+
+  /**
+   * The colour picker, on the real engine.
+   *
+   * Worth a case for the same reason the export ones below are: what it
+   * replaced was `<input type="color">`, a hand-off to a host dialog, and a
+   * native control of that class is silently inert on WebKitGTK (#435). No
+   * component test can tell the difference — jsdom renders no dialog either
+   * way — so "the picker opens and changes a colour here" is a claim only this
+   * layer can make.
+   *
+   * Two of the three assertions are engine-specific on purpose. The wheel is
+   * an ImageData written per pixel and blitted with `putImageData`, and the
+   * unit suite paints it into a STUB context that records nothing, so whether
+   * WebKitGTK 605 produces actual pixels is untested until here. And Escape's
+   * ordering — the picker claims the chord, the dialog behind it survives — is
+   * a real capture-phase dispatcher racing a real portal.
+   */
+  it("picks a colour with the wheel instead of the host's colour dialog", async () => {
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await openSettings("general.appearance");
+
+    const nordCard = $('[role="radio"][aria-label="Nord"]');
+    await nordCard.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "theme gallery never rendered the Nord card",
+    });
+    await $('button[aria-label="Duplicate Nord"]').click();
+    await $('[data-testid="theme-editor-name"]').waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "theme editor never opened from Duplicate",
+    });
+
+    // No native colour input anywhere in the editor — `test/nativeColorInput.
+    // test.ts` guards the source, this checks what the webview actually built.
+    expect(
+      await browser.execute(() => !!document.querySelector('input[type="color"]')),
+    ).toBe(false);
+
+    // The guided start's Accent swatch. The eighteen slot rows carry one too,
+    // including their own "Accent", but they live behind the collapsed
+    // disclosure — so while it is shut this selector is unambiguous.
+    await $('button[aria-label^="Accent — "]').click();
+    const picker = $("[data-pg-colorpicker]");
+    await picker.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the colour picker popover never opened",
+    });
+
+    // The wheel really painted. A stubbed 2D context (what the unit suite
+    // hands the painter) would leave this all-zero, and so would a WebKitGTK
+    // without `createImageData` — which is the failure mode that has to be
+    // caught on the engine rather than in jsdom.
+    const wheel = await browser.execute(() => {
+      const canvas = document.querySelector(
+        "[data-pg-colorpicker] canvas",
+      ) as HTMLCanvasElement | null;
+      if (!canvas || !canvas.width) return null;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return null;
+      // Dead centre is zero saturation at full value: white, opaque.
+      const px = ctx.getImageData(
+        Math.floor(canvas.width / 2),
+        Math.floor(canvas.height / 2),
+        1,
+        1,
+      ).data;
+      return { r: px[0], g: px[1], b: px[2], a: px[3] };
+    });
+    expect(wheel).not.toBeNull();
+    expect(wheel!.a).toBeGreaterThan(0);
+    expect(wheel!.r).toBeGreaterThan(200);
+    expect(wheel!.g).toBeGreaterThan(200);
+    expect(wheel!.b).toBeGreaterThan(200);
+
+    const accentOf = () =>
+      browser.execute(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--accent").trim(),
+      );
+    const before = await accentOf();
+    expect(before).toBeTruthy();
+
+    // The keyboard equivalent of dragging the wheel, which is also the only
+    // half of it WebDriver can reach — a synthetic pointer drag would stand in
+    // for a gesture nobody makes.
+    const hue = '[role="slider"][aria-label="HSV hue"]';
+    await $(hue).waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the picker never rendered its hue slider",
+    });
+    for (let i = 0; i < 20; i++) await jsKey(hue, "ArrowRight");
+
+    // Live-applied to the real document, which is what makes the app repaint
+    // behind the dialog while a colour is being chosen.
+    await browser.waitUntil(async () => (await accentOf()) !== before, {
+      timeout: 10_000,
+      timeoutMsg: "moving the hue slider never repainted --accent",
+    });
+
+    // Escape belongs to the picker while it is open: the popover goes, the
+    // theme editor stays. Registered-always-declining-while-closed is what
+    // makes both halves true, and only a real dispatcher proves the ordering.
+    await jsKey("[data-pg-colorpicker]", "Escape");
+    await picker.waitForExist({
+      reverse: true,
+      timeout: 10_000,
+      timeoutMsg: "Escape did not close the colour picker",
+    });
+    expect(await $('[data-testid="theme-editor-name"]').isExisting()).toBe(true);
+
+    // And a dismissal is not an answer — the colour goes back.
+    await browser.waitUntil(async () => (await accentOf()) === before, {
+      timeout: 10_000,
+      timeoutMsg: "Escape closed the picker without restoring the colour",
+    });
   });
 
   /**

--- a/src/design/color-picker.test.tsx
+++ b/src/design/color-picker.test.tsx
@@ -1,0 +1,447 @@
+// PGColorSwatch — the wheel-and-sliders popover that replaced the native
+// `<input type="color">` in the theme editor.
+//
+// A native colour input handed us a picker for free; these tests are what says
+// we actually re-provided it, and they lean on the same two house rules
+// `primitives.select.test.tsx` documents: every keyboard assertion runs with
+// the REAL capture-phase dispatcher installed, because that is the only
+// configuration the app ships in, and Escape must be claimed while the popover
+// is open and RELEASED while it is closed — otherwise a picker inside the theme
+// editor either cannot be dismissed or takes the dialog down with it.
+//
+// Pixels are not asserted here and never should be: the wheel's arithmetic is
+// pinned in `colorWheel.test.ts`, where real numbers exist. jsdom measures every
+// rendered box as 0, so what a component test can prove is wiring — which
+// control is connected to which channel, and what reaches `onChange`.
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { PGColorSwatch } from "./color-picker";
+import { PGModal } from "./modal";
+import { useFocusStore } from "@/features/keymap/useFocusStore";
+import { useKeymapStore } from "@/features/keymap/useKeymapStore";
+import { useOverlayStore } from "@/features/keymap/useOverlayStore";
+import { colorModel } from "@/lib/color";
+
+const ACCENT = "#5aa8e8";
+
+const trigger = () => screen.getByRole("button", { name: /accent/i });
+const popover = () => document.querySelector("[data-pg-colorpicker]");
+const hexField = () => screen.getByLabelText("Hex");
+const slider = (name: RegExp | string) => screen.getByRole("slider", { name });
+
+function withDispatcher(): () => void {
+  const onKey = (e: KeyboardEvent) => useKeymapStore.getState().dispatch(e);
+  window.addEventListener("keydown", onKey, true);
+  return () => window.removeEventListener("keydown", onKey, true);
+}
+
+let detach: (() => void) | null = null;
+
+beforeEach(() => {
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({ focused: "history.list" });
+  useOverlayStore.setState({ cheatSheetOpen: false });
+  detach = withDispatcher();
+});
+
+afterEach(() => {
+  detach?.();
+  detach = null;
+});
+
+/** Render with a caller that keeps the value, the way every real one does. */
+function renderLive(props: Record<string, unknown> = {}) {
+  const onChange = vi.fn();
+  function Host() {
+    const [value, setValue] = React.useState(ACCENT);
+    return (
+      <PGColorSwatch
+        label="Accent"
+        value={value}
+        onChange={(v: string) => {
+          setValue(v);
+          onChange(v);
+        }}
+        {...props}
+      />
+    );
+  }
+  const utils = render(<Host />);
+  return { ...utils, onChange };
+}
+
+function open(): void {
+  fireEvent.click(trigger());
+}
+
+describe("PGColorSwatch — the trigger", () => {
+  it("is a button that names the field it edits", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    expect(trigger()).toBeTruthy();
+    expect(popover()).toBeNull();
+  });
+
+  it("says the current colour in text, not only in paint", () => {
+    // A swatch alone is unreachable to a screen reader and unverifiable to a
+    // test, since jsdom renders no colour.
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    expect(trigger().getAttribute("aria-label")).toMatch(/#5aa8e8/i);
+  });
+
+  it("opens the popover on click and closes it on a second click", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    expect(popover()).toBeTruthy();
+    fireEvent.click(trigger());
+    expect(popover()).toBeNull();
+  });
+
+  it("renders no native colour input — the whole point of the exercise", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    expect(document.querySelector('input[type="color"]')).toBeNull();
+  });
+});
+
+describe("PGColorSwatch — the hex field", () => {
+  it("commits a typed hex on Enter", () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.change(hexField(), { target: { value: "#ff8800" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+    expect(onChange).toHaveBeenLastCalledWith("#ff8800");
+  });
+
+  it("accepts the shorthand and the missing hash, and canonicalizes both", () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.change(hexField(), { target: { value: "F80" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+    expect(onChange).toHaveBeenLastCalledWith("#ff8800");
+  });
+
+  it("leaves the colour alone when the text is not one", () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.change(hexField(), { target: { value: "rebeccapurple" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("PGColorSwatch — the sliders", () => {
+  it("shows the wheel's own axes by default, so the controls agree", () => {
+    // The tall slider and the numeric row are the same axis. Defaulting the row
+    // to HSL instead would put two different lightness controls side by side,
+    // each moving the other.
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    expect(slider(/hsv hue/i)).toBeTruthy();
+    expect(slider(/hsv saturation/i)).toBeTruthy();
+    expect(slider(/hsv value/i)).toBeTruthy();
+    expect(slider(/brightness/i)).toBeTruthy();
+  });
+
+  it("gives the two lightness controls distinguishable names", () => {
+    // The tall slider IS the HSV model's V. Two role=slider nodes both named
+    // "Value" would be one control announced twice, with no way to tell a
+    // screen reader user which is which.
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    const names = screen
+      .getAllByRole("slider")
+      .map((el) => el.getAttribute("aria-label"));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("moves the colour by one step on an arrow key", () => {
+    const { onChange } = renderLive();
+    open();
+    const before = colorModel("hsv").read(ACCENT);
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalled();
+    const after = colorModel("hsv").read(onChange.mock.lastCall![0]);
+    expect(after[0]).toBeGreaterThan(before[0]);
+  });
+
+  it("moves ten steps with Shift held", () => {
+    // Asserted on the slider's own reported value, not on the hue read back
+    // out of the hex: a theme colour is eight bits per channel, so the STORED
+    // colour necessarily lands on the nearest representable hue (0.14° away
+    // here). That quantization is the reason the channel values have to be
+    // held rather than re-derived, and re-deriving them to check would be
+    // measuring the very thing being avoided.
+    renderLive();
+    open();
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    const one = Number(slider(/hsv hue/i).getAttribute("aria-valuenow"));
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight", shiftKey: true });
+    const eleven = Number(slider(/hsv hue/i).getAttribute("aria-valuenow"));
+    expect(eleven - one).toBe(10);
+  });
+
+  it("jumps to the ends with Home and End", () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.keyDown(slider(/hsv saturation/i), { key: "Home" });
+    expect(colorModel("hsv").read(onChange.mock.lastCall![0])[1]).toBe(0);
+    fireEvent.keyDown(slider(/hsv saturation/i), { key: "End" });
+    expect(colorModel("hsv").read(onChange.mock.lastCall![0])[1]).toBeCloseTo(1, 3);
+  });
+
+  it("keeps the hue after saturation goes to zero", () => {
+    // The failure this pins: a grey has no hue to report, so a naive read
+    // resets the angle to 0 and the wheel cursor teleports to red — taking the
+    // colour the user was tuning with it, since there is no way back.
+    renderLive();
+    open();
+    fireEvent.keyDown(slider(/hsv saturation/i), { key: "Home" });
+    expect(slider(/hsv hue/i).getAttribute("aria-valuenow")).toBe("207");
+  });
+
+  it("does not drift the channel across repeated steps", () => {
+    // Re-reading the channel values from the hex on every render made each
+    // step inherit the last one's rounding, so the error ACCUMULATED: ten
+    // presses of a one-degree step landed 1.4° past where they should, and the
+    // readout crept away from the number it had just shown. Ten steps from 207
+    // must read 217, not 218.
+    renderLive();
+    open();
+    const start = Number(slider(/hsv hue/i).getAttribute("aria-valuenow"));
+    for (let i = 0; i < 10; i++) {
+      fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    }
+    expect(Number(slider(/hsv hue/i).getAttribute("aria-valuenow"))).toBe(start + 10);
+  });
+
+  it("reports its range and position for a screen reader", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    const hue = slider(/hsv hue/i);
+    expect(hue.getAttribute("aria-valuemin")).toBe("0");
+    expect(hue.getAttribute("aria-valuemax")).toBe("360");
+    // The rounded number the readout shows beside it, not the raw 207.042…
+    expect(hue.getAttribute("aria-valuenow")).toBe("207");
+    expect(hue.getAttribute("aria-valuetext")).toBe("207°");
+  });
+});
+
+describe("PGColorSwatch — the model selector", () => {
+  it("swaps the channel set without changing the colour", () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /oklch/i }));
+    expect(slider(/lightness/i)).toBeTruthy();
+    expect(slider(/chroma/i)).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ends the chroma track where sRGB does", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /oklch/i }));
+    const chroma = slider(/chroma/i);
+    // Not the model's nominal 0.4: the reachable ceiling for this L and H.
+    const max = Number(chroma.getAttribute("aria-valuemax"));
+    expect(max).toBeGreaterThan(0);
+    expect(max).toBeLessThan(0.4);
+  });
+});
+
+describe("PGColorSwatch — the swatch rows", () => {
+  it("commits a colour taken from the theme's own palette", () => {
+    const { onChange } = renderLive({
+      swatches: [
+        { hex: "#1e222a", label: "Background · panel" },
+        { hex: "#eef1f5", label: "Foreground · primary" },
+      ],
+    });
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /Background · panel/ }));
+    expect(onChange).toHaveBeenLastCalledWith("#1e222a");
+  });
+
+  it("offers the colours picked recently", () => {
+    const { onChange } = renderLive({ recent: ["#ff8800", "#123456"] });
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /#ff8800/ }));
+    expect(onChange).toHaveBeenLastCalledWith("#ff8800");
+  });
+
+  it("shows no recent row at all when there is nothing in it", () => {
+    render(
+      <PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} recent={[]} />,
+    );
+    open();
+    expect(screen.queryByText(/recent/i)).toBeNull();
+  });
+});
+
+describe("PGColorSwatch — the contrast readout", () => {
+  it("measures the pair while you drag, where the finding is actionable", () => {
+    render(
+      <PGColorSwatch
+        label="Accent"
+        value={ACCENT}
+        onChange={() => {}}
+        contrast={{ against: "#0e1a26", label: "Accent · on-ink" }}
+      />,
+    );
+    open();
+    // #5aa8e8 on #0e1a26, by the same formula theme/contrast.ts uses.
+    expect(screen.getByTestId("colorpicker-contrast").textContent).toMatch(/6\.9:1/);
+  });
+
+  it("says nothing when the field has no pair to be read against", () => {
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    expect(screen.queryByTestId("colorpicker-contrast")).toBeNull();
+  });
+});
+
+describe("PGColorSwatch — copy and paste", () => {
+  // fireEvent, not userEvent: `userEvent.setup()` swaps `navigator.clipboard`
+  // for its own stub, which detaches a writeText spy so every clipboard
+  // assertion passes while asserting nothing.
+  const clipboard = (text = "") => {
+    const writeText = vi.fn();
+    const readText = vi.fn(async () => text);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText, readText },
+      configurable: true,
+    });
+    return { writeText, readText };
+  };
+
+  it("copies the colour from the swatch's own menu", () => {
+    const { writeText } = clipboard();
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    fireEvent.contextMenu(trigger());
+    fireEvent.click(screen.getByText(`Copy ${ACCENT}`));
+    expect(writeText).toHaveBeenCalledWith(ACCENT);
+  });
+
+  it("pastes a colour off the clipboard, in any of its written forms", async () => {
+    clipboard("  F80 ");
+    const onChange = vi.fn();
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={onChange} />);
+    fireEvent.contextMenu(trigger());
+    fireEvent.click(screen.getByText("Paste colour"));
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith("#ff8800"));
+  });
+
+  it("leaves the colour alone when the clipboard holds no colour", async () => {
+    clipboard("git rebase --continue");
+    const onChange = vi.fn();
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={onChange} />);
+    fireEvent.contextMenu(trigger());
+    fireEvent.click(screen.getByText("Paste colour"));
+    await vi.waitFor(() =>
+      expect(screen.getByText(/clipboard holds no colour/i)).toBeTruthy(),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("survives its own menu being clicked while the popover is open", async () => {
+    // The #422 trap: the menu is portalled onto document.body, so an outside
+    // handler that only checks `contains` reads a press on the menu as a press
+    // outside the popover, closes on mousedown, and the entry's click lands on
+    // a detached node doing nothing at all.
+    const { writeText } = clipboard();
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.contextMenu(trigger());
+    const entry = screen.getByText(`Copy ${ACCENT}`);
+    fireEvent.mouseDown(entry);
+    expect(popover()).toBeTruthy();
+    fireEvent.click(entry);
+    expect(writeText).toHaveBeenCalledWith(ACCENT);
+  });
+});
+
+describe("PGColorSwatch — dismissal", () => {
+  it("Escape closes the popover and puts the colour back", () => {
+    // Consistent with the theme editor one level up, whose close() re-applies
+    // the theme that was live on open: a dismissal is not an answer.
+    const { onChange } = renderLive();
+    open();
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalled();
+    fireEvent.keyDown(popover()!, { key: "Escape" });
+    expect(popover()).toBeNull();
+    expect(onChange).toHaveBeenLastCalledWith(ACCENT);
+  });
+
+  it("Escape is claimed while open and RELEASED while closed", () => {
+    const outer = vi.fn(() => true);
+    const un = useKeymapStore.getState().register("app.closeOverlay", outer);
+    render(<PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />);
+    open();
+    fireEvent.keyDown(popover()!, { key: "Escape" });
+    expect(popover()).toBeNull();
+    expect(outer).not.toHaveBeenCalled();
+    // Closed, the picker declines and the chord goes back to the outer handler.
+    fireEvent.keyDown(trigger(), { key: "Escape" });
+    expect(outer).toHaveBeenCalledOnce();
+    un();
+  });
+
+  it("does not take the dialog it is inside down with it", () => {
+    // The case that actually matters. No dialog REGISTERS app.closeOverlay, so
+    // what protects the theme editor is the picker claiming the chord before
+    // the catalog's default runner is ever reached.
+    useOverlayStore.setState({ cheatSheetOpen: true });
+    render(
+      <PGModal onCancel={() => {}}>
+        <PGColorSwatch label="Accent" value={ACCENT} onChange={() => {}} />
+      </PGModal>,
+    );
+    open();
+    fireEvent.keyDown(popover()!, { key: "Escape" });
+    expect(popover()).toBeNull();
+    expect(useOverlayStore.getState().cheatSheetOpen).toBe(true);
+    fireEvent.keyDown(trigger(), { key: "Escape" });
+    expect(useOverlayStore.getState().cheatSheetOpen).toBe(false);
+  });
+
+  it("a click outside KEEPS the colour, unlike Escape", async () => {
+    const { onChange } = renderLive();
+    open();
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    const picked = onChange.mock.lastCall![0];
+    // The outside listener is armed on a timeout, so the very click that
+    // OPENED the popover cannot immediately close it again — hence the tick.
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.mouseDown(document.body);
+    expect(popover()).toBeNull();
+    expect(onChange).toHaveBeenLastCalledWith(picked);
+  });
+
+  it("reports the kept colour once, for the recents list", async () => {
+    const onCommit = vi.fn();
+    renderLive({ onCommit });
+    open();
+    fireEvent.change(hexField(), { target: { value: "#ff8800" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+    expect(onCommit).not.toHaveBeenCalled();
+    // The outside listener is armed on a timeout, so the very click that
+    // OPENED the popover cannot immediately close it again — hence the tick.
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.mouseDown(document.body);
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("#ff8800");
+  });
+
+  it("reports nothing on a dismissal", () => {
+    const onCommit = vi.fn();
+    renderLive({ onCommit });
+    open();
+    fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
+    fireEvent.keyDown(popover()!, { key: "Escape" });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/src/design/color-picker.tsx
+++ b/src/design/color-picker.tsx
@@ -1,0 +1,986 @@
+// PGColorSwatch — a colour swatch that opens a real picker.
+//
+// It replaced `<input type="color">`, which was never a picker so much as a
+// hand-off: whatever dialog the host webview felt like showing, if it showed
+// one at all. That is a bad deal on three counts. The dialog is unstyled and
+// unthemed, so choosing a dark theme's greys happens in a bright OS panel; it
+// offers hex and an OS colour model but nothing that helps build a RAMP, which
+// is what a theme actually is; and on WebKitGTK a native control of this shape
+// is exactly the kind that quietly does nothing (see `lib/userFile.ts` and the
+// `<a download>` story — a webview is not a browser).
+//
+// The arithmetic lives elsewhere on purpose. `lib/color.ts` owns the spaces and
+// the channel registry, `colorWheel.ts` owns where things are, and both are
+// pure — so what is left here is wiring, which is the only part jsdom can
+// actually judge. See `color-picker.test.tsx`.
+//
+// Two rules this file inherits rather than invents:
+//   * Escape comes through the keymap's `app.closeOverlay`, never a local
+//     listener — the same registration PGSelect documents at length. Registered
+//     always, DECLINING while closed, so a picker open inside the theme editor
+//     eats Escape and the dialog survives, and a closed one gives the chord
+//     back.
+//   * The popover is `position: fixed` and portalled, placed by `selectPos.ts`,
+//     because the shell is a fixed frame: a popup off the viewport is not ugly,
+//     it is unreachable.
+
+import React from "react";
+import { createPortal } from "react-dom";
+
+import { useAction } from "@/features/keymap/useAction";
+import {
+  COLOR_MODELS,
+  colorModel,
+  hexToHsv,
+  hsvToHex,
+  normalizeHex,
+  trackStops,
+  type ColorChannel,
+  type ColorModel,
+  type Hsv,
+} from "@/lib/color";
+import { pressIsInsideMenu, useContextMenu } from "./context-menu";
+import { PGIcon } from "./icons";
+import { pgFlash } from "./ui-helpers";
+import { selectPopoverPos } from "./selectPos";
+import {
+  paintWheelRgba,
+  sliderFraction,
+  sliderValue,
+  wheelHueSatClamped,
+  wheelPoint,
+} from "./colorWheel";
+
+/** One entry in the palette row. */
+export interface ColorSwatchOption {
+  hex: string;
+  label: string;
+}
+
+export interface PGColorSwatchProps {
+  /** The field this edits, for the trigger's accessible name. */
+  label: string;
+  value: string;
+  /**
+   * Every change, including each frame of a drag.
+   *
+   * Live on purpose: the theme editor's `patchColors` applies to `:root`, so
+   * dragging repaints the actual application behind the dialog. That is the
+   * feedback the old native dialog could not give at any price.
+   */
+  onChange: (hex: string) => void;
+  /**
+   * The colour the popover closed on, once, when it was KEPT.
+   *
+   * Separate from `onChange` because a recents list wants the colour someone
+   * settled on, not the four hundred it passed through on the way.
+   */
+  onCommit?: (hex: string) => void;
+  /** Colours to offer alongside the wheel — in the theme editor, the palette. */
+  swatches?: ColorSwatchOption[];
+  /** Recently chosen colours, newest first. */
+  recent?: string[];
+  /** A pair to measure while dragging, where a low ratio is still fixable. */
+  contrast?: { against: string; label: string };
+  /** Trailing content in the trigger row, e.g. a ratio badge. */
+  title?: string;
+}
+
+const WHEEL_SIZE = 168;
+const VALUE_W = 18;
+const POPOVER_W = 268;
+
+export function PGColorSwatch({
+  label,
+  value,
+  onChange,
+  onCommit,
+  swatches,
+  recent,
+  contrast,
+  title,
+}: PGColorSwatchProps) {
+  const [open, setOpen] = React.useState(false);
+  const [anchor, setAnchor] = React.useState<{
+    left: number;
+    top: number;
+    bottom: number;
+    width: number;
+  } | null>(null);
+  const [pos, setPos] = React.useState<{ left: number; top: number } | null>(null);
+  const btnRef = React.useRef<HTMLButtonElement | null>(null);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+
+  /**
+   * The colour the popover opened on. Escape puts it back — a dismissal is not
+   * an answer, the rule `pgConfirm` and the theme editor's own `close()` both
+   * follow.
+   */
+  const opened = React.useRef(value);
+
+  const show = () => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (r) setAnchor({ left: r.left, top: r.top, bottom: r.bottom, width: r.width });
+    opened.current = value;
+    setPos(null);
+    setOpen(true);
+  };
+
+  /** Close, keeping the colour. */
+  const keep = React.useCallback(() => {
+    setOpen(false);
+    if (value !== opened.current) onCommit?.(value);
+  }, [value, onCommit]);
+
+  /** Close, putting the colour back where it was. */
+  const revert = React.useCallback(() => {
+    setOpen(false);
+    if (value !== opened.current) onChange(opened.current);
+  }, [value, onChange]);
+
+  const menu = useContextMenu<void>(() => [
+    {
+      icon: "copy",
+      label: `Copy ${value}`,
+      onClick: () => {
+        navigator.clipboard?.writeText(value);
+        pgFlash(`copied ${value}`);
+      },
+    },
+    {
+      // No clipboard glyph in the set, and `test/iconSet.test.ts` fails the
+      // build for a literal the union does not declare — a paste is an
+      // incoming copy, so "download" is the honest one of what is there.
+      icon: "download",
+      label: "Paste colour",
+      onClick: async () => {
+        const text = await navigator.clipboard?.readText?.();
+        const hex = text ? normalizeHex(text) : null;
+        if (!hex) {
+          pgFlash("clipboard holds no colour");
+          return;
+        }
+        onChange(hex);
+        onCommit?.(hex);
+      },
+    },
+  ]);
+
+  // Placed once the panel has a measured box, in a layout effect so the placed
+  // position is what paints. The arithmetic is `selectPos.ts`'s, where it can be
+  // tested with real numbers.
+  React.useLayoutEffect(() => {
+    if (!open || !anchor) return;
+    const el = panelRef.current;
+    if (!el) return;
+    setPos(
+      selectPopoverPos({
+        anchor,
+        listW: el.offsetWidth,
+        listH: el.offsetHeight,
+        viewportW: window.innerWidth,
+        viewportH: window.innerHeight,
+      }),
+    );
+  }, [open, anchor]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    // A context menu opened from the swatch is portalled onto `document.body`,
+    // so `contains` reads a press on it as a press outside the popover: the
+    // popover would close on mousedown, taking the menu with it, and the
+    // entry's click would land on a detached node doing nothing (#422). Hence
+    // `pressIsInsideMenu` — the guard every self-dismissing surface here owes.
+    const inside = (t: Node | null) =>
+      !!t &&
+      !!(
+        btnRef.current?.contains(t) ||
+        panelRef.current?.contains(t) ||
+        pressIsInsideMenu(t)
+      );
+    const outside = (e: Event) => {
+      if (inside(e.target as Node | null)) return;
+      keep();
+    };
+    // A fixed popup cannot follow a scrolling anchor or a resized window — both
+    // detach it from the trigger, so close rather than chase. The panel has its
+    // own scrollable rows, hence the inside() guard on a capture-phase listener.
+    const onScroll = (e: Event) => {
+      if (inside(e.target as Node | null)) return;
+      keep();
+    };
+    // Deferred: the mousedown that OPENED the popover is still propagating when
+    // this effect runs.
+    const armed = window.setTimeout(() => {
+      document.addEventListener("mousedown", outside);
+      document.addEventListener("scroll", onScroll, true);
+      window.addEventListener("resize", keep);
+    }, 0);
+    return () => {
+      window.clearTimeout(armed);
+      document.removeEventListener("mousedown", outside);
+      document.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", keep);
+    };
+  }, [open, keep]);
+
+  // See the file header: registered always, declining while closed.
+  useAction(
+    "app.closeOverlay",
+    () => {
+      if (!open) return false;
+      revert();
+      return true;
+    },
+    [open, revert],
+  );
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        aria-label={`${label} — ${value}. Choose a colour`}
+        aria-expanded={open}
+        title={title}
+        onClick={() => (open ? keep() : show())}
+        onContextMenu={(e) => menu.onContextMenu(e, undefined)}
+        style={{
+          position: "relative",
+          width: 28,
+          height: 28,
+          padding: 0,
+          borderRadius: "var(--r-3)",
+          border: `1px solid ${open ? "var(--accent)" : "var(--border-1)"}`,
+          background: value,
+          cursor: "pointer",
+          flexShrink: 0,
+          overflow: "hidden",
+          boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.15)",
+        }}
+      />
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            data-pg-colorpicker=""
+            role="dialog"
+            aria-label={`${label} colour`}
+            onKeyDown={(e) => {
+              // Escape is the keymap's, but a component test mounts no
+              // dispatcher — this is the same fallback PGSelect keeps.
+              if (e.key === "Escape") {
+                e.stopPropagation();
+                revert();
+              }
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+            style={{
+              position: "fixed",
+              left: pos?.left ?? anchor?.left ?? 0,
+              top: pos?.top ?? anchor?.bottom ?? 0,
+              width: POPOVER_W,
+              // Hidden until placed, so it never paints at the unplaced
+              // position first — a 268px panel visibly jumping is worse than a
+              // frame of nothing.
+              visibility: pos ? "visible" : "hidden",
+              background: "var(--bg-2)",
+              border: "1px solid var(--border-1)",
+              borderRadius: "var(--r-3)",
+              boxShadow: "var(--shadow-2)",
+              padding: 12,
+              // Above PGModal (100) and level with PGContextMenu: the theme
+              // editor is a dialog, and this has to draw over its backdrop.
+              zIndex: 100000,
+              fontFamily: "var(--font-sans)",
+              fontSize: "var(--fs-12)",
+              color: "var(--fg-0)",
+              userSelect: "none",
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+            }}
+          >
+            <PickerBody
+              label={label}
+              value={value}
+              onChange={onChange}
+              swatches={swatches}
+              recent={recent}
+              contrast={contrast}
+            />
+          </div>,
+          document.body,
+        )}
+      {menu.menu}
+    </>
+  );
+}
+
+// ─── The popover's contents ──────────────────────────────────────────────────
+
+function PickerBody({
+  label,
+  value,
+  onChange,
+  swatches,
+  recent,
+  contrast,
+}: {
+  label: string;
+  value: string;
+  onChange: (hex: string) => void;
+  swatches?: ColorSwatchOption[];
+  recent?: string[];
+  contrast?: { against: string; label: string };
+}) {
+  // HSV by default so the numeric row is the WHEEL's own two axes plus the
+  // brightness slider beside it — the three controls above then agree instead
+  // of offering two different lightnesses that move each other.
+  const [modelId, setModelId] = React.useState<ColorModel["id"]>("hsv");
+  const model = colorModel(modelId);
+
+  /**
+   * HSV is the state; the hex is derived.
+   *
+   * The other way round loses the wheel's position at both edges — a grey has
+   * no hue and black has neither hue nor saturation — so dragging value to the
+   * floor and back would come up on a different colour than the one you left.
+   * `hexToHsv` carries the angle across; this ref is what gives it something to
+   * carry, including across a change that came from OUTSIDE the popover (a
+   * palette swatch, a typed hex, the theme editor's own Revert).
+   */
+  const hsvRef = React.useRef<Hsv>(hexToHsv(value));
+  if (hsvToHex(hsvRef.current) !== value) {
+    hsvRef.current = hexToHsv(value, hsvRef.current);
+  }
+  const hsv = hsvRef.current;
+
+  const setHsv = (next: Hsv) => {
+    hsvRef.current = next;
+    onChange(hsvToHex(next));
+  };
+
+  /**
+   * The selected model's channel values, held rather than re-derived.
+   *
+   * Re-reading them from the hex on every render quantizes them, and the error
+   * ACCUMULATES: ten arrow presses on hue moved 10.14° instead of 10, and the
+   * readout drifted a little further from the number it had just shown. So the
+   * draft is authoritative while it still describes the current colour, and is
+   * re-seeded the moment the colour arrives from anywhere else — the wheel, a
+   * palette swatch, the hex field, or the theme editor's Revert.
+   */
+  const valuesRef = React.useRef<number[]>(model.read(value));
+  const modelWas = React.useRef(modelId);
+  if (modelWas.current !== modelId) {
+    modelWas.current = modelId;
+    valuesRef.current = model.read(value);
+  } else if (model.write(valuesRef.current) !== value) {
+    valuesRef.current = model.read(value);
+  }
+  const values = valuesRef.current;
+
+  const setChannel = (index: number, next: number) => {
+    const edited = [...values];
+    edited[index] = next;
+    valuesRef.current = edited;
+    const hex = model.write(edited);
+    // Back through hexToHsv so the wheel follows a slider from another model,
+    // and so an achromatic result does not discard the angle.
+    hsvRef.current = hexToHsv(hex, hsvRef.current);
+    onChange(hex);
+  };
+
+  return (
+    <>
+      <div style={{ display: "flex", gap: 10 }}>
+        <ColorWheel
+          hsv={hsv}
+          onChange={(h, s) => setHsv({ ...hsv, h, s })}
+          label={label}
+        />
+        <ValueSlider hsv={hsv} onChange={(v) => setHsv({ ...hsv, v })} />
+      </div>
+
+      <HexRow value={value} onChange={onChange} contrast={contrast} />
+
+      <div
+        role="group"
+        aria-label="Colour model"
+        style={{ display: "flex", gap: 2 }}
+      >
+        {COLOR_MODELS.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            aria-pressed={m.id === modelId}
+            onClick={() => setModelId(m.id)}
+            style={{
+              flex: 1,
+              padding: "3px 0",
+              background: m.id === modelId ? "var(--bg-4)" : "transparent",
+              color: m.id === modelId ? "var(--fg-0)" : "var(--fg-2)",
+              border: "1px solid",
+              borderColor: m.id === modelId ? "var(--border-2)" : "transparent",
+              borderRadius: "var(--r-2)",
+              cursor: "pointer",
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--fs-10)",
+              letterSpacing: "0.03em",
+            }}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+        {model.channels.map((ch, i) => (
+          <ChannelSlider
+            key={`${model.id}.${ch.key}`}
+            channel={ch}
+            model={model}
+            values={values}
+            index={i}
+            onChange={(next) => setChannel(i, next)}
+          />
+        ))}
+      </div>
+
+      {!!swatches?.length && (
+        <SwatchRow
+          heading="This theme"
+          items={swatches}
+          current={value}
+          onPick={onChange}
+        />
+      )}
+      {!!recent?.length && (
+        <SwatchRow
+          heading="Recent"
+          items={recent.map((hex) => ({ hex, label: hex }))}
+          current={value}
+          onPick={onChange}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── The wheel ───────────────────────────────────────────────────────────────
+
+function ColorWheel({
+  hsv,
+  onChange,
+  label,
+}: {
+  hsv: Hsv;
+  onChange: (h: number, s: number) => void;
+  label: string;
+}) {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
+  const boxRef = React.useRef<HTMLDivElement | null>(null);
+
+  // The wheel is painted ONCE at full value and dimmed by compositing black
+  // over it, which is exact: HSV's value scales all three channels linearly, so
+  // `hsv(h, s, v)` IS `hsv(h, s, 1)` under black at alpha `1 - v`. Re-running
+  // the per-pixel loop on every frame of a value drag would be ~28k pixels of
+  // arithmetic per frame for a result identical to one composite.
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const px = Math.round(WHEEL_SIZE * dpr);
+    canvas.width = px;
+    canvas.height = px;
+    const ctx = canvas.getContext("2d");
+    // A webview without a 2D context must not crash the theme editor; the
+    // sliders still work, the wheel is simply blank.
+    if (!ctx?.createImageData) return;
+    const img = ctx.createImageData(px, px);
+    paintWheelRgba(img.data, px);
+    ctx.putImageData?.(img, 0, 0);
+  }, []);
+
+  const radius = WHEEL_SIZE / 2;
+  const cursor = wheelPoint(hsv.h, hsv.s, radius);
+
+  /** Screen point → hue and saturation, clamped to the rim for a drag. */
+  const pick = (clientX: number, clientY: number) => {
+    const r = boxRef.current?.getBoundingClientRect();
+    if (!r || r.width === 0) return;
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const { h, s } = wheelHueSatClamped(clientX - cx, clientY - cy, r.width / 2);
+    onChange(h, s);
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    // Pointer events with capture, the way `resizable.tsx` drags a pane —
+    // never HTML5 drag and drop, and the keyboard equivalent is right below.
+    e.preventDefault();
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    pick(e.clientX, e.clientY);
+  };
+
+  const step = (dh: number, ds: number) =>
+    onChange(
+      ((hsv.h + dh) % 360 + 360) % 360,
+      Math.min(1, Math.max(0, hsv.s + ds)),
+    );
+
+  return (
+    <div
+      ref={boxRef}
+      tabIndex={0}
+      role="group"
+      // The wheel is two axes at once, which `role="slider"` cannot describe.
+      // Its keyboard equivalent is the arrow keys here plus the H and S
+      // sliders below, which ARE these axes and carry the numbers.
+      aria-label={`${label} hue and saturation wheel. Arrow keys adjust hue and saturation.`}
+      onPointerDown={onPointerDown}
+      onPointerMove={(e) => {
+        if (e.buttons !== 1) return;
+        pick(e.clientX, e.clientY);
+      }}
+      onKeyDown={(e) => {
+        const big = e.shiftKey ? 10 : 1;
+        if (e.key === "ArrowLeft") step(-big, 0);
+        else if (e.key === "ArrowRight") step(big, 0);
+        else if (e.key === "ArrowUp") step(0, 0.01 * big);
+        else if (e.key === "ArrowDown") step(0, -0.01 * big);
+        else return;
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      style={{
+        position: "relative",
+        width: WHEEL_SIZE,
+        height: WHEEL_SIZE,
+        flexShrink: 0,
+        borderRadius: "50%",
+        cursor: "crosshair",
+        touchAction: "none",
+        outlineOffset: 2,
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        aria-hidden
+        style={{
+          width: WHEEL_SIZE,
+          height: WHEEL_SIZE,
+          display: "block",
+          borderRadius: "50%",
+          pointerEvents: "none",
+        }}
+      />
+      {/* The value dim, as one composite over the painted wheel. */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          background: "#000",
+          opacity: 1 - hsv.v,
+          pointerEvents: "none",
+        }}
+      />
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          left: radius + cursor.x,
+          top: radius + cursor.y,
+          width: 12,
+          height: 12,
+          marginLeft: -6,
+          marginTop: -6,
+          borderRadius: "50%",
+          border: "2px solid #fff",
+          boxShadow: "0 0 0 1px rgba(0,0,0,0.6), inset 0 0 0 1px rgba(0,0,0,0.35)",
+          pointerEvents: "none",
+        }}
+      />
+    </div>
+  );
+}
+
+// ─── Sliders ─────────────────────────────────────────────────────────────────
+
+/**
+ * The shared slider. Pointer-driven rather than an `<input type="range">`, for
+ * the same reason the wheel is a canvas: the track has to be painted with the
+ * colours it would actually pick, and a live gradient through a WebKit
+ * `::-webkit-slider-runnable-track` is a fight with no upside.
+ *
+ * `role="slider"` with the full value trio, so what a screen reader gets is a
+ * named channel with a range — not an unlabelled div.
+ */
+function Slider({
+  name,
+  valueText,
+  min,
+  max,
+  step,
+  value,
+  shownValue,
+  vertical,
+  trackCss,
+  onChange,
+}: {
+  name: string;
+  valueText: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  /**
+   * What `aria-valuenow` reports, when it differs from the exact `value`.
+   *
+   * The exact value is a float the readout rounds — announcing
+   * "207.04225352112678 degrees" is noise, and the number a screen reader gives
+   * should be the one on screen beside it.
+   */
+  shownValue?: number;
+  vertical?: boolean;
+  trackCss: string;
+  onChange: (next: number) => void;
+}) {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  // Measured at event time rather than observed: a drag needs the rect as it is
+  // under the pointer NOW, and the popover is `fixed` inside a scrollable
+  // dialog, so a cached box is a stale box.
+  const pick = (clientX: number, clientY: number) => {
+    const r = ref.current?.getBoundingClientRect();
+    if (!r) return;
+    // Vertical runs bottom-to-top: the maximum belongs at the TOP, which is
+    // where every value slider in every picker puts it.
+    const along = vertical ? r.bottom - clientY : clientX - r.left;
+    const len = vertical ? r.height : r.width;
+    onChange(sliderValue(along, len, min, max));
+  };
+
+  const nudge = (dir: number, big: boolean) =>
+    onChange(Math.min(max, Math.max(min, value + dir * step * (big ? 10 : 1))));
+
+  const frac = sliderFraction(value, min, max);
+
+  return (
+    <div
+      ref={ref}
+      role="slider"
+      tabIndex={0}
+      aria-label={name}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={shownValue ?? value}
+      aria-valuetext={valueText}
+      aria-orientation={vertical ? "vertical" : "horizontal"}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        (e.target as Element).setPointerCapture?.(e.pointerId);
+        pick(e.clientX, e.clientY);
+      }}
+      onPointerMove={(e) => {
+        if (e.buttons !== 1) return;
+        pick(e.clientX, e.clientY);
+      }}
+      onKeyDown={(e) => {
+        const back = vertical ? "ArrowDown" : "ArrowLeft";
+        const fwd = vertical ? "ArrowUp" : "ArrowRight";
+        if (e.key === back) nudge(-1, e.shiftKey);
+        else if (e.key === fwd) nudge(1, e.shiftKey);
+        else if (e.key === "Home") onChange(min);
+        else if (e.key === "End") onChange(max);
+        else if (e.key === "PageDown") nudge(-1, true);
+        else if (e.key === "PageUp") nudge(1, true);
+        else return;
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      style={{
+        position: "relative",
+        flex: vertical ? undefined : 1,
+        width: vertical ? VALUE_W : undefined,
+        height: vertical ? WHEEL_SIZE : 12,
+        borderRadius: 999,
+        border: "1px solid var(--border-1)",
+        background: trackCss,
+        cursor: vertical ? "ns-resize" : "ew-resize",
+        touchAction: "none",
+        outlineOffset: 2,
+        minWidth: 0,
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          left: vertical ? "50%" : `${frac * 100}%`,
+          top: vertical ? `${(1 - frac) * 100}%` : "50%",
+          width: vertical ? VALUE_W + 4 : 12,
+          height: vertical ? 12 : 16,
+          marginLeft: vertical ? -(VALUE_W + 4) / 2 : -6,
+          marginTop: vertical ? -6 : -8,
+          borderRadius: vertical ? 4 : 999,
+          border: "2px solid #fff",
+          boxShadow: "0 0 0 1px rgba(0,0,0,0.6)",
+          pointerEvents: "none",
+        }}
+      />
+    </div>
+  );
+}
+
+/** A left-to-right gradient through the colours a track would pick. */
+function gradient(stops: string[], vertical = false): string {
+  return `linear-gradient(${vertical ? "to top" : "to right"}, ${stops.join(", ")})`;
+}
+
+/**
+ * The wheel's third axis, as the tall slider beside it.
+ *
+ * Named "Brightness" rather than "Value" and that is not decoration: the HSV
+ * model's own V channel is in the numeric row below, so two `role="slider"`
+ * nodes would otherwise carry the identical accessible name and a screen
+ * reader would offer the same control twice with no way to tell them apart.
+ * Brightness is HSV's V under the name Photoshop's "B" has always used.
+ */
+function ValueSlider({ hsv, onChange }: { hsv: Hsv; onChange: (v: number) => void }) {
+  const top = hsvToHex({ ...hsv, v: 1 });
+  return (
+    <Slider
+      name="Brightness"
+      valueText={`${Math.round(hsv.v * 100)}%`}
+      min={0}
+      max={1}
+      step={0.01}
+      value={hsv.v}
+      vertical
+      trackCss={gradient(["#000000", top], true)}
+      onChange={onChange}
+    />
+  );
+}
+
+function ChannelSlider({
+  channel,
+  model,
+  values,
+  index,
+  onChange,
+}: {
+  channel: ColorChannel;
+  model: ColorModel;
+  values: number[];
+  index: number;
+  onChange: (next: number) => void;
+}) {
+  // A chroma slider's real end is where sRGB runs out, not the model's nominal
+  // maximum — otherwise the last third of the track picks nothing and the
+  // per-channel clamp shifts the hue while it happens.
+  const max = Math.min(channel.max, model.ceiling?.(values, index) ?? Infinity);
+  const shown = (values[index] * channel.scale).toFixed(channel.places);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <span
+        aria-hidden
+        style={{
+          width: 12,
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-10)",
+          color: "var(--fg-2)",
+        }}
+      >
+        {channel.label}
+      </span>
+      <Slider
+        // Prefixed with the model, because four models are one click apart and
+        // "Hue" alone does not say whether you are moving HSV's or OKLCh's —
+        // which are different angles on the same colour.
+        name={`${model.label} ${channel.name.toLowerCase()}`}
+        valueText={`${shown}${channel.unit}`}
+        min={channel.min}
+        max={max}
+        step={channel.step}
+        value={Math.min(values[index], max)}
+        shownValue={Number(shown) / channel.scale}
+        trackCss={gradient(trackStops(model, values, index))}
+        onChange={onChange}
+      />
+      <span
+        style={{
+          width: 38,
+          textAlign: "right",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-10)",
+          color: "var(--fg-1)",
+        }}
+      >
+        {shown}
+        {channel.unit}
+      </span>
+    </div>
+  );
+}
+
+// ─── Hex + contrast ──────────────────────────────────────────────────────────
+
+function HexRow({
+  value,
+  onChange,
+  contrast,
+}: {
+  value: string;
+  onChange: (hex: string) => void;
+  contrast?: { against: string; label: string };
+}) {
+  const [draft, setDraft] = React.useState(value);
+  React.useEffect(() => setDraft(value), [value]);
+
+  const commit = () => {
+    const hex = normalizeHex(draft);
+    if (hex) onChange(hex);
+    else setDraft(value);
+  };
+
+  const ratio = contrast ? contrastOf(value, contrast.against) : null;
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <input
+        aria-label="Hex"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit();
+            e.stopPropagation();
+          }
+          // Every other key stays local: the popover lives inside a dialog and
+          // the dispatcher must not read typing as chords.
+          if (e.key !== "Escape") e.stopPropagation();
+        }}
+        spellCheck={false}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: "var(--bg-1)",
+          border: "1px solid var(--border-1)",
+          borderRadius: "var(--r-2)",
+          outline: "none",
+          color: "var(--fg-0)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-11)",
+          padding: "3px 6px",
+        }}
+      />
+      {ratio !== null && (
+        <span
+          data-testid="colorpicker-contrast"
+          title={`Contrast against ${contrast!.label}: ${ratio.toFixed(2)}:1`}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 3,
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-10)",
+            color:
+              ratio < 3
+                ? "var(--git-removed)"
+                : ratio < 4.5
+                  ? "var(--git-modified)"
+                  : "var(--fg-3)",
+          }}
+        >
+          {ratio < 4.5 && <PGIcon name="warn" size={10} />}
+          {ratio.toFixed(1)}:1
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * WCAG relative-luminance contrast, the same formula `theme/contrast.ts` uses.
+ *
+ * Duplicated rather than imported because `src/design/` does not reach into
+ * `features/` for domain logic, and this is four lines of a published spec. The
+ * theme editor's own findings still come from `theme/contrast.ts` — this only
+ * decorates the popover.
+ */
+function contrastOf(a: string, b: string): number | null {
+  const lum = (hex: string): number | null => {
+    const norm = normalizeHex(hex);
+    if (!norm) return null;
+    const ch = [1, 3, 5].map((i) => Number.parseInt(norm.slice(i, i + 2), 16) / 255);
+    const lin = ch.map((c) =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+    );
+    return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+  };
+  const la = lum(a);
+  const lb = lum(b);
+  if (la === null || lb === null) return null;
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+// ─── Swatch rows ─────────────────────────────────────────────────────────────
+
+function SwatchRow({
+  heading,
+  items,
+  current,
+  onPick,
+}: {
+  heading: string;
+  items: ColorSwatchOption[];
+  current: string;
+  onPick: (hex: string) => void;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-10)",
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          color: "var(--fg-3)",
+          marginBottom: 4,
+        }}
+      >
+        {heading}
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
+        {items.map((s, i) => (
+          <button
+            key={`${s.hex}-${i}`}
+            type="button"
+            aria-label={`${s.label}${s.label === s.hex ? "" : ` (${s.hex})`}`}
+            title={`${s.label} — ${s.hex}`}
+            onClick={() => onPick(s.hex)}
+            style={{
+              width: 16,
+              height: 16,
+              padding: 0,
+              borderRadius: 3,
+              background: s.hex,
+              border:
+                s.hex.toLowerCase() === current.toLowerCase()
+                  ? "2px solid var(--accent)"
+                  : "1px solid var(--border-1)",
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/design/colorWheel.test.ts
+++ b/src/design/colorWheel.test.ts
@@ -1,0 +1,176 @@
+// The colour wheel's geometry — PURE arithmetic, no React and no DOM, for the
+// same reason `selectPos.ts` and `paneSize.ts` sit beside their components:
+// jsdom performs no layout, so a rendered wheel measures 0×0 and every
+// assertion a component test could make about where the cursor went would be
+// made against zeroes.
+//
+// Orientation is the thing worth pinning. Hue 0 at the right, increasing
+// counter-clockwise, is invisible in code and obvious on screen, and getting it
+// wrong mirrors the whole wheel while every round-trip test still passes.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  paintWheelRgba,
+  sliderFraction,
+  sliderValue,
+  wheelHueSat,
+  wheelHueSatClamped,
+  wheelPoint,
+} from "./colorWheel";
+
+describe("wheelPoint", () => {
+  it("puts hue 0 on the right rim", () => {
+    const p = wheelPoint(0, 1, 100);
+    expect(p.x).toBeCloseTo(100, 6);
+    expect(p.y).toBeCloseTo(0, 6);
+  });
+
+  it("runs counter-clockwise, so hue 90 is straight up", () => {
+    const p = wheelPoint(90, 1, 100);
+    expect(p.x).toBeCloseTo(0, 6);
+    // Screen coordinates: up is NEGATIVE y.
+    expect(p.y).toBeCloseTo(-100, 6);
+  });
+
+  it("collapses every hue to the centre at zero saturation", () => {
+    for (const h of [0, 90, 200, 359]) {
+      expect(wheelPoint(h, 0, 100)).toEqual({ x: 0, y: 0 });
+    }
+  });
+
+  it("places saturation linearly along the radius", () => {
+    expect(wheelPoint(0, 0.5, 100).x).toBeCloseTo(50, 6);
+  });
+});
+
+describe("wheelHueSat", () => {
+  it("inverts wheelPoint", () => {
+    for (const h of [0, 37, 90, 180, 275, 359]) {
+      for (const s of [0.15, 0.5, 1]) {
+        const p = wheelPoint(h, s, 100);
+        const back = wheelHueSat(p.x, p.y, 100)!;
+        expect(back.h).toBeCloseTo(h, 4);
+        expect(back.s).toBeCloseTo(s, 6);
+      }
+    }
+  });
+
+  it("refuses a point outside the disc", () => {
+    expect(wheelHueSat(101, 0, 100)).toBeNull();
+    expect(wheelHueSat(80, 80, 100)).toBeNull();
+  });
+});
+
+describe("wheelHueSatClamped", () => {
+  it("pins a drag that left the disc to the rim, keeping its angle", () => {
+    // A pointer that runs off the wheel mid-drag must keep picking the hue it
+    // is pointing at, not stop dead or jump back to the centre.
+    const far = wheelHueSatClamped(400, 0, 100);
+    expect(far.s).toBe(1);
+    expect(far.h).toBeCloseTo(0, 6);
+
+    const up = wheelHueSatClamped(0, -400, 100);
+    expect(up.s).toBe(1);
+    expect(up.h).toBeCloseTo(90, 6);
+  });
+
+  it("leaves a point inside the disc alone", () => {
+    const inside = wheelHueSatClamped(50, 0, 100);
+    expect(inside.s).toBeCloseTo(0.5, 6);
+  });
+
+  it("answers the centre without dividing by zero", () => {
+    const c = wheelHueSatClamped(0, 0, 100);
+    expect(c.s).toBe(0);
+    expect(Number.isFinite(c.h)).toBe(true);
+  });
+});
+
+describe("paintWheelRgba", () => {
+  const size = 65; // odd, so there is an exact centre pixel
+  const paint = () => {
+    const data = new Uint8ClampedArray(size * size * 4);
+    paintWheelRgba(data, size);
+    return data;
+  };
+  const at = (data: Uint8ClampedArray, x: number, y: number) => {
+    const i = (y * size + x) * 4;
+    return { r: data[i], g: data[i + 1], b: data[i + 2], a: data[i + 3] };
+  };
+
+  it("paints the centre white — zero saturation at full value", () => {
+    const c = (size - 1) / 2;
+    const px = at(paint(), c, c);
+    expect(px.a).toBe(255);
+    expect(px.r).toBeGreaterThan(250);
+    expect(px.g).toBeGreaterThan(250);
+    expect(px.b).toBeGreaterThan(250);
+  });
+
+  it("paints the right rim red, which is what fixes the orientation", () => {
+    const c = (size - 1) / 2;
+    const px = at(paint(), size - 2, c);
+    expect(px.r).toBeGreaterThan(px.g);
+    expect(px.r).toBeGreaterThan(px.b);
+  });
+
+  it("paints the top green-ish, not blue — counter-clockwise, not clockwise", () => {
+    const c = (size - 1) / 2;
+    const px = at(paint(), c, 1);
+    expect(px.g).toBeGreaterThan(px.b);
+  });
+
+  it("leaves the corners transparent", () => {
+    const data = paint();
+    expect(at(data, 0, 0).a).toBe(0);
+    expect(at(data, size - 1, size - 1).a).toBe(0);
+  });
+
+  it("feathers the rim instead of stair-stepping it", () => {
+    // An alpha of exactly 0 or 255 everywhere means a hard edge, which reads
+    // as a cog rather than a circle at this size.
+    const data = paint();
+    let partial = 0;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] > 0 && data[i] < 255) partial++;
+    }
+    expect(partial).toBeGreaterThan(0);
+  });
+});
+
+describe("sliderValue", () => {
+  it("maps a position along the track onto the range", () => {
+    expect(sliderValue(0, 200, 0, 360)).toBe(0);
+    expect(sliderValue(100, 200, 0, 360)).toBe(180);
+    expect(sliderValue(200, 200, 0, 360)).toBe(360);
+  });
+
+  it("clamps a pointer that ran past either end", () => {
+    expect(sliderValue(-40, 200, 0, 360)).toBe(0);
+    expect(sliderValue(999, 200, 0, 360)).toBe(360);
+  });
+
+  it("answers the minimum for a track with no length", () => {
+    // A slider measured before layout: 0 width must not produce NaN, which
+    // would poison the colour and blank the whole popover.
+    expect(sliderValue(50, 0, 0, 360)).toBe(0);
+  });
+});
+
+describe("sliderFraction", () => {
+  it("reports where the handle belongs, 0 to 1", () => {
+    expect(sliderFraction(180, 0, 360)).toBeCloseTo(0.5, 6);
+    expect(sliderFraction(0, 0, 360)).toBe(0);
+    expect(sliderFraction(360, 0, 360)).toBe(1);
+  });
+
+  it("clamps a value from outside the range", () => {
+    expect(sliderFraction(-10, 0, 360)).toBe(0);
+    expect(sliderFraction(400, 0, 360)).toBe(1);
+  });
+
+  it("answers zero for an empty range", () => {
+    expect(sliderFraction(5, 3, 3)).toBe(0);
+  });
+});

--- a/src/design/colorWheel.ts
+++ b/src/design/colorWheel.ts
@@ -1,0 +1,137 @@
+// Where things are on a colour wheel and along a slider — PURE arithmetic, no
+// React and no DOM, for the reason `selectPos.ts` and `paneSize.ts` give: jsdom
+// performs no layout, so a component test measures a rendered wheel as 0×0 and
+// could only ever assert about zeroes.
+//
+// Conventions, both of them invisible in code and glaring on screen:
+//
+//   * Hue 0 is at the RIGHT and increases COUNTER-CLOCKWISE. Mirror it and
+//     every round-trip test still passes while the wheel reads backwards.
+//   * Coordinates are offsets from the wheel's CENTRE, in CSS pixels, with +y
+//     pointing DOWN the way the DOM does. Callers subtract the centre before
+//     asking and add it back before drawing.
+
+import { hsvToRgb } from "@/lib/color";
+
+const clamp = (n: number, lo: number, hi: number) => (n < lo ? lo : n > hi ? hi : n);
+const DEG = 180 / Math.PI;
+
+/** Where the cursor for this hue and saturation sits, relative to the centre. */
+export function wheelPoint(h: number, s: number, radius: number): { x: number; y: number } {
+  const a = h / DEG;
+  const r = clamp(s, 0, 1) * radius;
+  // `+ 0` folds away the negative zeroes trigonometry leaves at the axes
+  // (`Math.cos(Math.PI) * 0` is `-0`). Nothing renders differently, but it
+  // keeps "zero saturation is exactly the centre" true as an equality rather
+  // than only as an approximation.
+  return { x: Math.cos(a) * r + 0, y: -Math.sin(a) * r + 0 };
+}
+
+/**
+ * How far past the rim still counts as on it.
+ *
+ * `wheelPoint(h, 1, r)` comes back at `r + 1e-14` for most angles, so a strict
+ * `dist > radius` refuses the fully-saturated rim it just produced — the wheel
+ * would go dead in a one-float-wide ring exactly where the pure colours are.
+ */
+const RIM_EPS = 1e-9;
+
+/** The hue and saturation a point names, or null when it is off the disc. */
+export function wheelHueSat(
+  x: number,
+  y: number,
+  radius: number,
+): { h: number; s: number } | null {
+  const dist = Math.hypot(x, y);
+  if (dist > radius + RIM_EPS) return null;
+  return { h: angleOf(x, y), s: radius === 0 ? 0 : Math.min(1, dist / radius) };
+}
+
+/**
+ * The same, but a point outside the disc is pinned to the rim rather than
+ * refused.
+ *
+ * This is the one a DRAG uses. A pointer that slips off the wheel mid-gesture
+ * must keep picking the hue it is pointing at — stopping dead at the rim, or
+ * worse reading the miss as "no colour", is what makes a wheel feel broken
+ * exactly when someone is trying to reach full saturation.
+ */
+export function wheelHueSatClamped(
+  x: number,
+  y: number,
+  radius: number,
+): { h: number; s: number } {
+  const dist = Math.hypot(x, y);
+  return {
+    h: angleOf(x, y),
+    s: radius === 0 ? 0 : Math.min(1, dist / radius),
+  };
+}
+
+/** Screen-space offset → hue degrees in `[0, 360)`. The centre answers 0. */
+function angleOf(x: number, y: number): number {
+  if (x === 0 && y === 0) return 0;
+  const deg = Math.atan2(-y, x) * DEG;
+  return deg < 0 ? deg + 360 : deg;
+}
+
+/** How wide the rim's alpha ramp is, in pixels. */
+const FEATHER = 1.2;
+
+/**
+ * Paint the wheel at FULL VALUE into an RGBA buffer of `size`×`size`.
+ *
+ * Full value only, and that is the whole performance story. HSV's value scales
+ * all three channels linearly, so `hsv(h, s, v)` is exactly `hsv(h, s, 1)`
+ * composited under black at alpha `1 - v` — which means the value slider costs
+ * one composite of an already-painted bitmap instead of re-running this loop.
+ * At the sizes a popover uses that is the difference between a wheel that
+ * tracks the pointer and one that hitches on every frame.
+ *
+ * The rim gets an alpha ramp rather than a hard cut: at 170-odd pixels across,
+ * an aliased edge reads as a cog, not a circle.
+ */
+export function paintWheelRgba(data: Uint8ClampedArray, size: number): void {
+  const radius = size / 2;
+  const cx = (size - 1) / 2;
+  const cy = (size - 1) / 2;
+
+  for (let py = 0; py < size; py++) {
+    for (let px = 0; px < size; px++) {
+      const i = (py * size + px) * 4;
+      const dx = px - cx;
+      const dy = py - cy;
+      const dist = Math.hypot(dx, dy);
+      if (dist > radius) {
+        data[i + 3] = 0;
+        continue;
+      }
+      const { r, g, b } = hsvToRgb({
+        h: angleOf(dx, dy),
+        s: Math.min(1, dist / radius),
+        v: 1,
+      });
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = Math.round(255 * clamp((radius - dist) / FEATHER, 0, 1));
+    }
+  }
+}
+
+/** The value a pointer `pos` pixels along a `length`-pixel track picks. */
+export function sliderValue(
+  pos: number,
+  length: number,
+  min: number,
+  max: number,
+): number {
+  if (length <= 0) return min;
+  return min + (max - min) * clamp(pos / length, 0, 1);
+}
+
+/** Where a value's handle belongs along its track, 0 to 1. */
+export function sliderFraction(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return clamp((value - min) / (max - min), 0, 1);
+}

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -5,6 +5,7 @@ export * from "./primitives";
 export * from "./git-components";
 export * from "./chrome";
 export * from "./context-menu";
+export * from "./color-picker";
 export * from "./dialog";
 export * from "./ui-helpers";
 export * from "./empty-state";

--- a/src/features/settings/theme/ColorEditor.tsx
+++ b/src/features/settings/theme/ColorEditor.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 
-import { THEME_COLOR_FIELDS, type ThemeColors } from "@/features/settings/useSettingsStore";
+import { PGColorSwatch, type ColorSwatchOption } from "@/design";
+import {
+  THEME_COLOR_FIELDS,
+  useSettingsStore,
+  type ThemeColors,
+} from "@/features/settings/useSettingsStore";
 import { normalizeHex } from "@/lib/color";
+
+import { CONTRAST_PAIRS } from "./contrast";
 
 export function ColorEditor({
   colors,
@@ -65,6 +72,8 @@ export function ColorEditor({
                   onPatch({ [f.key]: v } as Partial<ThemeColors>)
                 }
                 badge={badgeFor?.(f.key)}
+                palette={colors}
+                slot={f.key}
               />
             ))}
           </div>
@@ -80,21 +89,40 @@ export function ColorField({
   value,
   onChange,
   badge,
+  palette,
+  slot,
 }: {
   label: string;
   hint?: string;
   value: string;
   onChange: (v: string) => void;
   badge?: React.ReactNode;
+  /**
+   * The whole draft, offered inside the picker as swatches.
+   *
+   * "Make the border match the panel" is the most-used move in here, and
+   * without it that means reading a hex off one row and typing it into another.
+   */
+  palette?: ThemeColors;
+  /** Which slot this edits, for the picker's contrast partner. */
+  slot?: keyof ThemeColors;
 }) {
   const [draft, setDraft] = React.useState(value);
   React.useEffect(() => setDraft(value), [value]);
+  const recentColors = useSettingsStore((s) => s.recentColors);
+  const pushRecentColor = useSettingsStore((s) => s.pushRecentColor);
 
   const commitHex = (v: string) => {
     const normalized = normalizeHex(v);
     if (!normalized) return;
     onChange(normalized);
   };
+
+  const swatches: ColorSwatchOption[] | undefined = palette
+    ? THEME_COLOR_FIELDS.map((f) => ({ hex: palette[f.key], label: f.label }))
+    : undefined;
+
+  const contrast = slot ? contrastPartner(slot, palette) : null;
 
   return (
     <div
@@ -109,34 +137,16 @@ export function ColorField({
       }}
       title={hint}
     >
-      <label
-        style={{
-          position: "relative",
-          width: 28,
-          height: 28,
-          borderRadius: "var(--r-3)",
-          border: "1px solid var(--border-1)",
-          background: value,
-          cursor: "pointer",
-          flexShrink: 0,
-          overflow: "hidden",
-          boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.15)",
-        }}
-      >
-        <input
-          type="color"
-          aria-label={`${label} colour picker`}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          style={{
-            position: "absolute",
-            inset: 0,
-            opacity: 0,
-            cursor: "pointer",
-            border: "none",
-          }}
-        />
-      </label>
+      <PGColorSwatch
+        label={label}
+        value={value}
+        onChange={onChange}
+        onCommit={pushRecentColor}
+        swatches={swatches}
+        recent={recentColors}
+        contrast={contrast ?? undefined}
+        title={hint}
+      />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
@@ -185,5 +195,25 @@ export function ColorField({
       {badge}
     </div>
   );
+}
+
+/**
+ * The colour this slot is read against, for the picker's live ratio.
+ *
+ * Reads BOTH sides of a `CONTRAST_PAIRS` entry, unlike the row's own badge,
+ * which only fires for the `a` side. A background is exactly what someone drags
+ * while watching whether the text on it still reads, so `bg0` has to know about
+ * `fg0` — the pair is symmetric even though the list only spells it one way.
+ */
+function contrastPartner(
+  slot: keyof ThemeColors,
+  palette?: ThemeColors,
+): { against: string; label: string } | null {
+  if (!palette) return null;
+  const pair = CONTRAST_PAIRS.find((p) => p.a === slot || p.b === slot);
+  if (!pair) return null;
+  const other = pair.a === slot ? pair.b : pair.a;
+  const label = THEME_COLOR_FIELDS.find((f) => f.key === other)?.label ?? other;
+  return { against: palette[other], label };
 }
 

--- a/src/features/settings/theme/ColorEditor.tsx
+++ b/src/features/settings/theme/ColorEditor.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { THEME_COLOR_FIELDS, type ThemeColors } from "@/features/settings/useSettingsStore";
+import { normalizeHex } from "@/lib/color";
 
 export function ColorEditor({
   colors,
@@ -186,14 +187,3 @@ export function ColorField({
   );
 }
 
-export function normalizeHex(v: string): string | null {
-  const raw = v.trim().toLowerCase().replace(/^#/, "");
-  if (/^[0-9a-f]{3}$/.test(raw)) {
-    return `#${raw
-      .split("")
-      .map((ch) => ch + ch)
-      .join("")}`;
-  }
-  if (/^[0-9a-f]{6}$/.test(raw)) return `#${raw}`;
-  return null;
-}

--- a/src/features/settings/theme/ThemeEditorDialog.test.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.test.tsx
@@ -218,3 +218,106 @@ describe("ThemeEditorDialog", () => {
     expect(ed().colors.bg0).not.toBe(dark.colors.bg0);
   });
 });
+
+describe("ThemeEditorDialog — the colour picker", () => {
+  beforeEach(() => {
+    resetDialogs();
+    ed().close();
+    useSettingsStore.getState().reset();
+  });
+
+  const swatchFor = (label: RegExp) =>
+    screen.getByRole("button", { name: label });
+  const picker = () => document.querySelector("[data-pg-colorpicker]");
+
+  it("hands every slot a real picker instead of the host's colour dialog", () => {
+    // The whole point: `<input type="color">` was a hand-off to whatever the
+    // webview felt like showing — an unthemed OS panel on macOS, and on
+    // WebKitGTK a control of exactly the shape that silently does nothing.
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    expect(document.querySelector('input[type="color"]')).toBeNull();
+    fireEvent.click(swatchFor(/^background · base — #1a1d24/i));
+    expect(picker()).toBeTruthy();
+  });
+
+  it("offers the theme's own palette inside the picker", () => {
+    // "Make the border match the panel" is the most-used move in a theme
+    // editor, and without this it means reading a hex off one row and typing
+    // it into another.
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^border · subtle/i));
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Background · panel \(#1e222a\)$/ }),
+    );
+    expect(ed().colors.border0).toBe("#1e222a");
+  });
+
+  it("measures a paired slot against its partner while it is being dragged", () => {
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^foreground · primary/i));
+    // fg0 against bg0 — the pair CONTRAST_PAIRS names first.
+    expect(screen.getByTestId("colorpicker-contrast")).toBeTruthy();
+  });
+
+  it("measures a BACKGROUND against its text, not only the text against it", () => {
+    // A background is exactly what you drag while watching readability, so the
+    // partner lookup has to read both sides of a pair.
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^background · base/i));
+    expect(screen.getByTestId("colorpicker-contrast")).toBeTruthy();
+  });
+
+  it("says nothing about contrast for a slot that is in no pair", () => {
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^logo · bill/i));
+    expect(screen.queryByTestId("colorpicker-contrast")).toBeNull();
+  });
+
+  it("remembers a colour once it is settled on, not once per drag frame", async () => {
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^accent · on-ink/i));
+    const hex = screen.getByLabelText("Hex");
+    fireEvent.change(hex, { target: { value: "#ff8800" } });
+    fireEvent.keyDown(hex, { key: "Enter" });
+    // Still open, so nothing is remembered yet.
+    expect(useSettingsStore.getState().recentColors).toEqual([]);
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.mouseDown(document.body);
+    expect(useSettingsStore.getState().recentColors).toEqual(["#ff8800"]);
+  });
+
+  it("offers those remembered colours back", () => {
+    useSettingsStore.getState().pushRecentColor("#ff8800");
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+    fireEvent.click(swatchFor(/^border · default/i));
+    fireEvent.click(screen.getByRole("button", { name: /^#ff8800$/ }));
+    expect(ed().colors.border1).toBe("#ff8800");
+  });
+
+  it("gives the Accent field the same picker as the eighteen", () => {
+    // The guided start's accent field is a ColorField too, and a picker that
+    // appeared on the collapsed rows but not on the one field everybody edits
+    // would be the feature missing from where it matters most.
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(swatchFor(/^accent — #5aa8e8/i));
+    expect(picker()).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /^Background · panel \(#1e222a\)$/ }),
+    ).toBeTruthy();
+  });
+});

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -201,6 +201,12 @@ export function ThemeEditorDialog() {
                   value={ed.colors.accent}
                   onChange={(v) => ed.applyBase(ed.baseId, v)}
                   badge={<RatioBadge a="accentInk" b="accent" colors={ed.colors} />}
+                  // The guided start's one field gets the same picker as the
+                  // eighteen behind the disclosure — a wheel that appeared on
+                  // the collapsed rows but not on the field everybody edits
+                  // would be missing from where it matters most.
+                  palette={ed.colors}
+                  slot="accent"
                 />
                 <div
                   style={{

--- a/src/features/settings/theme/contrast.ts
+++ b/src/features/settings/theme/contrast.ts
@@ -1,6 +1,6 @@
 import type { ThemeColors } from "@/features/settings/useSettingsStore";
 
-import { normalizeHex } from "./ColorEditor";
+import { normalizeHex } from "@/lib/color";
 
 /**
  * WCAG contrast, for the four pairs that decide whether the app is readable.

--- a/src/features/settings/theme/deriveTheme.ts
+++ b/src/features/settings/theme/deriveTheme.ts
@@ -1,6 +1,6 @@
 import type { ThemeColors, ThemeDef } from "@/features/settings/useSettingsStore";
 
-import { normalizeHex } from "./ColorEditor";
+import { normalizeHex } from "@/lib/color";
 import { contrastRatio } from "./contrast";
 
 /**

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -119,7 +119,16 @@ const PORTABLE = [
 // `settingsPage` (#settings-nav) says where one person was standing in the
 // side menu, not how the app should behave — the same reasoning as
 // `lastCreateDir`.
-const EXCLUDED = ["lastCreateDir", "identities", "terminalShell", "settingsPage"];
+const EXCLUDED = [
+  "lastCreateDir",
+  "identities",
+  "terminalShell",
+  "settingsPage",
+  // The colour picker's Recent row: one person's history, not a description of
+  // how the app behaves. The custom THEMES those colours went into are
+  // portable — that is the finished artefact, this is the scratch pad.
+  "recentColors",
+];
 
 describe("the exported key set", () => {
   it("is exactly the schema minus the deny-list", async () => {

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -503,3 +503,92 @@ describe("useSettingsStore custom actions", () => {
     expect(useSettingsStore.getState().customActions).toEqual([]);
   });
 });
+
+describe("recentColors", () => {
+  it("starts empty, so the picker shows no row at all", async () => {
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().recentColors).toEqual([]);
+  });
+
+  it("puts the newest colour first", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().pushRecentColor("#ff8800");
+    useSettingsStore.getState().pushRecentColor("#123456");
+    expect(useSettingsStore.getState().recentColors).toEqual(["#123456", "#ff8800"]);
+  });
+
+  it("moves a colour already in the list rather than repeating it", async () => {
+    const { useSettingsStore } = await freshStore();
+    for (const hex of ["#ff8800", "#123456", "#ff8800"]) {
+      useSettingsStore.getState().pushRecentColor(hex);
+    }
+    expect(useSettingsStore.getState().recentColors).toEqual(["#ff8800", "#123456"]);
+  });
+
+  it("canonicalizes before comparing, so one colour is one entry", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().pushRecentColor("#FF8800");
+    useSettingsStore.getState().pushRecentColor("f80");
+    expect(useSettingsStore.getState().recentColors).toEqual(["#ff8800"]);
+  });
+
+  it("keeps at most ten", async () => {
+    const { useSettingsStore } = await freshStore();
+    for (let i = 0; i < 15; i++) {
+      useSettingsStore.getState().pushRecentColor(`#0000${i.toString(16)}0`);
+    }
+    expect(useSettingsStore.getState().recentColors).toHaveLength(10);
+  });
+
+  it("ignores a value that is not a colour", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().pushRecentColor("rebeccapurple");
+    expect(useSettingsStore.getState().recentColors).toEqual([]);
+  });
+
+  it("survives a reload", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().pushRecentColor("#ff8800");
+    const again = await freshStore();
+    expect(again.useSettingsStore.getState().recentColors).toEqual(["#ff8800"]);
+  });
+
+  it("repairs a stored list of junk instead of trusting it", async () => {
+    // Array-valued, so the scalar type-guard in coerceSettings never looked at
+    // it: this arrives from localStorage — or a shared settings file — exactly
+    // as it was written, and an unusable entry must cost only itself.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ recentColors: ["#ABC", 7, null, "nope", "#123456"] }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().recentColors).toEqual(["#aabbcc", "#123456"]);
+  });
+
+  it("falls back to empty when the stored value is not a list", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ recentColors: "#ff8800" }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().recentColors).toEqual([]);
+  });
+
+  it("truncates an over-long stored list", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        recentColors: Array.from({ length: 40 }, (_, i) => `#0000${(i % 16).toString(16)}0`),
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().recentColors.length).toBeLessThanOrEqual(10);
+  });
+
+  it("stays out of a settings export — it is this machine's history", async () => {
+    // An export is a file people SHARE. Which colours someone tried last week
+    // is not a preference describing how the app should behave, and a colleague
+    // importing it gains nothing and loses their own list.
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().pushRecentColor("#ff8800");
+    const bag = JSON.parse(useSettingsStore.getState().exportSettings());
+    expect(JSON.stringify(bag)).not.toContain("ff8800");
+  });
+});

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { normalizeHex } from "@/lib/color";
 import type { PullMode } from "@/lib/tauri";
 import { type DateFormat, isDateFormat } from "@/lib/commitDate";
 import { DATE_COL_W } from "@/design/graph-geometry";
@@ -1009,6 +1010,18 @@ interface PersistedState {
    * why `resolvePageId` guards the read side.
    */
   settingsPage: SettingsPageId;
+  /**
+   * Colours chosen in `PGColorSwatch` recently, newest first, canonical hex.
+   *
+   * Incidental state rather than a setting — there is no control for it, so it
+   * joins no Settings page and `settings.index.test.tsx` has nothing to check.
+   * Array-valued, so the scalar type-guard in `coerceSettings` reads it as
+   * `"object"` and never looks inside: it gets its own normalizer, the same
+   * call `customThemes` and `headMarks` made.
+   *
+   * NOT portable — see NON_PORTABLE_KEYS.
+   */
+  recentColors: string[];
 }
 
 export interface SettingsState extends PersistedState {
@@ -1040,6 +1053,15 @@ export interface SettingsState extends PersistedState {
    * in `main.tsx`; exported so a test can flip the OS without one.
    */
   syncSystemAppearance: (appearance: Appearance) => void;
+  /**
+   * Remember a colour the user settled on, newest first, de-duplicated and
+   * capped at [`RECENT_COLORS_MAX`].
+   *
+   * Called on COMMIT — when a picker closes on a colour that was kept — never
+   * on every frame of a drag, or the list would be ten neighbouring shades of
+   * the same blue.
+   */
+  pushRecentColor: (hex: string) => void;
   updateActiveColors: (patch: Partial<ThemeColors>) => void;
   saveAsNewTheme: (name: string) => ThemeDef;
   renameTheme: (id: string, name: string) => void;
@@ -1098,6 +1120,7 @@ const DEFAULTS: PersistedState = {
   updateChannel: "stable",
   lastCreateDir: "",
   settingsPage: FIRST_PAGE,
+  recentColors: [],
 };
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1169,6 +1192,14 @@ export const NON_PORTABLE_KEYS: readonly (keyof PersistedState)[] = [
    * colleague's Settings to an unrelated page on their next visit.
    */
   "settingsPage",
+  /**
+   * Recently picked colours. Denied for the same reason as `settingsPage`: it
+   * is one person's history, not a description of how the app should behave,
+   * and importing it would replace a colleague's own list with colours they
+   * have never used. The custom THEMES those colours went into are portable —
+   * that is the finished artefact, and this is the scratch pad.
+   */
+  "recentColors",
 ];
 
 /** `DEFAULTS`' keys minus the deny-list — exactly what an export carries. */
@@ -1326,6 +1357,32 @@ function normalizeCustomThemes(value: unknown, fallback: ThemeDef[]): ThemeDef[]
  * `BUILTIN_THEMES[0]`), so the worst case is the theme the person already had
  * rather than an app with no theme at all.
  */
+/** How many colours the picker's Recent row remembers. */
+export const RECENT_COLORS_MAX = 10;
+
+/**
+ * A stored `recentColors` into something the picker can render.
+ *
+ * Lenient in the same direction `normalizeCustomThemes` chose: an unusable
+ * entry costs only itself, because the alternative — dropping the list on one
+ * bad element — throws away nine good colours to punish a tenth. Every survivor
+ * goes through `normalizeHex`, so the list the picker compares against the
+ * current value is canonical and one colour can never appear twice under two
+ * spellings.
+ */
+function normalizeRecentColors(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const hex = normalizeHex(entry);
+    if (!hex || out.includes(hex)) continue;
+    out.push(hex);
+    if (out.length === RECENT_COLORS_MAX) break;
+  }
+  return out;
+}
+
 function normalizeThemePreference(value: unknown): ThemePreference {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return { ...DEFAULT_THEME_PREFERENCE };
@@ -1505,6 +1562,10 @@ function coerceSettings(
   // action saved before `surfaces` existed is carried forward as a palette
   // action, which is the only surface it ever had.
   out.customActions = coerceCustomActions(out.customActions) ?? base.customActions;
+
+  // Recently picked colours. Array-valued, so the scalar type-guard above never
+  // looked at them either.
+  out.recentColors = normalizeRecentColors(out.recentColors);
 
   // THEME PREFERENCE (#236). Runs after `customThemes` so both the repair and
   // the seed can see the theme list this payload actually brings.
@@ -1743,6 +1804,14 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     set({ activeThemeId });
     persist(snapshot(get()));
     applyResolved(get());
+  },
+
+  pushRecentColor(hex) {
+    const norm = normalizeHex(hex);
+    if (!norm) return;
+    const rest = get().recentColors.filter((c) => c !== norm);
+    set({ recentColors: [norm, ...rest].slice(0, RECENT_COLORS_MAX) });
+    persist(snapshot(get()));
   },
 
   updateActiveColors(patch) {

--- a/src/lib/color.test.ts
+++ b/src/lib/color.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES, THEME_COLOR_FIELDS } from "@/features/settings/useSettingsStore";
+import { srgbChromaCeiling } from "./cssColor";
+import {
+  COLOR_MODELS,
+  colorModel,
+  hexToHsv,
+  hexToRgb,
+  hslToRgb,
+  hsvToHex,
+  hsvToRgb,
+  normalizeHex,
+  rgbToHex,
+  rgbToHsl,
+  rgbToHsv,
+  trackStops,
+} from "./color";
+
+/** Every colour the built-in themes actually ship, as the round-trip corpus. */
+const THEME_HEXES = BUILTIN_THEMES.flatMap((t) =>
+  THEME_COLOR_FIELDS.map((f) => t.colors[f.key]),
+);
+
+const EDGES = ["#000000", "#ffffff", "#ff0000", "#00ff00", "#0000ff", "#808080"];
+
+describe("hex", () => {
+  it("writes six lowercase digits with a leading hash", () => {
+    expect(rgbToHex({ r: 0, g: 0, b: 0 })).toBe("#000000");
+    expect(rgbToHex({ r: 90, g: 168, b: 232 })).toBe("#5aa8e8");
+    expect(rgbToHex({ r: 255, g: 255, b: 255 })).toBe("#ffffff");
+  });
+
+  it("rounds and clamps a channel rather than emitting a bad digit", () => {
+    expect(rgbToHex({ r: 89.6, g: -3, b: 999 })).toBe("#5a00ff");
+  });
+
+  it("reads the three- and six-digit forms, with or without the hash", () => {
+    expect(hexToRgb("#5aa8e8")).toEqual({ r: 90, g: 168, b: 232 });
+    expect(hexToRgb("5aa8e8")).toEqual({ r: 90, g: 168, b: 232 });
+    expect(hexToRgb("#FFF")).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("returns null for a string that is not a colour", () => {
+    for (const junk of ["", "#12", "#12345", "rebeccapurple", "#gggggg"]) {
+      expect(hexToRgb(junk)).toBeNull();
+    }
+  });
+
+  it("normalizes to the canonical form", () => {
+    expect(normalizeHex(" #ABC ")).toBe("#aabbcc");
+    expect(normalizeHex("5AA8E8")).toBe("#5aa8e8");
+    expect(normalizeHex("nope")).toBeNull();
+  });
+});
+
+describe("hsv", () => {
+  it("round-trips every colour the built-in themes ship", () => {
+    for (const hex of [...THEME_HEXES, ...EDGES]) {
+      expect(hsvToHex(rgbToHsv(hexToRgb(hex)!))).toBe(hex);
+    }
+  });
+
+  it("puts the primaries on their own hue", () => {
+    expect(rgbToHsv({ r: 255, g: 0, b: 0 })).toEqual({ h: 0, s: 1, v: 1 });
+    expect(rgbToHsv({ r: 0, g: 255, b: 0 })).toEqual({ h: 120, s: 1, v: 1 });
+    expect(rgbToHsv({ r: 0, g: 0, b: 255 })).toEqual({ h: 240, s: 1, v: 1 });
+  });
+
+  it("reads a grey as zero saturation", () => {
+    expect(rgbToHsv({ r: 128, g: 128, b: 128 }).s).toBe(0);
+  });
+
+  it("clamps rather than wrapping an out-of-range hsv", () => {
+    expect(hsvToRgb({ h: 360, s: 1, v: 1 })).toEqual({ r: 255, g: 0, b: 0 });
+    expect(hsvToRgb({ h: 0, s: 2, v: -1 })).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe("hexToHsv", () => {
+  it("keeps the previous hue when the new colour is grey", () => {
+    // The bug this exists to prevent: drag saturation to zero and the cursor
+    // teleports to red, because a grey has no hue of its own to report.
+    const prev = { h: 206, s: 0.61, v: 0.91 };
+    expect(hexToHsv("#808080", prev).h).toBe(206);
+  });
+
+  it("keeps the previous hue AND saturation when the new colour is black", () => {
+    // Same bug one axis further in: value at zero discards both, so dragging
+    // back up returns a different colour than the one you left.
+    const prev = { h: 206, s: 0.61, v: 0.91 };
+    const at0 = hexToHsv("#000000", prev);
+    expect(at0.h).toBe(206);
+    expect(at0.s).toBe(0.61);
+    expect(at0.v).toBe(0);
+  });
+
+  it("takes the new colour's own hue when it has one", () => {
+    expect(hexToHsv("#00ff00", { h: 206, s: 0.61, v: 0.91 }).h).toBe(120);
+  });
+
+  it("falls back to black for an unreadable string", () => {
+    expect(hexToHsv("nope")).toEqual({ h: 0, s: 0, v: 0 });
+  });
+});
+
+describe("hsl", () => {
+  it("round-trips every colour the built-in themes ship", () => {
+    for (const hex of [...THEME_HEXES, ...EDGES]) {
+      const rgb = hexToRgb(hex)!;
+      expect(hslToRgb(rgbToHsl(rgb))).toEqual(rgb);
+    }
+  });
+
+  it("puts a mid grey at half lightness and no saturation", () => {
+    const hsl = rgbToHsl({ r: 128, g: 128, b: 128 });
+    expect(hsl.s).toBe(0);
+    expect(hsl.l).toBeCloseTo(128 / 255, 5);
+  });
+});
+
+describe("COLOR_MODELS", () => {
+  it("offers exactly the four the picker advertises", () => {
+    expect(COLOR_MODELS.map((m) => m.id)).toEqual(["hsv", "hsl", "rgb", "oklch"]);
+  });
+
+  it("round-trips every theme colour through every model", () => {
+    for (const model of COLOR_MODELS) {
+      for (const hex of [...THEME_HEXES, ...EDGES]) {
+        expect(model.write(model.read(hex))).toBe(hex);
+      }
+    }
+  });
+
+  it("moves the colour on a single step of any channel", () => {
+    // The anti-stall property. A step finer than one 8-bit level would leave
+    // the slider fighting the user: the handle moves, the colour does not, and
+    // the next render snaps the handle back where it started.
+    const hex = "#5aa8e8";
+    for (const model of COLOR_MODELS) {
+      const base = model.read(hex);
+      model.channels.forEach((ch, i) => {
+        const up = [...base];
+        up[i] = Math.min(ch.max, base[i] + ch.step);
+        const down = [...base];
+        down[i] = Math.max(ch.min, base[i] - ch.step);
+        expect(
+          model.write(up) !== hex || model.write(down) !== hex,
+          `${model.id}.${ch.key} does not move the colour in either direction`,
+        ).toBe(true);
+      });
+    }
+  });
+
+  it("names every channel with a range a slider can lay out", () => {
+    for (const model of COLOR_MODELS) {
+      expect(model.channels.length).toBeGreaterThanOrEqual(3);
+      for (const ch of model.channels) {
+        expect(ch.max).toBeGreaterThan(ch.min);
+        expect(ch.step).toBeGreaterThan(0);
+        expect(ch.label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("clamps a channel handed a value past its range", () => {
+    const rgb = colorModel("rgb");
+    expect(rgb.write([999, -5, 0])).toBe("#ff0000");
+  });
+
+  it("ends the oklch chroma track at the sRGB boundary", () => {
+    const oklch = colorModel("oklch");
+    const values = oklch.read("#5aa8e8");
+    const ceiling = oklch.ceiling!(values, 1);
+    expect(ceiling).toBeCloseTo(srgbChromaCeiling(values[0], values[2]), 6);
+    // And it is a real ceiling for THIS colour, not a constant.
+    expect(ceiling).toBeGreaterThan(values[1]);
+    expect(ceiling).toBeLessThan(0.4);
+  });
+
+  it("has no ceiling to report for the models whose ranges are fixed", () => {
+    for (const model of COLOR_MODELS.filter((m) => m.id !== "oklch")) {
+      expect(model.ceiling).toBeUndefined();
+    }
+  });
+});
+
+describe("trackStops", () => {
+  it("spans the channel from its own minimum to its own maximum", () => {
+    const hsv = colorModel("hsv");
+    const values = hsv.read("#5aa8e8");
+    const stops = trackStops(hsv, values, 0);
+    expect(stops.length).toBeGreaterThan(4);
+    expect(stops[0]).toBe(hsv.write([hsv.channels[0].min, values[1], values[2]]));
+    expect(stops[stops.length - 1]).toBe(
+      hsv.write([hsv.channels[0].max, values[1], values[2]]),
+    );
+  });
+
+  it("holds the other channels still", () => {
+    // A saturation track has to stay on the colour's own hue, or the gradient
+    // under the handle is not the colour the handle would pick.
+    const hsv = colorModel("hsv");
+    const values = hsv.read("#5aa8e8");
+    for (const stop of trackStops(hsv, values, 1)) {
+      const back = hsv.read(stop);
+      expect(back[2]).toBeCloseTo(values[2], 2);
+    }
+  });
+
+  it("walks a chroma track only as far as sRGB reaches", () => {
+    const oklch = colorModel("oklch");
+    const values = oklch.read("#5aa8e8");
+    const stops = trackStops(oklch, values, 1);
+    // The last stop is the boundary colour, not a clamped-and-hue-shifted one.
+    const lastC = oklch.read(stops[stops.length - 1])[1];
+    expect(lastC).toBeCloseTo(oklch.ceiling!(values, 1), 2);
+  });
+});

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,357 @@
+// Colour conversions and the picker's model registry, in TypeScript.
+//
+// The division of labour with `cssColor.ts` next door: that module PARSES what
+// CSS can say (including `oklch()`, which the Linux webview cannot) so a canvas
+// can be handed a colour. This one converts between the spaces a HUMAN moves —
+// hex, HSV, HSL, OKLCh — for `PGColorPicker`. The OKLab matrices live in
+// `cssColor.ts` and are imported here rather than copied: two sets of
+// Ottosson's constants in one tree is a drift waiting to happen.
+//
+// Everything here is pure and DOM-free, which is the point: the picker's
+// interesting behaviour is arithmetic (does a step move the colour, does a grey
+// keep its hue, where does sRGB run out), and arithmetic is testable without
+// laying out a wheel that jsdom would measure as 0×0 anyway.
+
+import { oklchToRgb, rgbToOklch, srgbChromaCeiling } from "./cssColor";
+
+/** sRGB, 0-255 per channel. Integers once it has been through [`rgbToHex`]. */
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Hue 0-360, saturation and value 0-1. The picker's own state. */
+export interface Hsv {
+  h: number;
+  s: number;
+  v: number;
+}
+
+/** Hue 0-360, saturation and lightness 0-1. */
+export interface Hsl {
+  h: number;
+  s: number;
+  l: number;
+}
+
+const clamp = (n: number, lo: number, hi: number) => (n < lo ? lo : n > hi ? hi : n);
+const byte = (n: number) => clamp(Math.round(n), 0, 255);
+
+// ─── Hex ─────────────────────────────────────────────────────────────────────
+
+/**
+ * sRGB → the canonical `#rrggbb`, always six lowercase digits.
+ *
+ * Canonical matters more than it looks: `ThemeColors` compares hex strings to
+ * decide whether a draft is still untouched, so `#FFF` and `#ffffff` being the
+ * same colour but different strings would make the theme editor's "Revert"
+ * offer itself against a draft nobody edited.
+ */
+export function rgbToHex(rgb: Rgb): string {
+  const hex = (n: number) => byte(n).toString(16).padStart(2, "0");
+  return `#${hex(rgb.r)}${hex(rgb.g)}${hex(rgb.b)}`;
+}
+
+/** `#abc`, `#aabbcc`, or either without the hash. Null for anything else. */
+export function hexToRgb(value: string): Rgb | null {
+  const raw = value.trim().toLowerCase().replace(/^#/, "");
+  if (!/^[0-9a-f]+$/.test(raw)) return null;
+  if (raw.length === 3) {
+    return {
+      r: Number.parseInt(raw[0] + raw[0], 16),
+      g: Number.parseInt(raw[1] + raw[1], 16),
+      b: Number.parseInt(raw[2] + raw[2], 16),
+    };
+  }
+  if (raw.length === 6) {
+    return {
+      r: Number.parseInt(raw.slice(0, 2), 16),
+      g: Number.parseInt(raw.slice(2, 4), 16),
+      b: Number.parseInt(raw.slice(4, 6), 16),
+    };
+  }
+  return null;
+}
+
+/** A user-typed colour as canonical `#rrggbb`, or null when it is not one. */
+export function normalizeHex(value: string): string | null {
+  const rgb = hexToRgb(value);
+  return rgb ? rgbToHex(rgb) : null;
+}
+
+// ─── HSV ─────────────────────────────────────────────────────────────────────
+
+export function rgbToHsv(rgb: Rgb): Hsv {
+  const r = rgb.r / 255;
+  const g = rgb.g / 255;
+  const b = rgb.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+
+  let h = 0;
+  if (d !== 0) {
+    if (max === r) h = 60 * (((g - b) / d) % 6);
+    else if (max === g) h = 60 * ((b - r) / d + 2);
+    else h = 60 * ((r - g) / d + 4);
+  }
+  return { h: h < 0 ? h + 360 : h, s: max === 0 ? 0 : d / max, v: max };
+}
+
+export function hsvToRgb(hsv: Hsv): Rgb {
+  const h = ((hsv.h % 360) + 360) % 360;
+  const s = clamp(hsv.s, 0, 1);
+  const v = clamp(hsv.v, 0, 1);
+  const c = v * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = v - c;
+  const sector = Math.floor(h / 60) % 6;
+  const [r, g, b] = (
+    [
+      [c, x, 0],
+      [x, c, 0],
+      [0, c, x],
+      [0, x, c],
+      [x, 0, c],
+      [c, 0, x],
+    ] as const
+  )[sector];
+  return { r: byte((r + m) * 255), g: byte((g + m) * 255), b: byte((b + m) * 255) };
+}
+
+export function hsvToHex(hsv: Hsv): string {
+  return rgbToHex(hsvToRgb(hsv));
+}
+
+/**
+ * A hex string as HSV, keeping whatever the previous HSV still knows.
+ *
+ * HSV loses information at two edges and the picker has to survive both. A grey
+ * has no hue: read it naively and the wheel's cursor teleports to red the
+ * instant saturation reaches zero. Black has neither hue nor saturation: drag
+ * value to the floor and back, and without this you come up somewhere else
+ * entirely. So the previous angle survives the trip, and only what the new
+ * colour genuinely determines is taken from it.
+ */
+export function hexToHsv(value: string, prev?: Hsv): Hsv {
+  const rgb = hexToRgb(value);
+  if (!rgb) return prev ? { ...prev, v: 0 } : { h: 0, s: 0, v: 0 };
+  const next = rgbToHsv(rgb);
+  if (!prev) return next;
+  return {
+    h: next.s === 0 ? prev.h : next.h,
+    s: next.v === 0 ? prev.s : next.s,
+    v: next.v,
+  };
+}
+
+// ─── HSL ─────────────────────────────────────────────────────────────────────
+
+export function rgbToHsl(rgb: Rgb): Hsl {
+  const { h, s: sv, v } = rgbToHsv(rgb);
+  const l = v * (1 - sv / 2);
+  const s = l === 0 || l === 1 ? 0 : (v - l) / Math.min(l, 1 - l);
+  return { h, s, l };
+}
+
+export function hslToRgb(hsl: Hsl): Rgb {
+  const l = clamp(hsl.l, 0, 1);
+  const s = clamp(hsl.s, 0, 1);
+  const v = l + s * Math.min(l, 1 - l);
+  return hsvToRgb({ h: hsl.h, s: v === 0 ? 0 : 2 * (1 - l / v), v });
+}
+
+// ─── The model registry ──────────────────────────────────────────────────────
+
+export interface ColorChannel {
+  /** Stable key, for a test and for React. */
+  key: string;
+  /** The one- or two-letter label beside the slider. */
+  label: string;
+  /** Spelt out for the slider's accessible name. */
+  name: string;
+  min: number;
+  max: number;
+  /** One arrow-key press. Never finer than one 8-bit level — see the test. */
+  step: number;
+  /** Suffix in the readout: `°`, `%`, or nothing. */
+  unit: string;
+  /** Decimal places in the readout. */
+  places: number;
+  /** Multiplier between the stored value and the readout (0-1 shown as 0-100). */
+  scale: number;
+}
+
+export interface ColorModel {
+  id: "hsv" | "hsl" | "rgb" | "oklch";
+  label: string;
+  channels: ColorChannel[];
+  /**
+   * The channel values for a colour, UNROUNDED.
+   *
+   * Unrounded on purpose: the readout rounds for display, but editing one
+   * channel keeps the others exactly as they were. Storing the rounded values
+   * instead would drag the colour a byte sideways every time you touched an
+   * unrelated slider.
+   */
+  read(hex: string): number[];
+  /** The colour those channel values name. Clamps; never throws. */
+  write(values: number[]): string;
+  /**
+   * A channel's real upper bound given the others, where it is not `max`.
+   *
+   * Only OKLCh has one: chroma's ceiling depends on lightness and hue, and a
+   * track that ignores it spends its last third doing nothing while the
+   * per-channel clamp shifts the hue.
+   */
+  ceiling?(values: number[], index: number): number;
+}
+
+const pct = (key: string, label: string, name: string): ColorChannel => ({
+  key,
+  label,
+  name,
+  min: 0,
+  max: 1,
+  // 1% — a hair under three 8-bit levels, so one arrow press always lands on a
+  // different colour.
+  step: 0.01,
+  unit: "%",
+  places: 0,
+  scale: 100,
+});
+
+const hueChannel: ColorChannel = {
+  key: "h",
+  label: "H",
+  name: "Hue",
+  min: 0,
+  max: 360,
+  step: 1,
+  unit: "°",
+  places: 0,
+  scale: 1,
+};
+
+const rgbChannel = (key: string, label: string, name: string): ColorChannel => ({
+  key,
+  label,
+  name,
+  min: 0,
+  max: 255,
+  step: 1,
+  unit: "",
+  places: 0,
+  scale: 1,
+});
+
+export const COLOR_MODELS: ColorModel[] = [
+  {
+    id: "hsv",
+    label: "HSV",
+    channels: [hueChannel, pct("s", "S", "Saturation"), pct("v", "V", "Value")],
+    read: (hex) => {
+      const { h, s, v } = rgbToHsv(hexToRgb(hex) ?? { r: 0, g: 0, b: 0 });
+      return [h, s, v];
+    },
+    write: ([h, s, v]) => hsvToHex({ h, s, v }),
+  },
+  {
+    id: "hsl",
+    label: "HSL",
+    channels: [hueChannel, pct("s", "S", "Saturation"), pct("l", "L", "Lightness")],
+    read: (hex) => {
+      const { h, s, l } = rgbToHsl(hexToRgb(hex) ?? { r: 0, g: 0, b: 0 });
+      return [h, s, l];
+    },
+    write: ([h, s, l]) => rgbToHex(hslToRgb({ h, s, l })),
+  },
+  {
+    id: "rgb",
+    label: "RGB",
+    channels: [
+      rgbChannel("r", "R", "Red"),
+      rgbChannel("g", "G", "Green"),
+      rgbChannel("b", "B", "Blue"),
+    ],
+    read: (hex) => {
+      const { r, g, b } = hexToRgb(hex) ?? { r: 0, g: 0, b: 0 };
+      return [r, g, b];
+    },
+    write: ([r, g, b]) => rgbToHex({ r, g, b }),
+  },
+  {
+    id: "oklch",
+    label: "OKLCH",
+    channels: [
+      {
+        key: "l",
+        label: "L",
+        name: "Lightness",
+        min: 0,
+        max: 1,
+        // 0.5% of perceptual lightness — just over one 8-bit level in the mid
+        // range, which is where every grey slot in a theme sits.
+        step: 0.005,
+        unit: "%",
+        places: 1,
+        scale: 100,
+      },
+      {
+        key: "c",
+        label: "C",
+        name: "Chroma",
+        min: 0,
+        // CSS's own 100% for oklch chroma. The reachable end is `ceiling`.
+        max: 0.4,
+        step: 0.005,
+        unit: "",
+        places: 3,
+        scale: 1,
+      },
+      hueChannel,
+    ],
+    read: (hex) => {
+      const { l, c, h } = rgbToOklch(hexToRgb(hex) ?? { r: 0, g: 0, b: 0 });
+      return [l, c, h];
+    },
+    write: ([l, c, h]) =>
+      rgbToHex(oklchToRgb(clamp(l, 0, 1), Math.max(0, c), h)),
+    ceiling: ([l, , h], index) => (index === 1 ? srgbChromaCeiling(l, h) : Infinity),
+  },
+];
+
+/** The model with this id. Throws only on a typo, which the union prevents. */
+export function colorModel(id: ColorModel["id"]): ColorModel {
+  return COLOR_MODELS.find((m) => m.id === id)!;
+}
+
+/** How many colours a slider's gradient is built from. */
+const TRACK_STOPS = 16;
+
+/**
+ * The colours a channel's slider track is painted with, left to right.
+ *
+ * Sampled rather than hand-written per model, which is what lets OKLCh have a
+ * correct track for free — and what makes the track honest: every stop is the
+ * colour that position would actually pick, so the gradient under the handle is
+ * a preview rather than a decoration. Where a channel has a [`ColorModel.ceiling`],
+ * the track stops there instead of running on into clamped, hue-shifted colours
+ * the handle can never reach.
+ */
+export function trackStops(
+  model: ColorModel,
+  values: number[],
+  index: number,
+): string[] {
+  const ch = model.channels[index];
+  const hi = Math.min(ch.max, model.ceiling?.(values, index) ?? Infinity);
+  const out: string[] = [];
+  for (let i = 0; i <= TRACK_STOPS; i++) {
+    const next = [...values];
+    next[index] = ch.min + ((hi - ch.min) * i) / TRACK_STOPS;
+    out.push(model.write(next));
+  }
+  return out;
+}

--- a/src/lib/cssColor.test.ts
+++ b/src/lib/cssColor.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { parseCssColor, rgbaCss } from "./cssColor";
+import {
+  inSrgbGamut,
+  oklchToRgb,
+  parseCssColor,
+  rgbToOklch,
+  rgbaCss,
+  srgbChromaCeiling,
+} from "./cssColor";
 
 describe("parseCssColor", () => {
   it("reads every hex length", () => {
@@ -74,5 +81,65 @@ describe("rgbaCss", () => {
   it("multiplies rather than replaces the colour's own alpha", () => {
     expect(rgbaCss({ r: 1, g: 2, b: 3, a: 0.5 }, 0.5)).toBe("rgba(1, 2, 3, 0.25)");
     expect(rgbaCss({ r: 1, g: 2, b: 3, a: 1 }, 0.1)).toBe("rgba(1, 2, 3, 0.1)");
+  });
+});
+
+describe("rgbToOklch", () => {
+  it("round-trips every channel corner back to the same bytes", () => {
+    // The picker's OKLCH sliders read this inverse and write the forward
+    // direction, so a lossy pair would drift the value every time the popover
+    // was opened and closed.
+    for (const rgb of [
+      { r: 0, g: 0, b: 0 },
+      { r: 255, g: 255, b: 255 },
+      { r: 255, g: 0, b: 0 },
+      { r: 0, g: 255, b: 0 },
+      { r: 0, g: 0, b: 255 },
+      { r: 90, g: 168, b: 232 }, // dark-cool's accent
+      { r: 45, g: 50, b: 60 }, // a near-grey border, the common case here
+    ]) {
+      const { l, c, h } = rgbToOklch(rgb);
+      expect(oklchToRgb(l, c, h)).toEqual(rgb);
+    }
+  });
+
+  it("reports a grey as zero chroma", () => {
+    expect(rgbToOklch({ r: 128, g: 128, b: 128 }).c).toBeCloseTo(0, 6);
+  });
+
+  it("agrees with the forward parse on a known token", () => {
+    const rgb = parseCssColor("oklch(0.72 0.15 155)")!;
+    const back = rgbToOklch(rgb);
+    expect(back.l).toBeCloseTo(0.72, 2);
+    expect(back.c).toBeCloseTo(0.15, 2);
+    expect(back.h).toBeCloseTo(155, 0);
+  });
+});
+
+describe("srgbChromaCeiling", () => {
+  it("finds a ceiling a hair inside the gamut, never outside it", () => {
+    for (const [l, h] of [
+      [0.72, 155],
+      [0.5, 25],
+      [0.85, 300],
+    ] as const) {
+      const c = srgbChromaCeiling(l, h);
+      // In gamut at the ceiling…
+      expect(inSrgbGamut(l, c, h)).toBe(true);
+      // …and out of it a step beyond, which is what makes it a CEILING and not
+      // merely some safe small number.
+      expect(inSrgbGamut(l, c + 0.02, h)).toBe(false);
+    }
+  });
+
+  it("leaves the achromatic ends with nowhere to go", () => {
+    expect(srgbChromaCeiling(0, 200)).toBeCloseTo(0, 2);
+    expect(srgbChromaCeiling(1, 200)).toBeCloseTo(0, 2);
+  });
+
+  it("keeps an in-gamut colour's own chroma reachable", () => {
+    // A colour that came FROM sRGB must not be pushed inward by its own ceiling.
+    const { l, c, h } = rgbToOklch({ r: 90, g: 168, b: 232 });
+    expect(srgbChromaCeiling(l, h)).toBeGreaterThanOrEqual(c);
   });
 });

--- a/src/lib/cssColor.ts
+++ b/src/lib/cssColor.ts
@@ -47,14 +47,24 @@ function gamma(c: number): number {
   return x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
 }
 
+/** The inverse of [`gamma`] — encoded sRGB → linear light. */
+function degamma(c: number): number {
+  const x = c < 0 ? 0 : c;
+  return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+}
+
 /**
- * OKLCh → sRGB, via OKLab and linear sRGB (Björn Ottosson's matrices).
+ * OKLCh → LINEAR sRGB, unclamped (Björn Ottosson's matrices).
  *
- * Out-of-gamut values are clamped per channel rather than gamut-mapped. Every
- * token this parses is already inside sRGB — they were authored against a
- * browser rendering them — so the clamp is a guard, not the normal path.
+ * Unclamped is the whole point of the split: a channel outside `[0, 1]` here is
+ * how [`inSrgbGamut`] knows the colour is unrepresentable, and clamping first
+ * would erase exactly that signal.
  */
-function oklchToRgb(L: number, C: number, hDeg: number): { r: number; g: number; b: number } {
+function oklchToLinearSrgb(
+  L: number,
+  C: number,
+  hDeg: number,
+): { r: number; g: number; b: number } {
   const h = (hDeg * Math.PI) / 180;
   const a = C * Math.cos(h);
   const bb = C * Math.sin(h);
@@ -67,11 +77,107 @@ function oklchToRgb(L: number, C: number, hDeg: number): { r: number; g: number;
   const m = m_ * m_ * m_;
   const s = s_ * s_ * s_;
 
-  const rLin = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
-  const gLin = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
-  const bLin = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
+  return {
+    r: 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    g: -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    b: -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  };
+}
 
-  return { r: byte(gamma(rLin)), g: byte(gamma(gLin)), b: byte(gamma(bLin)) };
+/**
+ * OKLCh → sRGB bytes, via OKLab and linear sRGB.
+ *
+ * Out-of-gamut values are clamped per channel rather than gamut-mapped. Every
+ * token this parses is already inside sRGB — they were authored against a
+ * browser rendering them — so the clamp is a guard, not the normal path. A
+ * caller that lets a HUMAN move chroma is the exception, and reaches for
+ * [`srgbChromaCeiling`] instead of discovering the clamp as a hue shift.
+ */
+export function oklchToRgb(
+  L: number,
+  C: number,
+  hDeg: number,
+): { r: number; g: number; b: number } {
+  const lin = oklchToLinearSrgb(L, C, hDeg);
+  return { r: byte(gamma(lin.r)), g: byte(gamma(lin.g)), b: byte(gamma(lin.b)) };
+}
+
+/** OKLCh, the shape the colour picker's sliders read and write. */
+export interface Oklch {
+  /** Perceptual lightness, 0-1. */
+  l: number;
+  /** Chroma, 0 to about 0.37 inside sRGB. See [`srgbChromaCeiling`]. */
+  c: number;
+  /** Hue angle in degrees, `[0, 360)`. */
+  h: number;
+}
+
+/**
+ * sRGB bytes → OKLCh, the exact inverse of [`oklchToRgb`].
+ *
+ * Round-trip exactness is the requirement, not an accident: the picker holds
+ * HSV as its state and derives OKLCh on every render, so a lossy pair would
+ * walk the value a little further every time the popover opened.
+ */
+export function rgbToOklch(rgb: { r: number; g: number; b: number }): Oklch {
+  const r = degamma(rgb.r / 255);
+  const g = degamma(rgb.g / 255);
+  const b = degamma(rgb.b / 255);
+
+  const l_ = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m_ = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s_ = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  const L = 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_;
+  const a = 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_;
+  const bb = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_;
+
+  const c = Math.sqrt(a * a + bb * bb);
+  const hDeg = (Math.atan2(bb, a) * 180) / Math.PI;
+  return { l: L, c, h: hDeg < 0 ? hDeg + 360 : hDeg };
+}
+
+/**
+ * The largest chroma sRGB can show at this lightness and hue.
+ *
+ * Bisection rather than a formula because the sRGB gamut's shape in OKLab has
+ * no closed form. Two facts make it sound: the achromatic axis is inside the
+ * cube for every `0 < L < 1`, and the cube is convex — so a ray leaving that
+ * axis crosses the surface exactly once and "in gamut" is one interval from 0.
+ *
+ * Callers use it to END a chroma slider's track. Letting the track run to a
+ * fixed 0.4 instead means the last third of the drag does nothing visible and
+ * the per-channel clamp quietly shifts the hue while it happens.
+ */
+export function srgbChromaCeiling(l: number, h: number): number {
+  if (!inSrgbGamut(l, 0, h)) return 0;
+  let lo = 0;
+  let hi = 0.4; // CSS's own 100% for oklch chroma; nothing in sRGB comes near.
+  if (inSrgbGamut(l, hi, h)) return hi;
+  for (let i = 0; i < 24; i++) {
+    const mid = (lo + hi) / 2;
+    if (inSrgbGamut(l, mid, h)) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Whether this OKLCh triple has an sRGB colour, before any clamping.
+ *
+ * The epsilon absorbs float noise and NOTHING else — it is deliberately far
+ * below one 8-bit step rather than set to it. Near `L = 0` the OKLab cube
+ * crushes all three linear channels toward zero, so an epsilon loose enough to
+ * look like a display tolerance (1e-6) reads a chroma of 0.014 as
+ * representable at pure black, and the ceiling stops being a ceiling exactly
+ * where the picker's grey slots live.
+ */
+export function inSrgbGamut(l: number, c: number, h: number): boolean {
+  const { r, g, b } = oklchToLinearSrgb(l, c, h);
+  const eps = 1e-9;
+  return (
+    r >= -eps && r <= 1 + eps && g >= -eps && g <= 1 + eps && b >= -eps && b <= 1 + eps
+  );
 }
 
 function parseHex(s: string): Rgba | null {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -133,6 +133,14 @@ HTMLCanvasElement.prototype.getContext = function stubGetContext(
     clearRect() {},
     fillRect() {},
     strokeRect() {},
+    // The colour wheel paints per-pixel into an ImageData (design/colorWheel.ts).
+    // A real buffer, not a no-op: the painter WRITES into `.data`, so a stub
+    // without it would make the wheel's paint pass throw here rather than run —
+    // which is the opposite of what this stub is for.
+    createImageData(w: number, h: number) {
+      return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+    },
+    putImageData() {},
   } as unknown as CanvasRenderingContext2D;
 } as never;
 

--- a/test/nativeColorInput.test.ts
+++ b/test/nativeColorInput.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment node
+ */
+// "No native `<input type=\"color\">` anywhere in `src/`."
+//
+// The theme editor's eighteen slots each had one. A native colour input is not
+// a picker so much as a hand-off: the webview shows whatever dialog the host
+// platform supplies, which means choosing a dark theme's greys happens in a
+// bright, unthemed OS panel, offering hex and the OS's own colour model but
+// nothing that helps build the RAMP a theme actually is.
+//
+// Two further reasons it is worth a guard rather than a code review:
+//
+//   * It is untestable. The dialog is a host window, so no e2e spec can drive
+//     it and no component test can see it — the control could stop working
+//     entirely and the whole suite would stay green.
+//   * Native controls of this class have a record here. `<a download>` and
+//     `<input type="file">` are both SILENTLY inert in WebKitGTK (#435, see
+//     `lib/userFile.ts` and `test/fileSave.test.ts`), and the platform that
+//     class of bug belongs to is the one nobody develops on. Reintroducing one
+//     is a two-character mistake with no visible consequence on macOS.
+//
+// Same shape and same reasoning as `nativeSelect.test.ts` beside it, and as
+// `src-tauri/tests/spawn_no_window.rs`. Lives at the repo root because it reads
+// the SOURCE TEXT of the tree rather than rendering anything.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC = resolve(process.cwd(), "src");
+
+/** SHIPPED source only — a test's own prose names the very attribute it is
+ *  asserting the absence of. */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "test") continue;
+      out.push(...sourceFiles(p));
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Comments are stripped first, so the prose explaining WHY there is no native
+ *  colour input cannot trip the check that there is none. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+describe("no native colour input in the frontend", () => {
+  const files = sourceFiles(SRC);
+
+  it("finds source files to check at all", () => {
+    // A broken walk would make every assertion below vacuous.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it('has no type="color" input', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const code = stripComments(readFileSync(file, "utf8"));
+      // Both quote styles, and `type = "color"` with spaces.
+      if (/type\s*=\s*["']color["']/.test(code)) {
+        offenders.push(relative(process.cwd(), file));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("still exports the replacement, so this is not passing by deletion", () => {
+    const picker = readFileSync(join(SRC, "design", "color-picker.tsx"), "utf8");
+    expect(picker).toContain("export function PGColorSwatch(");
+    // The three things that make it a picker rather than a swatch: the wheel,
+    // keyboard-reachable channel sliders, and a hex field.
+    expect(picker).toContain('role="slider"');
+    expect(picker).toContain("paintWheelRgba");
+    expect(picker).toContain('aria-label="Hex"');
+  });
+
+  it("keeps the picker reachable from the design system's entry point", () => {
+    // `@/design` is the only import path the app uses; a component exported
+    // from its own file but not from the barrel is one nobody finds.
+    const barrel = readFileSync(join(SRC, "design", "index.ts"), "utf8");
+    expect(barrel).toContain("./color-picker");
+  });
+});


### PR DESCRIPTION
The theme editor's colour picker was a native `<input type="color">` — which is not really a picker but a hand-off to whatever dialog the host webview supplies. This replaces all nineteen of them (the eighteen slots plus the guided start's Accent) with `PGColorSwatch`: a hue/saturation wheel with a brightness slider, a hex field, and a numeric row that switches between HSV, HSL, RGB and OKLCH.

Also in the popover: the draft's own palette as swatches, a recent-colours row, a live contrast ratio for a paired slot, and copy/paste on the swatch's context menu.

### Why replace it at all

The native control is an unstyled OS panel — so a dark theme's greys get chosen in a bright window — and it offers hex plus the host's own colour model, nothing that helps build the **ramp** a theme actually is. It is also untestable by construction: the dialog is a host window, so it could stop working entirely with the whole suite green. And it belongs to the class of native control that is silently inert on WebKitGTK; `<a download>` and `<input type="file">` both were, in #435.

`test/nativeColorInput.test.ts` now fails the build for one anywhere in shipped `src/`, the same shape as `nativeSelect.test.ts` beside it, and checks the replacement is still exported so the guard cannot pass by deletion.

### The parts that are load-bearing

Each of these is a bug the obvious implementation ships, and each is pinned by a test whose teeth were checked by planting the violation:

- **HSV is the state; the hex is derived.** A grey has no hue and black has neither hue nor saturation, so reading the state back out of the colour teleports the wheel cursor to red the instant saturation reaches zero.
- **The selected model's channel values are held, not re-derived per render.** Re-deriving quantizes them and the error *accumulates* — ten presses of a one-degree step moved the hue 10.14°, and the readout crept away from the number it had just shown.
- **`inSrgbGamut`'s epsilon absorbs float noise only.** Near L=0 the OKLab cube crushes every linear channel toward zero, so an epsilon loose enough to look like a display tolerance reads chroma 0.014 as representable at pure black — and the chroma ceiling stops being a ceiling exactly where a theme keeps its greys.
- **The outside-press handler consults `pressIsInsideMenu`.** The context menu is portalled onto `document.body`, so a `contains`-only check reads a press on it as a press outside, closes the popover on `mousedown`, and lands the entry's click on a detached node — #422 again.

Escape follows `PGSelect`'s registration exactly (`app.closeOverlay`, registered always and **declining while closed**), so an open picker eats the chord and the theme editor survives, while a closed one hands it back. A dismissal reverts; a click away keeps and is the only thing that reaches `recentColors`.

### Performance

The wheel is painted once at full brightness and dimmed by compositing black over it. That is exact, not an approximation — HSV's value scales all three channels linearly — so the brightness slider costs one composite of an already-painted bitmap instead of re-running a 28k-pixel loop per frame.

### Structure

Arithmetic is separated from React because that is the only part jsdom can judge: `lib/color.ts` owns the spaces and the channel registry, `lib/cssColor.ts` gains the OKLCh inverse beside the forward one it already had, and `design/colorWheel.ts` owns the geometry — the same call `selectPos.ts` and `paneSize.ts` make, since jsdom lays nothing out and a rendered wheel measures 0×0. Its tests caught two real bugs the arithmetic would otherwise have shipped: `hypot` returns `radius + 1e-14` at full saturation, so a strict `dist > radius` went dead in a one-float-wide ring exactly where the pure colours are, and trigonometry left negative zeroes on the axes.

`normalizeHex` moves from `theme/ColorEditor` to `lib/color`, where its two other callers can reach it without importing a component.

`recentColors` joins `PersistedState` with its own normalizer, since the scalar type-guard in `coerceSettings` reads every array as `"object"`. It is **non-portable**: an export is a file people share, and one person's colour history describes nothing about how the app should behave. The export test's explicit key accounting is what forced that decision, which is the test doing its job. No Settings row — there is no control for it.

### Verification

- `pnpm test` — 4042 passing, 399 files
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — both clean
- `pnpm test:e2e:docker full --spec e2e/specs/settings.e2e.ts` — 13 passing on WebKitGTK 605.1.15, 0 stalled driver scripts, re-run after rebasing onto #448

The e2e case covers what only the real engine can answer. The wheel is an `ImageData` written per pixel and blitted with `putImageData`, and the unit suite paints it into a stub context that records nothing — so the spec reads the centre pixel back and requires white, which neither a zeroed buffer nor a WebKitGTK without `createImageData` could produce. It also drives the hue slider and checks Escape's ordering against a real capture-phase dispatcher racing a real portal.

### Note for the merger

This branch has four curated commits, but the `main` ruleset currently lists `allowed_merge_methods: ["squash"]` while `CLAUDE.md` documents rebase-and-merge. Squashing is what is actually permitted, so this body is written to stand as the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
