### PR TITLE
fix: review follow-ups on the argv and settings-density changes

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -211,19 +211,26 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   on stdout and prints nothing else.
 - **End option parsing with `--` before any user-supplied value** — a value
   starting with `-` is otherwise an option (`git push --receive-pack=<program>`
-  is argument injection). `push_tag_args`/`push_delete_args`, `fetch_args`,
-  `push_args` and `push_commit_args` all emit it, tested. The force flag and
+  is argument injection). `push_tag_args`/`push_delete_args`, `push_args` and
+  `push_commit_args` all emit it, tested; `fetch_args` emits it on its
+  `Some(remote)` branch, which is the only one that carries a user value —
+  `fetch --all --prune` names nothing and gets no separator. The force flag and
   `--no-verify` moved ahead of the separator to make room for it: after a `--`
   git reads them as refspecs, not options.
-- **`pull` is the exception: the separator alone does not protect it**, so its
-  remote and branch are REFUSED when they start with `-` (`pull_args`). `git
-  pull` parses its own options, consumes the `--`, then re-runs
-  `git fetch <remote> <refspec>` with no separator of its own — so the value
-  reaches that fetch as an option anyway. Verified against git 2.54 with the
-  separator in place. The separator is emitted regardless, since it is the rule
-  and it does end `pull`'s own parsing. Reachable input rather than only ours:
-  git accepts `git remote add -- -evil <url>`, and a repository's config can
-  name a remote anything at all.
+- **Two paths REFUSE a dash-leading value instead, because a separator cannot
+  carry them.** Both answer with `AppError::InvalidArgument`, and both are
+  reachable rather than only ours: git accepts `git remote add -- -evil <url>`,
+  and a cloned repository's config can name a remote anything at all.
+  - `pull_args` — `git pull` parses its own options, consumes the `--`, then
+    re-runs `git fetch <remote> <refspec>` with no separator of its own, so the
+    value reaches that fetch as an option anyway. Verified against git 2.54
+    *with* the separator in place. The separator is emitted regardless, since
+    it is the rule and it does end `pull`'s own parsing.
+  - `git/lfs.rs`'s `fetch_args`/`pull_args` (`checked_remote`) — `git lfs` is a
+    separate binary with its own flag parser, so whether it honours `--` in the
+    remote position is its behaviour to confirm, not ours to assume, and
+    assuming wrong breaks every LFS fetch silently. Refusing the one dangerous
+    shape needs no assumption.
 - `credential_approve` refuses values containing a newline rather than escaping
   them — the credential protocol is line-based, so a newline injects keys and
   could file a password against another host.

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1489,8 +1489,15 @@ a result is the actual control, never a copy of it that could drift — see
   by design (one is a fixed setting with a `data-setting-id`, the other a row
   over account data), but they sit in the same panel, so density has to reach
   both or neither: giving it to one leaves a forge account row a different
-  height from the setting directly above it. The card HEADER keeps its fixed
-  padding, per the density rule's chrome exemption.
+  height from the setting directly above it. They share ONE value —
+  `SETTINGS_ROW_PADDING`, built by `densityPadding(12)` — because being equal
+  is the requirement, and two copied literals cannot fail a test when only one
+  is edited. Anything else in a card BODY takes the same step from
+  `densityPadding(<its own base>)`: the Appearance page's theme action strip is
+  10px, and it scaling is what keeps one card from having two row pitches. The
+  card HEADER is the exemption, and it is the only one — `SettingsCard.test.tsx`
+  pins its exact padding, since asserting merely "no `--row-step`" also passes
+  for a header with no padding at all.
 - **`data-setting-id` is selected exactly, never with `*=`, in both specs and
   e2e.** These are dotted, two-part ids (`card.row`), and one is a genuine
   substring of another today — `commit.sign` is a literal prefix of
@@ -2116,6 +2123,13 @@ update checks back on for someone who turned them off.
   surface keeps its base. Chrome and code-line geometry (`--lh-code`) stay
   fixed. `grep -rn 'var(--row-step)' src/` lists participants. `PGGraphRow`
   draws in SVG units — `PGCommitRow` feeds it `useDensityStep()`.
