### PR TITLE
fix(git): push and pull the ref the user picked, not a force refspec

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -217,6 +217,42 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `fetch --all --prune` names nothing and gets no separator. The force flag and
   `--no-verify` moved ahead of the separator to make room for it: after a `--`
   git reads them as refspecs, not options.
+- **`--` ends OPTION parsing, not REFSPEC parsing — so a value in refspec
+  position is named by its FULL ref on both sides** (#451). The two positions
+  have different grammars, and in refspec position a leading `+` means
+  *force-update*. A branch legitimately named `+main` (git accepts it —
+  `git check-ref-format --branch '+main'` passes, and a clone can bring one in)
+  was therefore sent as "force-update `main`": measured against git 2.50.1 on a
+  diverged remote as `+ b51af1b...bf589a0 main -> main (forced update)`, with no
+  `refs/heads/+main` created and no `confirmRewrite` in front of it, because the
+  app believed it was pushing normally. Silent history loss on the remote's
+  default branch — the worst outcome in the app — and `validate_ref_name` cannot
+  catch it, since `+` is legal in a ref name.
+  - `push_args` sends `refs/heads/<branch>:refs/heads/<branch>` and
+    `push_tag_args` sends `refs/tags/<tag>:refs/tags/<tag>`, the shape
+    `push_commit_args` already used. Spelling both sides REMOVES the ambiguity
+    instead of detecting it, and measured equivalent to the bare name for `-u`
+    (still writes `branch.<n>.merge = refs/heads/<n>`), `--force-with-lease`
+    (still refuses with `stale info`), `--force`, branch creation and slashed
+    names. It also settles two cases the bare name got wrong: `+main` reaches
+    `refs/heads/+main`, and a repository holding both a branch and a tag named
+    `dup` pushes the BRANCH rather than failing with
+    `src refspec dup matches more than one`.
+  - `pull_args` names the SRC half only — `refs/heads/<branch>`. A `<src>:<dst>`
+    pair here would name a LOCAL ref for the fetch to update and git refuses to
+    fetch into the checked-out branch. Pull was in the same class and the issue
+    did not report it: `git pull --ff-only -- origin '+main'` merged `main`.
+    Milder (a local merge of the wrong branch, not remote history loss) and the
+    same defect. The auto-generated merge subject is unchanged —
+    `Merge branch 'main' of <url>` byte for byte.
+  - `push_delete_args` is deliberately NOT changed: `--delete` takes the name
+    literally, measured as `error: unable to delete '+keepme': remote ref does
+    not exist` with `keepme` untouched.
+  - `tests/network.rs` runs REAL git for all three, asserting the bare name's
+    damage as well as the fix. Reverting a builder fails four unit tests in
+    `commands/branches.rs`, but those only assert our own choice back to us —
+    the integration tests are the evidence that the choice is right, which is
+    the half #451 existed for: the grammar had been reasoned about, not run.
 - **Two paths REFUSE a dash-leading value instead, because a separator cannot
   carry them.** Both answer with `AppError::InvalidArgument`, and both are
   reachable rather than only ours: git accepts `git remote add -- -evil <url>`,

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -350,7 +350,29 @@ pub async fn unshallow(
 ///
 /// `--progress` for the same reason `fetch_args` carries it: a pull is a fetch,
 /// and the fetch half is the part that takes the time.
-fn pull_args<'a>(mode_flag: &'a str, remote: &'a str, branch: &'a str) -> AppResult<Vec<&'a str>> {
+///
+/// **The branch is named by its FULL ref** — #451 reaches this builder too,
+/// though the issue only reported the push half. The branch is a refspec to
+/// `git pull` as well, so a leading `+` was git's force marker here and the
+/// pull merged a different branch than the one named: measured against git
+/// 2.50.1 with a remote carrying both `main` and `+main`,
+/// `git pull --progress --ff-only -- origin '+main'` reported
+/// `* branch main -> FETCH_HEAD` and fast-forwarded to `main`. Milder than the
+/// push — a local merge of the wrong branch, not remote history loss — and the
+/// same defect.
+///
+/// Only the SRC half, unlike the push builders: a `<src>:<dst>` pair here
+/// names a LOCAL ref for the fetch to update, and git refuses to fetch into
+/// the branch that is checked out. Measured equivalent to the bare name for
+/// all three modes, including the auto-generated merge subject, which stays
+/// `Merge branch 'main' of <url>` byte for byte.
+///
+/// The dash refusal above still stands, and the REMOTE is now the half that
+/// needs it: a prefixed branch cannot begin with `-` any more, so its check is
+/// a clearer error rather than the injection guard it was. Keep both — the
+/// remote's is load-bearing, and one of the two silently becoming decorative
+/// is not a reason to make the pair inconsistent.
+fn pull_args(mode_flag: &str, remote: &str, branch: &str) -> AppResult<Vec<String>> {
     for (what, value) in [("remote", remote), ("branch", branch)] {
         if value.starts_with('-') {
             return Err(AppError::InvalidArgument(format!(
@@ -358,7 +380,14 @@ fn pull_args<'a>(mode_flag: &'a str, remote: &'a str, branch: &'a str) -> AppRes
             )));
         }
     }
-    Ok(vec!["pull", "--progress", mode_flag, "--", remote, branch])
+    Ok(vec![
+        "pull".to_string(),
+        "--progress".to_string(),
+        mode_flag.to_string(),
+        "--".to_string(),
+        remote.to_string(),
+        format!("refs/heads/{branch}"),
+    ])
 }
 
 #[tauri::command]
@@ -379,13 +408,14 @@ pub async fn pull(
     };
     // Before the path lookup: a refused argument must cost nothing.
     let args = pull_args(mode_flag, remote.as_str(), branch.as_str())?;
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let path = get_repo_path(&state, &repo_id).await?;
     let outcome = run_git_progress(
         &app,
         &path,
         &repo_id,
         NetOp::Pull,
-        &args,
+        &arg_refs,
         credentials.as_ref(),
     )
     .await;
@@ -512,6 +542,27 @@ pub async fn fast_forward_all_branches(
 /// `git push --progress -u --force-with-lease -- origin main` pushes normally,
 /// and `-- --receive-pack=/bin/false main` is refused as a strange pathname
 /// instead of running the named program.
+///
+/// **The branch is named in FULL on both sides of the refspec** — the fix for
+/// #451, and the shape `push_commit_args` already uses. `--` ends OPTION
+/// parsing, but the branch lands in REFSPEC position, which has a grammar of
+/// its own, and a leading `+` there is git's force marker. A branch
+/// legitimately named `+main` (git accepts it —
+/// `git check-ref-format --branch '+main'` passes, and a clone can bring one
+/// in) was therefore sent as "force-update `main`": measured against git
+/// 2.50.1 on a diverged remote as
+/// `+ b51af1b...bf589a0 main -> main (forced update)`, with no
+/// `refs/heads/+main` created and no `confirmRewrite` in front of it, because
+/// the app believed it was pushing normally.
+///
+/// Spelling both sides removes the ambiguity rather than detecting it, and
+/// costs nothing — measured equivalent to the bare name for `-u` (sets
+/// `branch.<n>.merge = refs/heads/<n>` identically), `--force-with-lease`
+/// (still refuses with `stale info`), `--force`, branch creation and slashed
+/// names. It also settles two cases the bare name got wrong: `+main` now
+/// reaches `refs/heads/+main`, and a repository holding both a branch and a
+/// tag named `dup` pushes the BRANCH instead of failing with
+/// `src refspec dup matches more than one`.
 fn push_args(
     remote: &str,
     branch: &str,
@@ -539,7 +590,9 @@ fn push_args(
     // user-supplied values after it.
     args.push("--".to_string());
     args.push(remote.to_string());
-    args.push(branch.to_string());
+    // Both sides in full, so no character of the branch name is ever the first
+    // character of the refspec — see the doc comment (#451).
+    args.push(format!("refs/heads/{branch}:refs/heads/{branch}"));
     args
 }
 
@@ -666,11 +719,24 @@ mod push_args_tests {
     fn no_verify_is_added_only_when_asked_and_precedes_the_separator() {
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, false),
-            vec!["push", "--progress", "--", "origin", "main"]
+            vec![
+                "push",
+                "--progress",
+                "--",
+                "origin",
+                "refs/heads/main:refs/heads/main"
+            ]
         );
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, true),
-            vec!["push", "--progress", "--no-verify", "--", "origin", "main"]
+            vec![
+                "push",
+                "--progress",
+                "--no-verify",
+                "--",
+                "origin",
+                "refs/heads/main:refs/heads/main"
+            ]
         );
     }
 