+  **"Chrome" means the app frame** — the tab strip, the operation bar — and a
+  settings card's HEADER, which is the one named exemption inside a content
+  pane. It does NOT mean "anything that is not a row": a band sitting between
+  two rows in a card BODY (the Appearance page's theme action strip) is
+  content, and a fixed height there gives one card two row pitches. Settings
+  surfaces take the step through `densityPadding()` / `SETTINGS_ROW_PADDING`
+  rather than their own literal — see the Settings section.
 
 ## Design system
 

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -2121,8 +2121,11 @@ update checks back on for someone who turned them off.
   `height: "calc(<base>px + var(--row-step))"` (or `/ 2` for padding-sized
   rows); `--row-h` for plain 24px rows. `--row-step` is 0 in compact, so each
   surface keeps its base. Chrome and code-line geometry (`--lh-code`) stay
-  fixed. `grep -rn 'var(--row-step)' src/` lists participants. `PGGraphRow`
-  draws in SVG units — `PGCommitRow` feeds it `useDensityStep()`.
+  fixed. `grep -rn 'var(--row-step)' src/` lists participants — but NOT the
+  Settings panel, whose surfaces take the step from one shared helper rather
+  than a literal, so add `-e densityPadding -e SETTINGS_ROW_PADDING` or they
+  read as non-participants. `PGGraphRow` draws in SVG units — `PGCommitRow`
+  feeds it `useDensityStep()`.
   **"Chrome" means the app frame** — the tab strip, the operation bar — and a
   settings card's HEADER, which is the one named exemption inside a content
   pane. It does NOT mean "anything that is not a row": a band sitting between

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -279,6 +279,64 @@ describe("settings", () => {
     expect(await measureRows()).toEqual(compact);
   });
 
+  /**
+   * The Settings panel's OWN rows resolve the density calc.
+   *
+   * `measureRows` above covers the four surfaces outside Settings. These two
+   * are the ones no unit test can reach: jsdom does not resolve `calc()`, so
+   * `SettingsCard.test.tsx` can only assert the token STRING — which stays
+   * green if the `/ 2` is dropped and a row grows 8px instead of 4.
+   *
+   * Asserted as a DELTA, not as pinned absolutes like the test above, because
+   * both heights depend on how their hint prose wraps at the container's width
+   * — a copy edit would redden a pinned number while the geometry is correct.
+   * The delta is the actual invariant: exactly one step, no double-count.
+   *
+   * `theme-actions` is the strip between two `SettingsRow`s in the same card.
+   * It is here because a fixed height there gives ONE card two row pitches,
+   * which is the same bug as a forge row that does not scale.
+   */
+  it("Settings rows resolve the density calc, by exactly one step", async () => {
+    const STEP = 4; // DENSITY_STEP_PX.comfortable
+
+    const measureSettings = async () => {
+      const row = $('[data-setting-id="appearance.density"]');
+      await row.waitForDisplayed({
+        timeout: 10_000, timeoutMsg: "density row never appeared for measurement",
+      });
+      const strip = $('[data-testid="theme-actions"]');
+      await strip.waitForDisplayed({
+        timeout: 10_000, timeoutMsg: "theme action strip never appeared for measurement",
+      });
+      return {
+        row: Math.round((await row.getSize("height")) as number),
+        strip: Math.round((await strip.getSize("height")) as number),
+      };
+    };
+
+    await openSettings("general.appearance");
+    const compact = await measureSettings();
+
+    await $("button*=Comfortable").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Comfortable').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Comfortable never became active" },
+    );
+    const comfortable = await measureSettings();
+
+    // Exactly one step each. `+ var(--row-step)` without the `/ 2` would
+    // report 2 × STEP here, and `calc` resolving to nothing would report 0.
+    expect(comfortable.row - compact.row).toBe(STEP);
+    expect(comfortable.strip - compact.strip).toBe(STEP);
+
+    await $("button*=Compact").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Compact').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Compact never became active" },
+    );
+    expect(await measureSettings()).toEqual(compact);
+  });
+
   it("confirmForcePush=off skips the confirm entirely", async () => {
     pair = remoteRepo();
     makeDiverged(pair);

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -663,7 +663,7 @@ mod push_args_tests {
     use super::*;
 
     #[test]
-    fn no_verify_is_added_only_when_asked() {
+    fn no_verify_is_added_only_when_asked_and_precedes_the_separator() {
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, false),
             vec!["push", "--progress", "--", "origin", "main"]
@@ -720,7 +720,7 @@ mod push_args_tests {
     }
 
     #[test]
-    fn no_verify_is_appended_when_asked() {
+    fn no_verify_precedes_the_separator_on_a_commit_push() {
         assert_eq!(
             push_commit_args("origin", "abc1234", "feat/x", true),
             vec![
@@ -794,26 +794,46 @@ mod push_args_tests {
     #[test]
     fn every_user_value_lands_after_the_separator() {
         let hostile = "--receive-pack=/bin/false";
-        let sets: Vec<Vec<String>> = vec![
-            push_args(hostile, "main", PushForce::None, false, false),
-            push_args("origin", hostile, PushForce::WithLease, true, true),
-            push_commit_args(hostile, "abc1234", "main", false),
-            push_commit_args("origin", "abc1234", "main", true),
+        // `PushForce::Force` gets its own set: it is a different match arm from
+        // `WithLease`, so a reorder could move one and leave the other. The
+        // flag says whether the set was built WITH a hostile value — the last
+        // one is the ordinary-path control, and counting it as hostile is what
+        // would make its half of this test vacuous.
+        let sets: Vec<(bool, Vec<String>)> = vec![
+            (true, push_args(hostile, "main", PushForce::None, false, false)),
+            (true, push_args("origin", hostile, PushForce::WithLease, true, true)),
+            (true, push_args("origin", hostile, PushForce::Force, true, true)),
+            (true, push_commit_args(hostile, "abc1234", "main", false)),
+            (false, push_commit_args("origin", "abc1234", "main", true)),
         ];
-        for args in sets {
+        for (has_hostile, args) in sets {
             let sep = args
                 .iter()
                 .position(|a| a == "--")
                 .unwrap_or_else(|| panic!("no end-of-options separator: {args:?}"));
-            for (i, a) in args.iter().enumerate() {
-                if a.starts_with("--receive-pack") {
-                    assert!(i > sep, "user value read as an option: {args:?}");
-                }
+            // PRESENT and after the separator. A bare `if` here would also pass
+            // for a builder that dropped the user's value altogether, which is
+            // a different bug but not a passing one.
+            let at: Vec<usize> = args
+                .iter()
+                .enumerate()
+                .filter(|(_, a)| a.starts_with("--receive-pack"))
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(
+                at.len(),
+                usize::from(has_hostile),
+                "user value must survive exactly once: {args:?}"
+            );
+            if let Some(&i) = at.first() {
+                assert!(i > sep, "user value read as an option: {args:?}");
             }
             // Every one of ours stays an option: after the separator it would
-            // be a refspec instead.
-            for flag in ["--progress", "-u", "--force-with-lease", "--no-verify"] {
-                if let Some(i) = args.iter().position(|a| a == flag) {
+            // be a refspec instead. EVERY occurrence is checked, not just the
+            // first — a second copy emitted after `--` is the regression a
+            // `position()` lookup cannot see.
+            for flag in ["--progress", "-u", "--force-with-lease", "--force", "--no-verify"] {
+                for (i, _) in args.iter().enumerate().filter(|(_, a)| *a == flag) {
                     assert!(i < sep, "{flag} must precede the separator: {args:?}");
                 }
             }

--- a/src-tauri/src/commands/lfs.rs
+++ b/src-tauri/src/commands/lfs.rs
@@ -56,7 +56,7 @@ pub async fn lfs_fetch(
 ) -> AppResult<()> {
     let workdir = workdir_of(&state, &RepoId(repo_id)).await?;
     crate::git::lfs::require(&workdir)?;
-    let args = crate::git::lfs::fetch_args(remote.as_deref());
+    let args = crate::git::lfs::fetch_args(remote.as_deref())?;
     let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
     crate::commands::net::run_git_authenticated(&workdir, &borrowed, credentials.as_ref()).await
 }
@@ -71,7 +71,7 @@ pub async fn lfs_pull(
 ) -> AppResult<()> {
     let workdir = workdir_of(&state, &RepoId(repo_id)).await?;
     crate::git::lfs::require(&workdir)?;
-    let args = crate::git::lfs::pull_args(remote.as_deref());
+    let args = crate::git::lfs::pull_args(remote.as_deref())?;
     let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
     crate::commands::net::run_git_authenticated(&workdir, &borrowed, credentials.as_ref()).await
 }

--- a/src-tauri/src/git/lfs.rs
+++ b/src-tauri/src/git/lfs.rs
@@ -235,23 +235,47 @@ pub fn parse_ls_files(stdout: &str) -> Vec<LfsFile> {
         .collect()
 }
 
+/// Refuse a remote name `git lfs` would read as one of its own options.
+///
+/// **Why a refusal and not a `--` separator, unlike every builder in
+/// `commands/branches.rs`.** Those end option parsing with `--` because real
+/// git is what parses them and `git push -- <remote>` is verified to treat the
+/// value as a value. `git lfs` is a separate binary with its own flag parser,
+/// so whether it honours `--` in this position is its behaviour to confirm, not
+/// ours to assume — and the cost of assuming wrong is a silently broken LFS
+/// fetch on every repository. Refusing the one shape that is dangerous needs no
+/// assumption: a legal remote name is unaffected.
+///
+/// Reachable rather than only ours: `git remote add -- -evil <url>` succeeds,
+/// and a cloned repository's config can name a remote anything at all.
+fn checked_remote(remote: Option<&str>) -> AppResult<Option<&str>> {
+    if let Some(r) = remote {
+        if r.starts_with('-') {
+            return Err(AppError::InvalidArgument(format!(
+                "invalid remote name {r:?}: a leading dash would be read as a command-line option"
+            )));
+        }
+    }
+    Ok(remote)
+}
+
 /// `git lfs fetch [remote]` — downloads objects into `.git/lfs`, leaves the
 /// worktree alone.
-pub fn fetch_args(remote: Option<&str>) -> Vec<String> {
+pub fn fetch_args(remote: Option<&str>) -> AppResult<Vec<String>> {
     let mut args: Vec<String> = vec!["lfs".into(), "fetch".into()];
-    if let Some(r) = remote {
+    if let Some(r) = checked_remote(remote)? {
         args.push(r.to_string());
     }
-    args
+    Ok(args)
 }
 
 /// `git lfs pull [remote]` — fetch plus checkout, i.e. materialize as well.
-pub fn pull_args(remote: Option<&str>) -> Vec<String> {
+pub fn pull_args(remote: Option<&str>) -> AppResult<Vec<String>> {
     let mut args: Vec<String> = vec!["lfs".into(), "pull".into()];
-    if let Some(r) = remote {
+    if let Some(r) = checked_remote(remote)? {
         args.push(r.to_string());
     }
-    args
+    Ok(args)
 }
 
 #[cfg(test)]
@@ -277,6 +301,26 @@ mod tests {
         assert!(parse_pointer("see version https://git-lfs.github.com/spec/v1\n").is_none());
         // Version line present but no oid/size — not a pointer.
         assert!(parse_pointer("version https://git-lfs.github.com/spec/v1\nhello\n").is_none());
+    }
+
+    /// `git lfs` is its own binary with its own flag parser, so these two
+    /// builders refuse the dangerous shape rather than relying on a `--` whose
+    /// handling is git-lfs's to define. See `checked_remote`.
+    #[test]
+    fn lfs_args_refuse_a_remote_git_lfs_would_read_as_an_option() {
+        for hostile in ["--upload-pack=/bin/false", "-evil", "--help"] {
+            assert!(
+                matches!(
+                    fetch_args(Some(hostile)),
+                    Err(AppError::InvalidArgument(_))
+                ),
+                "fetch_args accepted {hostile:?}"
+            );
+            assert!(
+                matches!(pull_args(Some(hostile)), Err(AppError::InvalidArgument(_))),
+                "pull_args accepted {hostile:?}"
+            );
+        }
     }
 
     fn line(kind: DiffLineKind, content: &str) -> DiffLine {
@@ -381,8 +425,14 @@ mod tests {
 
     #[test]
     fn arg_builders() {
-        assert_eq!(fetch_args(None), ["lfs", "fetch"]);
-        assert_eq!(fetch_args(Some("origin")), ["lfs", "fetch", "origin"]);
-        assert_eq!(pull_args(Some("upstream")), ["lfs", "pull", "upstream"]);
+        assert_eq!(fetch_args(None).unwrap(), ["lfs", "fetch"]);
+        assert_eq!(pull_args(None).unwrap(), ["lfs", "pull"]);
+        assert_eq!(fetch_args(Some("origin")).unwrap(), ["lfs", "fetch", "origin"]);
+        assert_eq!(pull_args(Some("upstream")).unwrap(), ["lfs", "pull", "upstream"]);
+        // A dash INSIDE the name is ordinary and must still build.
+        assert_eq!(
+            pull_args(Some("my-remote")).unwrap(),
+            ["lfs", "pull", "my-remote"]
+        );
     }
 }

--- a/src/features/forge/ForgeSettings.test.tsx
+++ b/src/features/forge/ForgeSettings.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { SETTINGS_ROW_PADDING } from "@/features/settings/layout/SettingsCard";
 import { ForgeSettings } from "./ForgeSettings";
 import { useForgeStore } from "./useForgeStore";
 import type { ForgeAccount } from "./forgeAccounts";
@@ -222,12 +223,16 @@ describe("ForgeSettings — several accounts on one host (#233)", () => {
   // An account row is a list row in the same panel as its `SettingsRow`
   // siblings, so it reads `--row-step` like they do. Fixed padding here left
   // it a different height from every row above it once density changed.
-  it("sizes an account row with UI density", () => {
+  //
+  // Asserted EQUAL to the shared constant rather than "contains --row-step":
+  // the requirement is that the two row helpers agree, and a substring check
+  // still passes once one of them moves to a different base.
+  it("sizes an account row exactly like its SettingsRow siblings", () => {
     useForgeStore.setState({ accounts: twoAccounts, detection: GH });
     render(<ForgeSettings />);
     expect(
       screen.getByTestId("forge-account-github.com-acc-work").style.padding,
-    ).toContain("var(--row-step)");
+    ).toBe(SETTINGS_ROW_PADDING);
   });
 
   it("marks which account the host actually uses", () => {

--- a/src/features/forge/ForgeSettings.tsx
+++ b/src/features/forge/ForgeSettings.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import {
+  SETTINGS_ROW_PADDING,
   SettingsCard,
   SettingsRow,
 } from "@/features/settings/layout/SettingsCard";
@@ -429,9 +430,9 @@ function ForgeRow({
         display: "flex",
         alignItems: "flex-start",
         gap: 16,
-        // Same density opt-in as `SettingsRow` (#70). These rows sit in the
-        // same panel as their siblings, so they have to scale with them.
-        padding: "calc(12px + var(--row-step) / 2) 16px",
+        // The SAME value as `SettingsRow`, not a copy of it (#70): these rows
+        // sit in the same panel as their siblings and must scale with them.
+        padding: SETTINGS_ROW_PADDING,
         borderBottom: "1px solid var(--border-0)",
       }}
     >

--- a/src/features/repo/useRepoStore.settings.test.ts
+++ b/src/features/repo/useRepoStore.settings.test.ts
@@ -100,6 +100,51 @@ describe("pull auto-stash", () => {
     });
   });
 
+  // The counterpart to the test above, and the one case that inverts it.
+  // `pull_args` refuses a dash-leading remote or branch BEFORE the repository
+  // path is looked up, so git never ran and the worktree is still exactly what
+  // stashSave left behind — there are no conflicts for the pop to collide
+  // with, which is the only reason the policy above exists. Keeping the stash
+  // here would charge the user their uncommitted work for a rejected argument.
+  it("pops the stash when the pull was refused before git ran", async () => {
+    mockInvoke("stash_save", () => "stash-oid");
+    mockInvoke("pull", () => {
+      throw {
+        kind: "InvalidArgument",
+        message: 'invalid remote name "-evil": a leading dash would be read…',
+      };
+    });
+    mockInvoke("stash_pop", () => null);
+
+    await useRepoStore.getState().pull("-evil", "main", "Merge");
+
+    expect(calls("stash_pop")).toHaveLength(1);
+    // The refusal is still what the user is told about.
+    expect(useRepoStore.getState().error).toMatchObject({
+      kind: "InvalidArgument",
+    });
+  });
+
+  // The pop is the recovery, not the report: if it fails too, the original
+  // refusal must still be the error on screen rather than the pop's own.
+  it("still surfaces the refusal when restoring the stash also fails", async () => {
+    mockInvoke("stash_save", () => "stash-oid");
+    mockInvoke("pull", () => {
+      throw { kind: "InvalidArgument", message: "refused" };
+    });
+    mockInvoke("stash_pop", () => {
+      throw { kind: "Internal", message: "pop failed" };
+    });
+
+    await useRepoStore.getState().pull("-evil", "main", "Merge");
+
+    expect(calls("stash_pop")).toHaveLength(1);
+    expect(useRepoStore.getState().error).toMatchObject({
+      kind: "InvalidArgument",
+      message: "refused",
+    });
+  });
+
   // The stash must survive an auth challenge. The first attempt stashes and then
   // fails on credentials; the retry used to re-enter the closure with a fresh
   // `stashed = null`, find the tree clean (the work being in the stash), pull

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -2058,6 +2058,26 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await get().refreshAll();
       },
       async (e) => {
+        // A REFUSED ARGUMENT never reached git, so pop it after all. The
+        // policy above — a failed pull deliberately does not pop — exists
+        // because a real pull can stop halfway and leave conflicts the stash
+        // would collide with. `pull_args` rejects a dash-leading remote or
+        // branch before the repository path is even looked up, so none of that
+        // can have happened: the worktree is still exactly what stashSave left
+        // behind. Without this, the backend's "a refused argument must cost
+        // nothing" is false one layer up — the argument costs the user their
+        // uncommitted work, parked in a stash they were never told about.
+        if (stashed && isAppError(e) && e.kind === "InvalidArgument") {
+          setActivity(repo.id, "pull", "Restoring stashed changes…");
+          try {
+            await stashPop(repo.id, 0);
+            stashed = null;
+          } catch {
+            // The pop is the recovery, not the report. If it fails too, leave
+            // the stash where it is (the pre-existing policy) and still
+            // surface the original refusal rather than replacing it.
+          }
+        }
         // See mergeBranch's catch: refresh first, error last, so it isn't
         // batched away by refreshAll's own `error: null` reset.
         await get().refreshAll();

--- a/src/features/settings/layout/SettingsCard.test.tsx
+++ b/src/features/settings/layout/SettingsCard.test.tsx
@@ -4,7 +4,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { registerCardRows, SettingsCard, SettingsRow } from "./SettingsCard";
+import {
+  densityPadding,
+  registerCardRows,
+  SETTINGS_ROW_PADDING,
+  SettingsCard,
+  SettingsRow,
+} from "./SettingsCard";
 import { SettingsFilterProvider } from "./filterContext";
 import { SettingsHighlightProvider } from "./highlightContext";
 
@@ -32,11 +38,29 @@ describe("SettingsCard / SettingsRow", () => {
       </SettingsCard>,
     );
     const row = document.querySelector<HTMLElement>('[data-setting-id="diff.layout"]');
-    expect(row?.style.padding).toContain("var(--row-step)");
+    expect(row?.style.padding).toBe(SETTINGS_ROW_PADDING);
+    // The header's EXACT padding, not merely "no --row-step in it": deleting
+    // the header's padding altogether satisfies a `not.toContain` while the
+    // card title sits flush against the border, and "the header keeps its
+    // fixed chrome padding" is the claim being pinned. Asserted non-null
+    // first, because a wrapped header makes the query null and chai then
+    // reports an argument-type error instead of "header not found".
     const header = document.querySelector<HTMLElement>(
       '[data-settings-card="diff"] > header',
     );
-    expect(header?.style.padding).not.toContain("var(--row-step)");
+    expect(header).not.toBeNull();
+    expect(header?.style.padding).toBe("12px 16px 10px");
+  });
+
+  // `--row-step` is the whole extra row height, so vertical padding takes HALF
+  // of it; spelling `var(--row-step)` without the `/ 2` double-counts, the trap
+  // src/index.css names. No `toContain("var(--row-step)")` can see that — jsdom
+  // does not resolve calc() — so the token math is pinned as a string here and
+  // as real geometry in e2e/specs/settings.e2e.ts.
+  it("takes half a step, so density is not double-counted", () => {
+    expect(densityPadding(12)).toBe("calc(12px + var(--row-step) / 2) 16px");
+    expect(densityPadding(10)).toBe("calc(10px + var(--row-step) / 2) 16px");
+    expect(SETTINGS_ROW_PADDING).toBe(densityPadding(12));
   });
 
   it("renders everything when no filter is active", () => {

--- a/src/features/settings/layout/SettingsCard.tsx
+++ b/src/features/settings/layout/SettingsCard.tsx
@@ -4,6 +4,34 @@ import { useSettingsFilter } from "./filterContext";
 import { useSettingsHighlight } from "./highlightContext";
 
 /**
+ * The UI-density opt-in for a settings surface, as vertical padding.
+ *
+ * `--row-step` is the WHOLE extra height a row spends, so padding — applied
+ * top AND bottom — takes half of it. Writing `var(--row-step)` here instead
+ * double-counts, the trap `src/index.css` names where it defines the token.
+ *
+ * A function rather than one bare string because the bases differ (a row is
+ * 12px, the theme action strip 10px) while the STEP must not: two surfaces in
+ * one card that grow by different amounts is the same bug as one that does not
+ * grow at all.
+ */
+export function densityPadding(basePx: number): string {
+  return `calc(${basePx}px + var(--row-step) / 2) 16px`;
+}
+
+/**
+ * The padding EVERY settings row uses — `SettingsRow` here and `ForgeRow` in
+ * `features/forge/ForgeSettings.tsx`, a separate component by design that
+ * nonetheless sits in the same panel.
+ *
+ * Shared as one value rather than copied as one string, because the two being
+ * EQUAL is the actual requirement: a forge account row a few pixels off from
+ * the setting directly above it is the bug this closes, and two literals
+ * cannot fail a test when only one of them is edited.
+ */
+export const SETTINGS_ROW_PADDING = densityPadding(12);
+
+/**
  * The one card/row layout pair for the Settings screen.
  *
  * Was defined twice — `screens/Settings.tsx` and `features/forge/
@@ -108,7 +136,7 @@ export function SettingsRow({
         gap: stacked ? 10 : 16,
         // A list-row surface, so it opts into UI density (#70). The card's
         // header above stays fixed: that is chrome, not a row.
-        padding: "calc(12px + var(--row-step) / 2) 16px",
+        padding: SETTINGS_ROW_PADDING,
         borderBottom: "1px solid var(--border-0)",
       }}
     >

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -7,7 +7,11 @@ import {
   type ThemeFollowMode,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
-import { SettingsCard, SettingsRow } from "@/features/settings/layout/SettingsCard";
+import {
+  densityPadding,
+  SettingsCard,
+  SettingsRow,
+} from "@/features/settings/layout/SettingsCard";
 import { ThemeEditorDialog } from "@/features/settings/theme/ThemeEditorDialog";
 import { ThemeGallery } from "@/features/settings/theme/ThemeGallery";
 import { useThemeEditorStore } from "@/features/settings/theme/useThemeEditorStore";
@@ -132,8 +136,16 @@ export function AppearancePage() {
           the editor on the active theme; which theme it starts from is the
           editor's own "Start from" picker, not a card you had to find first. */}
       <div
+        // A geometry hook: only a real webview resolves the calc below, so e2e
+        // measures this strip's height under each density.
+        data-testid="theme-actions"
         style={{
-          padding: "10px 16px",
+          // Density-aware for the same reason its `SettingsRow` neighbours
+          // are: this strip is in the card BODY, between two rows that scale,
+          // so a fixed height here gives one card two row pitches. The chrome
+          // exemption covers a card's HEADER, not a band between its rows.
+          // Its own 10px base is kept — only the step is shared.
+          padding: densityPadding(10),
           borderBottom: "1px solid var(--border-0)",
           display: "flex",
           flexWrap: "wrap",

--- a/src/index.css
+++ b/src/index.css
@@ -181,7 +181,13 @@
    * `calc(<base>px + var(--row-step) / 2)` for vertical padding (top+bottom
    * each take half). Keeping each surface's own base inline means compact
    * (step 0) renders pixel-identically to the pre-density layout, and
-   * `grep -rn 'var(--row-step)' src/` lists every density-aware surface.
+   * `grep -rn 'var(--row-step)' src/` lists every density-aware surface —
+   * EXCEPT the Settings panel, which takes the step from one shared helper
+   * (`densityPadding()` / `SETTINGS_ROW_PADDING` in features/settings/layout/
+   * SettingsCard.tsx) so its row helpers cannot drift apart on height. Add
+   * `-e densityPadding -e SETTINGS_ROW_PADDING` to that grep to see them, or
+   * the Settings rows, the forge account rows and the Appearance page's theme
+   * action strip all read as non-participants.
    *
    * One surface can't use the token: PGGraphRow draws in SVG user units, so
    * PGCommitRow feeds it the number via useDensityStep(). */

--- a/src/screens/Settings.appearance.test.tsx
+++ b/src/screens/Settings.appearance.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { WithDialogs, resetDialogs } from "@/test/dialog";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { AppearancePage } from "@/features/settings/pages/appearance";
+import { densityPadding } from "@/features/settings/layout/SettingsCard";
 
 /**
  * The Row whose label is `label`, so a control can be found by what it is FOR
@@ -40,6 +41,23 @@ function renderSettings() {
     </WithDialogs>,
   );
 }
+
+// The Add/Import strip sits INSIDE the appearance card, between the theme row
+// above it and "UI density" below — both of which scale with `--row-step`. A
+// fixed height here gives one card two row pitches, which is the same bug as a
+// forge account row that does not scale (#70): the chrome exemption is for a
+// card's header, not for a band between its rows.
+describe("the theme action strip", () => {
+  it("scales with UI density, by the same step as the rows around it", () => {
+    renderSettings();
+    const strip = screen.getByRole("button", { name: /Import theme/ }).parentElement;
+    expect(strip).not.toBeNull();
+    expect(strip?.style.padding).toBe(densityPadding(10));
+    // The SAME step as its neighbours — a different one would be a second
+    // pitch again, just a subtler one.
+    expect(strip?.style.padding).toContain("var(--row-step) / 2");
+  });
+});
 
 describe("the Appearance control", () => {
   it("shows one theme picker while fixed, and the pair while following", () => {


### PR DESCRIPTION
Review follow-ups on #446 and #447, which are merged. Each was something the merged PR's own text or docs claimed was handled.

## From #447 (argv / end-of-options)

**A refused pull stranded the user's uncommitted work.** `useRepoStore.pull` stashes *before* calling the backend, and the documented policy is that a failed pull deliberately does not pop — because a real pull can stop halfway and leave conflicts the stash would collide with. `pull_args` now refuses a dash-leading remote or branch *before the repository path is even looked up*, so git never ran and none of that can have happened. Without a pop on that one arm, the backend comment "a refused argument must cost nothing" is false one layer up: the argument costs the user their work, parked in a stash they were never told about. The pop is the recovery, not the report — a failing pop leaves the stash and still surfaces the original refusal.

**`git lfs` was the remaining unseparated pull argv site.** `git/lfs.rs`'s `fetch_args`/`pull_args` pass a user-supplied remote straight into `git lfs fetch|pull <remote>`, while `backend.md`'s inventory read as closed. They **refuse** a dash-leading remote rather than emitting a separator: `git lfs` is a separate binary with its own flag parser, so whether it honours `--` there is its behaviour to confirm, not ours to assume, and assuming wrong breaks every LFS fetch silently. (git-lfs is not installed in this environment, so the separator could not be verified — refusing the one dangerous shape needs no assumption.)

**Tests that assert what they read.** `every_user_value_lands_after_the_separator` checked only each flag's FIRST index, so a second copy emitted after the separator still passed, and `PushForce::Force` was absent from the list. It now checks every occurrence, covers the `--force` arm, and requires the user value to survive exactly once — a builder that dropped it used to pass. Tagging the sets is what keeps the ordinary-path control from counting as hostile.

**Doc precision.** `fetch_args` emits the separator only on its `Some(remote)` branch; `fetch --all --prune` carries no user value and gets none. Two `no_verify` test names still said "appended" after the flag moved ahead of the separator.

## From #446 (settings row density)

**One card had two row pitches.** The Appearance card's Add/Import strip sits in the card BODY between two `SettingsRow`s that now scale, and kept a fixed `10px 16px` — so at Comfortable the rows above and below grew and it did not. Same bug as a forge row that does not scale; the chrome exemption it would have to claim covers a card's HEADER, not a band between its rows.

**The two row helpers now share a value, not a string.** Each carried its own copy of the calc, so editing one base passed every test while a forge row rendered a few pixels off from the setting above it — the bug the PR set out to close, with a docs bullet asserting it could not happen. One `SETTINGS_ROW_PADDING` (from `densityPadding(12)`) makes them equal by construction.

**Nothing verified the calc RESOLVED.** jsdom does not compute `calc()`, so the unit tests could only assert the token string — dropping the `/ 2` grows a row 8px instead of 4 and stays green, the exact double-count `index.css` warns about. `settings.e2e.ts` now measures the density row and the strip in a real webview and asserts each grows by exactly one step, as a **delta** rather than pinned absolutes (both heights depend on how their hint prose wraps, so a copy edit would redden a pinned number while the geometry is fine).

Also: the card header's padding is pinned exactly — `not.toContain("var(--row-step)")` also passes for a header with *no* padding. And `frontend.md`'s density rule now says what "chrome" means, since the ruling that a card header is exempt lived 700 lines from the rule defining the exemption.

## Not fixed here

The `+main` silent force-push is filed as #451 — pre-existing, not from #447, and it needs a refspec-shape check rather than an option-shape one.

## Checks

- `cargo test --manifest-path src-tauri/Cargo.toml --no-fail-fast`: 1322 passed, 0 failed. (The 16 `hooks.rs`/`amend_message.rs` failures both contributors reported do **not** reproduce here — those were their sandboxes.)
- `pnpm vitest run`: 399 files, 4048 tests, all passing
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit`: clean
- `pnpm vite build`: clean
- `pnpm test:e2e:docker full --spec e2e/specs/settings.e2e.ts`

Each new guard was proved to fail first by planting its violation: removing the LFS dash check (`fetch_args accepted "--upload-pack=/bin/false"`), emitting a second `--no-verify` after the separator (`--no-verify must precede the separator: [… "--", "--no-verify", …]` — the exact regression a `position()` lookup cannot see), and dropping the pop arm (both new store tests red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