@@ -686,7 +752,7 @@ mod push_args_tests {
                 "--no-verify",
                 "--",
                 "origin",
-                "feat/x"
+                "refs/heads/feat/x:refs/heads/feat/x"
             ]
         );
     }
@@ -749,11 +815,24 @@ mod push_args_tests {
     fn adds_u_only_when_requested() {
         assert_eq!(
             push_args("origin", "main", PushForce::None, true, false),
-            vec!["push", "--progress", "-u", "--", "origin", "main"]
+            vec![
+                "push",
+                "--progress",
+                "-u",
+                "--",
+                "origin",
+                "refs/heads/main:refs/heads/main"
+            ]
         );
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, false),
-            vec!["push", "--progress", "--", "origin", "main"]
+            vec![
+                "push",
+                "--progress",
+                "--",
+                "origin",
+                "refs/heads/main:refs/heads/main"
+            ]
         );
     }
 
@@ -770,7 +849,7 @@ mod push_args_tests {
                 "--force-with-lease",
                 "--",
                 "origin",
-                "main"
+                "refs/heads/main:refs/heads/main"
             ]
         );
         assert_eq!(
@@ -782,9 +861,83 @@ mod push_args_tests {
                 "--force",
                 "--",
                 "origin",
-                "feat/x"
+                "refs/heads/feat/x:refs/heads/feat/x"
             ]
         );
+    }
+
+    // ─── #451: refspec position ─────────────────────────────────────────────
+
+    /// A branch whose name begins with `+` used to force-update a DIFFERENT
+    /// ref. The branch lands in refspec position, where a leading `+` is git's
+    /// force marker, so `+main` pushed local `main` over remote `main` and
+    /// never created `refs/heads/+main`.
+    ///
+    /// Measured against git 2.50.1 with a diverged remote, before this fix:
+    /// `git push --progress -- origin '+main'` answered
+    /// `+ b51af1b...bf589a0 main -> main (forced update)` and
+    /// `git ls-remote origin | grep -c 'heads/+main'` was `0`. Silent history
+    /// loss on the remote's default branch, with no `confirmRewrite` in front
+    /// of it, because as far as the app was concerned this was an ordinary
+    /// push. `--` does not help: it ends OPTION parsing, not refspec parsing.
+    #[test]
+    fn a_plus_leading_branch_pushes_itself_not_a_force_refspec() {
+        let args = push_args("origin", "+main", PushForce::None, false, false);
+        assert_eq!(
+            args,
+            vec![
+                "push",
+                "--progress",
+                "--",
+                "origin",
+                "refs/heads/+main:refs/heads/+main"
+            ]
+        );
+        // The bare name is the spelling git read as a force refspec, so its
+        // absence is the fix — asserting the pair alone would still pass for a
+        // builder that emitted both.
+        assert!(!args.iter().any(|a| a == "+main"), "{args:?}");
+    }
+
+    /// The same for a tag: `push_tag_args` puts the tag name in refspec
+    /// position too. Measured before the fix:
+    /// `git push --progress -- origin '+v1.2.0'` created no `+v1.2.0` and
+    /// force-updated `v1.2.0` instead.
+    #[test]
+    fn a_plus_leading_tag_pushes_itself_not_a_force_refspec() {
+        let args = push_tag_args("origin", "+v1.2.0");
+        assert_eq!(
+            args,
+            ["push", "--", "origin", "refs/tags/+v1.2.0:refs/tags/+v1.2.0"]
+        );
+        assert!(!args.iter().any(|a| *a == "+v1.2.0"), "{args:?}");
+    }
+
+    /// The invariant behind both: every user-supplied ref name is spelled as a
+    /// FULL `refs/…` path on both sides of the refspec, so no character of the
+    /// name is ever the first character of the refspec. That is what makes the
+    /// refspec metacharacters (`+` force, a leading `^` negation) ordinary
+    /// characters of a ref name instead of grammar.
+    #[test]
+    fn a_user_ref_name_is_never_the_start_of_the_refspec() {
+        // `:` and `^` are already illegal in a ref name, but the builders must
+        // not depend on a validator they do not call.
+        for name in ["+main", "^main", "-main", "main", "feat/+x", "+"] {
+            let args = push_args("origin", name, PushForce::None, false, false);
+            let spec = args.last().expect("a refspec is emitted");
+            assert_eq!(
+                *spec,
+                format!("refs/heads/{name}:refs/heads/{name}"),
+                "branch {name:?} must be named in full on both sides"
+            );
+
+            let targs = push_tag_args("origin", name);
+            assert_eq!(
+                *targs.last().expect("a refspec is emitted"),
+                format!("refs/tags/{name}:refs/tags/{name}"),
+                "tag {name:?} must be named in full on both sides"
+            );
+        }
     }
 
     /// #212, audit finding 4: these were the two push builders without an
@@ -814,10 +967,15 @@ mod push_args_tests {
             // PRESENT and after the separator. A bare `if` here would also pass
             // for a builder that dropped the user's value altogether, which is
             // a different bug but not a passing one.
+            // `contains`, not `starts_with`: since #451 the branch is wrapped
+            // in a full refspec, so a hostile branch name is no longer the
+            // start of its argument — which is exactly the protection, but it
+            // also means a `starts_with` probe would quietly find nothing and
+            // leave this guard asserting against an empty set.
             let at: Vec<usize> = args
                 .iter()
                 .enumerate()
-                .filter(|(_, a)| a.starts_with("--receive-pack"))
+                .filter(|(_, a)| a.contains("--receive-pack"))
                 .map(|(i, _)| i)
                 .collect();
             assert_eq!(
@@ -847,7 +1005,14 @@ mod push_args_tests {
         for mode_flag in ["--ff-only", "--no-rebase", "--rebase"] {
             assert_eq!(
                 pull_args(mode_flag, "origin", "main").unwrap(),
-                vec!["pull", "--progress", mode_flag, "--", "origin", "main"]
+                vec![
+                    "pull",
+                    "--progress",
+                    mode_flag,
+                    "--",
+                    "origin",
+                    "refs/heads/main"
+                ]
             );
         }
     }
@@ -874,6 +1039,37 @@ mod push_args_tests {
     #[test]
     fn pull_args_accept_a_dash_that_is_not_leading() {
         assert!(pull_args("--rebase", "my-remote", "feat/-x").is_ok());
+    }
+
+    /// #451 reaches `pull` as well, and the issue did not cover it: the branch
+    /// is a REFSPEC to `git pull` too, so a leading `+` merged a different
+    /// branch than the one named.
+    ///
+    /// Measured against git 2.50.1, with a remote carrying both `main` and
+    /// `+main`: `git pull --progress --ff-only -- origin '+main'` reported
+    /// `* branch main -> FETCH_HEAD` and fast-forwarded to `main`'s tip.
+    /// Milder than the push (it is a local merge of the wrong branch, not
+    /// remote history loss) but the same defect.
+    ///
+    /// The fix here is the SRC half only. A `<src>:<dst>` pair the way the
+    /// push builders use is wrong for pull: the dst would name a local branch
+    /// to update, and git refuses to fetch into the checked-out one.
+    #[test]
+    fn pull_args_name_the_branch_by_its_full_ref() {
+        assert_eq!(
+            pull_args("--ff-only", "origin", "+main").unwrap(),
+            vec!["pull", "--progress", "--ff-only", "--", "origin", "refs/heads/+main"]
+        );
+        // The bare name is the spelling git read as a force refspec.
+        let args = pull_args("--ff-only", "origin", "+main").unwrap();
+        assert!(!args.iter().any(|a| *a == "+main"), "{args:?}");
+
+        // ...and an ordinary branch is named the same way, so there is one
+        // shape rather than a special case that only triggers on `+`.
+        assert_eq!(
+            pull_args("--rebase", "origin", "feat/x").unwrap(),
+            vec!["pull", "--progress", "--rebase", "--", "origin", "refs/heads/feat/x"]
+        );
     }
 }
 
@@ -1034,8 +1230,19 @@ pub async fn checkout_ref(
 /// refspec; with it, git reports `src refspec --receive-pack=… does not match
 /// any`. Same class of finding as the #61 D5 security review's third item, where
 /// `verify_commit` handed an oid straight to `git show`.
-fn push_tag_args<'a>(remote: &'a str, name: &'a str) -> Vec<&'a str> {
-    vec!["push", "--", remote, name]
+///
+/// The tag is named in FULL on both sides for the reason `push_args` gives
+/// (#451): the separator ends option parsing, not refspec parsing, so a tag
+/// named `+v1.2.0` was read as "force-update `v1.2.0`". Measured against git
+/// 2.50.1: `git push --progress -- origin '+v1.2.0'` created no `+v1.2.0` and
+/// updated `v1.2.0` instead; the pair creates `refs/tags/+v1.2.0`.
+fn push_tag_args(remote: &str, name: &str) -> Vec<String> {
+    vec![
+        "push".to_string(),
+        "--".to_string(),
+        remote.to_string(),
+        format!("refs/tags/{name}:refs/tags/{name}"),
+    ]
 }
 
 /// Build `git push --delete <remote> <branch>` args.
@@ -1058,7 +1265,9 @@ pub async fn push_tag(
     credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git_creds(&path, &push_tag_args(&remote, &name), credentials.as_ref()).await
+    let args = push_tag_args(&remote, &name);
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    run_git_creds(&path, &arg_refs, credentials.as_ref()).await
 }
 
 #[tauri::command]
@@ -1129,7 +1338,10 @@ mod tests {
 
     #[test]
     fn push_tag_args_end_options_before_the_user_values() {
-        assert_eq!(push_tag_args("origin", "v1.2.0"), ["push", "--", "origin", "v1.2.0"]);
+        assert_eq!(
+            push_tag_args("origin", "v1.2.0"),
+            ["push", "--", "origin", "refs/tags/v1.2.0:refs/tags/v1.2.0"]
+        );
     }
 
     #[test]
@@ -1146,19 +1358,32 @@ mod tests {
         // The injection this guards: `--receive-pack` names a program git runs
         // for the transport. Both builders must keep every user-supplied value
         // strictly after the `--`.
-        for args in [
+        //
+        // `contains`, not `starts_with`: since #451 the tag builder wraps the
+        // name in a full refspec, so the hostile value is no longer the start
+        // of its argument — which is the point, but it means a `starts_with`
+        // probe would silently stop finding the value and this guard would
+        // pass without checking anything.
+        let sets: Vec<Vec<String>> = vec![
             push_tag_args("--receive-pack=/bin/false", "v1"),
             push_tag_args("origin", "--receive-pack=/bin/false"),
-            push_delete_args("--receive-pack=/bin/false", "main"),
-            push_delete_args("origin", "--receive-pack=/bin/false"),
-        ] {
+            push_delete_args("--receive-pack=/bin/false", "main")
+                .iter()
+                .map(|a| (*a).to_string())
+                .collect(),
+            push_delete_args("origin", "--receive-pack=/bin/false")
+                .iter()
+                .map(|a| (*a).to_string())
+                .collect(),
+        ];
+        for args in sets {
             let sep = args
                 .iter()
-                .position(|a| *a == "--")
+                .position(|a| a == "--")
                 .expect("builders must emit an end-of-options separator");
             let hostile = args
                 .iter()
-                .position(|a| a.starts_with("--receive-pack"))
+                .position(|a| a.contains("--receive-pack"))
                 .expect("test value present");
             assert!(hostile > sep, "{args:?}");
         }

--- a/src-tauri/tests/network.rs
+++ b/src-tauri/tests/network.rs
@@ -6,6 +6,7 @@
 mod support;
 
 use platypusgit_lib::git::GitBackend;
+use std::path::PathBuf;
 use support::{BareTempRepo, TempRepo};
 
 // ─────────────────────────────────────────────────────────────
@@ -311,4 +312,247 @@ fn push_with_u_leaves_an_upstream_branches_reports() {
         .find(|b| b.name == "main" && !b.is_remote)
         .expect("main branch");
     assert_eq!(main.upstream.as_deref(), Some("origin/main"));
+}
+
+// ─────────────────────────────────────────────────────────────
+// #451: a ref name beginning with `+` is a FORCE REFSPEC
+// ─────────────────────────────────────────────────────────────
+//
+// The argv `push_args`/`push_tag_args`/`pull_args` build is pinned by the unit
+// tests in `commands/branches.rs`, and reverting a builder to a bare ref name
+// fails four of them. What those cannot do is say whether the pinned string is
+// the RIGHT one: they assert our own choice back to us. These three pin the
+// evidence for that choice — git's behaviour, which is not ours to change and
+// which #451 existed because we had reasoned about rather than run.
+//
+// `--` ends OPTION parsing. The ref lands in REFSPEC position, which has a
+// grammar of its own, and a leading `+` there means *force-update*. So a branch
+// legitimately named `+main` — git accepts it, and a clone can bring one in —
+// was sent as "force-update `main`": the remote's default branch silently
+// overwritten, with no `confirmRewrite` in front of it, because as far as the
+// app was concerned this was an ordinary push.
+//
+// Each test asserts BOTH shapes. The bare-name half is the damage, so reverting
+// the fix fails here with the ref that moved rather than only on a string.
+
+/// Run `git -C <dir> <args…>`; return (success, stderr).
+fn git_at(dir: &std::path::Path, args: &[&str]) -> (bool, String) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("run git");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Subject of `HEAD` — which branch a pull actually merged.
+fn head_subject(dir: &std::path::Path) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["log", "-1", "--format=%s"])
+        .output()
+        .expect("run git log");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Does the bare remote carry this exact ref?
+fn bare_has(bare: &std::path::Path, full_ref: &str) -> bool {
+    git2::Repository::open_bare(bare)
+        .expect("open bare")
+        .find_reference(full_ref)
+        .is_ok()
+}
+
+/// Work repo wired to `bare`, with `main` already pushed.
+fn work_against(bare: &BareTempRepo) -> (TempRepo, PathBuf) {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let work = tr.path_buf();
+    assert!(
+        git_at(&work, &["remote", "add", "origin", bare.path.to_str().unwrap()]).0,
+        "add origin"
+    );
+    assert!(git_at(&work, &["push", "origin", "main"]).0, "seed push");
+    (tr, work)
+}
+
+#[test]
+fn a_bare_plus_branch_name_force_updates_the_branch_without_the_plus() {
+    if !git_available() {
+        eprintln!("SKIP: git not on PATH");
+        return;
+    }
+
+    let bare = BareTempRepo::new();
+    let (_tr, work) = work_against(&bare);
+
+    // git itself accepts the name — which is what makes this reachable at all.
+    assert!(
+        git_at(&work, &["check-ref-format", "--branch", "+main"]).0,
+        "git must accept `+main` as a branch name, or this bug is unreachable"
+    );
+
+    // Diverge local `main` from the remote, so the damage is a REWRITE and not
+    // a fast-forward that could be mistaken for harmless.
+    assert!(git_at(&work, &["commit", "--allow-empty", "-m", "second"]).0);
+    assert!(git_at(&work, &["push", "origin", "main"]).0, "advance main");
+    assert!(git_at(&work, &["branch", "+main"]).0);
+    assert!(git_at(&work, &["reset", "--hard", "HEAD~1"]).0);
+    assert!(git_at(&work, &["commit", "--allow-empty", "-m", "rewritten"]).0);
+
+    // The shape the app used to send.
+    let (ok, err) = git_at(&work, &["push", "--progress", "--", "origin", "+main"]);
+    assert!(ok, "bare `+main` push failed unexpectedly: {err}");
+    assert!(
+        !bare_has(&bare.path, "refs/heads/+main"),
+        "the bare name is supposed to MISS the branch the user picked"
+    );
+    assert!(
+        err.contains("forced update"),
+        "the bare name is supposed to force-update `main` instead: {err}"
+    );
+
+    // The shape the app sends now: named in full on both sides, so the `+` is
+    // an ordinary character of the ref name rather than refspec grammar.
+    let (ok, err) = git_at(
+        &work,
+        &[
+            "push",
+            "--progress",
+            "--",
+            "origin",
+            "refs/heads/+main:refs/heads/+main",
+        ],
+    );
+    assert!(ok, "full-refspec push failed: {err}");
+    assert!(
+        bare_has(&bare.path, "refs/heads/+main"),
+        "the full refspec must create the branch the user picked: {err}"
+    );
+}
+
+/// The tag half. `+v1.2.0` is a force refspec whose SRC is `v1.2.0`, so the
+/// damage depends on whether a `v1.2.0` also exists:
+///
+/// - it does — the common case, since a `+`-prefixed tag is usually a variant
+///   of one — and the wrong tag is pushed, silently, which is what this pins;
+/// - it does not, and git refuses with `src refspec v1.2.0 does not match any`,
+///   which is wrong but at least loud.
+#[test]
+fn a_bare_plus_tag_name_pushes_the_tag_without_the_plus() {
+    if !git_available() {
+        eprintln!("SKIP: git not on PATH");
+        return;
+    }
+
+    let bare = BareTempRepo::new();
+    let (_tr, work) = work_against(&bare);
+    assert!(git_at(&work, &["tag", "v1.2.0"]).0);
+    assert!(git_at(&work, &["commit", "--allow-empty", "-m", "second"]).0);
+    assert!(git_at(&work, &["tag", "+v1.2.0"]).0);
+
+    let (ok, err) = git_at(&work, &["push", "--progress", "--", "origin", "+v1.2.0"]);
+    assert!(ok, "bare `+v1.2.0` push failed unexpectedly: {err}");
+    assert!(
+        !bare_has(&bare.path, "refs/tags/+v1.2.0"),
+        "the bare name is supposed to MISS the tag the user picked"
+    );
+    assert!(
+        bare_has(&bare.path, "refs/tags/v1.2.0"),
+        "...and to push the OTHER tag instead: {err}"
+    );
+
+    let (ok, err) = git_at(
+        &work,
+        &[
+            "push",
+            "--progress",
+            "--",
+            "origin",
+            "refs/tags/+v1.2.0:refs/tags/+v1.2.0",
+        ],
+    );
+    assert!(ok, "full-refspec tag push failed: {err}");
+    assert!(
+        bare_has(&bare.path, "refs/tags/+v1.2.0"),
+        "the full refspec must create the tag the user picked: {err}"
+    );
+}
+
+/// The pull half, which #451 did not report: the branch is a refspec to
+/// `git pull` as well, so a leading `+` merged a DIFFERENT branch than the one
+/// named. Milder than the push — a local merge of the wrong branch rather than
+/// remote history loss — and the same defect.
+///
+/// `pull_args` names the SRC half only. A `<src>:<dst>` pair the way the push
+/// builders use it is wrong here: the dst would name a LOCAL ref for the fetch
+/// to update, and git refuses to fetch into the checked-out branch.
+#[test]
+fn a_bare_plus_branch_name_pulls_the_branch_without_the_plus() {
+    if !git_available() {
+        eprintln!("SKIP: git not on PATH");
+        return;
+    }
+
+    // A remote carrying two DIFFERENT branches, `main` and `+main`, so which
+    // one arrived is visible in the log.
+    let bare = BareTempRepo::new();
+    let (_seed, sp) = work_against(&bare);
+    assert!(git_at(&sp, &["commit", "--allow-empty", "-m", "main only"]).0);
+    assert!(git_at(&sp, &["push", "origin", "main"]).0, "advance main");
+    assert!(git_at(&sp, &["checkout", "-b", "+main", "HEAD~1"]).0);
+    assert!(git_at(&sp, &["commit", "--allow-empty", "-m", "plusmain only"]).0);
+    assert!(
+        git_at(&sp, &["push", "origin", "refs/heads/+main:refs/heads/+main"]).0,
+        "seed the +main branch"
+    );
+
+    // A clone sitting one commit behind `main`, so a pull has work to do.
+    let clone_behind = |dir: &std::path::Path| {
+        let ok = std::process::Command::new("git")
+            .args(["clone", "--quiet"])
+            .arg(&bare.path)
+            .arg(dir)
+            .status()
+            .expect("run git clone")
+            .success();
+        assert!(ok, "clone failed");
+        assert!(git_at(dir, &["checkout", "-B", "work", "origin/main~1"]).0);
+    };
+
+    let a_dir = tempfile::tempdir().expect("tempdir");
+    let a = a_dir.path().join("bare-name");
+    clone_behind(&a);
+    let (ok, err) = git_at(&a, &["pull", "--progress", "--ff-only", "--", "origin", "+main"]);
+    assert!(ok, "bare `+main` pull failed unexpectedly: {err}");
+    assert_eq!(
+        head_subject(&a),
+        "main only",
+        "the bare name is supposed to merge the WRONG branch"
+    );
+
+    let b_dir = tempfile::tempdir().expect("tempdir");
+    let b = b_dir.path().join("full-ref");
+    clone_behind(&b);
+    let (ok, err) = git_at(
+        &b,
+        &[
+            "pull",
+            "--progress",
+            "--ff-only",
+            "--",
+            "origin",
+            "refs/heads/+main",
+        ],
+    );
+    assert!(ok, "full-ref pull failed: {err}");
+    assert_eq!(
+        head_subject(&b),
+        "plusmain only",
+        "the full ref must merge the branch the user picked"
+    );
 }


### PR DESCRIPTION
A branch or tag whose name begins with `+` was sent as a **force refspec**: git force-updated the ref *without* the plus and never touched the one the user selected. No `confirmRewrite` ran, because as far as the app was concerned this was an ordinary push.

The `--` separator from #447 does not help — it ends **option** parsing, while the ref lands in **refspec** position, which has a grammar of its own where a leading `+` means force-update. `validate_ref_name` cannot catch it either: `+` is legal in a ref name, and git accepts `+main` as a branch.

## Reproduced (git 2.50.1, diverged remote)

```
$ git push --progress -- origin '+main'
 + b51af1b...bf589a0 main -> main (forced update)
$ git ls-remote origin | grep -c 'heads/+main'
0
```

Silent history loss on the remote's default branch.

## Pull is in the same class — #451 did not report it

The branch is a refspec to `git pull` too. With a remote carrying both `main` and `+main`:

```
$ git pull --progress --ff-only -- origin '+main'
 * branch            main       -> FETCH_HEAD
```

It merged the **wrong branch**. Milder than the push — a local merge, not remote history loss — but the same defect, so it is fixed here rather than filed separately.

## The fix

Name the ref in **full**, the shape `push_commit_args` already used, so no character of the name is ever the first character of the refspec:

| Builder | Now sends | |
|---|---|---|
| `push_args` | `refs/heads/<b>:refs/heads/<b>` | |
| `push_tag_args` | `refs/tags/<t>:refs/tags/<t>` | |
| `pull_args` | `refs/heads/<b>` | src half only — a `<src>:<dst>` pair names a LOCAL ref and git refuses to fetch into the checked-out branch |
| `push_delete_args` | unchanged | `--delete` takes the name literally |

This **removes** the ambiguity rather than detecting it, so a `+main` branch now pushes correctly instead of being refused.

## Measured equivalence

No behaviour change for any ordinary ref. Verified against git 2.50.1:

- `-u` still writes `branch.<n>.merge = refs/heads/<n>`
- `--force-with-lease` still refuses a stale push with `! [rejected] main -> main (stale info)`
- `--force`, branch creation, slashed names
- all three pull modes, including the auto-generated merge subject — `Merge branch 'main' of <url>`, byte for byte
- the non-fast-forward rejection advice, including the `'git pull' before pushing again` line `remote.e2e.ts` asserts

Two cases the bare name got **wrong** are also settled: `+main` reaches `refs/heads/+main`, and a repository holding both a branch and a tag named `dup` pushes the BRANCH instead of failing with `src refspec dup matches more than one`.

`push_delete_args` was checked in both directions and left alone: it deletes `+keepme` and leaves `keepme` untouched.

## Tests

Four unit guards in `commands/branches.rs` pin the argv; reverting any builder to a bare name fails all four (planted and confirmed, then restored).

Three new tests in `tests/network.rs` run **real git** against a bare remote and assert the bare name's damage as well as the fix. The unit tests only assert our own choice back to us — these are the evidence that the choice is right, which is the half #451 existed for: the grammar had been reasoned about, not run.

Green: 393 lib + all Rust integration tests, 4048 vitest tests, `tsc --noEmit`, and `remote.e2e.ts` (11 passing) in Docker.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
