### PR TITLE
feat(theme): Arc-style palette harmony and a shuffle for the theme editor

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -2039,10 +2039,40 @@ update checks back on for someone who turned them off.
   combination, because a report with twenty findings is one nobody reads. Save
   is never disabled by a finding: a deliberately low-contrast theme is the
   user's own call. A user never reads a colour-slot key; each finding carries
-  prose. `deriveTheme` is the guided start (base + accent) and recalculates
-  `accentInk` alone, preferring the base theme's own inks so derived themes stay
-  in the family — it is deliberately not a palette generator, because shifting
-  the greys too produces palettes nobody can predict or correct.
+  prose. `deriveTheme` is the accent swap the eighteen-slot path uses and
+  recalculates `accentInk` alone, preferring the base theme's own inks so
+  derived themes stay in the family.
+- **The palette generator holds LIGHTNESS and rewrites hue and chroma**
+  (`theme/palette.ts`). The editor's four traits — base ramp, seed colour,
+  harmony rule, tint strength — are its only inputs, each one lockable so the
+  dice re-rolls the rest. The earlier "deliberately not a palette generator"
+  rule was about HSL, where hue and lightness are one knob; OKLCh separates
+  them, and holding `l` is what keeps the base's hand-tuned ramp and its
+  contrast intact. Three properties are pinned by `palette.test.ts` and are why
+  the reversal is defensible rather than a change of mind: **tint 0 reproduces
+  the base byte-for-byte under EVERY rule** (so opening the editor moves
+  nothing), **no hue at any strength changes an AA verdict** (measured 0 in
+  3240 checks), and every output lands in sRGB via `srgbChromaCeiling`. Three
+  traps, each one a bug that shipped and was caught by a test written the strong
+  way:
+  - **The hue is a ROTATION, not an assignment.** dracula, solarized-dark and
+    gruvbox-dark put their text at a different hue from their surfaces on
+    purpose (dracula's split is 171°), and assigning one hue flattens all three.
+  - **The chroma is ADDITIVE over the base's own,** because a multiplier cannot
+    tint `dark-neutral`, which is chroma 0 in all fourteen slots. The cost is
+    that the same tint value bites harder on a base that already carries colour.
+  - **Tint 0 short-circuits the whole ramp AND the logo pair,** so `generate`
+    degenerates at 0 to exactly `deriveTheme`. Without it the ground is
+    `seed + the rule's quantised angle` while a base's real offset is whatever
+    it is — dark-cool sits at 18.6°, which no rule has — so merely opening a
+    theme rotated every slot and moved `bg0` from `#1a1d24` to `#1b1d24`.
+  `isGenerated` is what flips the readout to "Custom", and it skips `accentInk`:
+  the built-ins ship hand-authored inks that `inkFor` would not pick off their
+  own ramps, so comparing it made every theme read as Custom the moment it
+  opened. Traits are INFERRED from the palette on open and never persisted, so
+  the theme file format is unchanged. `SEMANTIC_TOKENS` and `SYNTAX_TOKENS` stay
+  out of it: diff green carries meaning, and a palette choice must not change
+  what a diff says.
 - **One theme format.** `themePayload()` is the per-theme serialiser behind both
   `exportTheme` and the settings bundle; the bundle adds only `id`, because
   `activeThemeId` has to stay resolvable. `normalizeCustomThemes` is lenient in

--- a/docs/superpowers/plans/2026-09-11-theme-palette-harmony.md
+++ b/docs/superpowers/plans/2026-09-11-theme-palette-harmony.md
@@ -1,0 +1,1634 @@
+# Theme palette harmony + shuffle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the theme editor an Arc-style palette: four lockable traits (base
+ramp, seed colour, harmony rule, tint strength) that generate all eighteen colour
+slots, plus a dice that re-rolls the unlocked ones.
+
+**Architecture:** One new pure module, `src/features/settings/theme/palette.ts`,
+holding every piece of arithmetic. It rewrites hue and chroma in OKLCh while
+holding each slot's lightness exactly, so the base theme's hand-tuned ramp and
+its contrast survive generation. `useThemeEditorStore` gains the four traits and
+their locks; `ThemeEditorDialog` replaces its "Start from" and "Accent" rows with
+a Palette section. `deriveTheme.ts` is unchanged except for exporting `inkFor`.
+
+**Tech Stack:** TypeScript, React 19, Zustand, vitest (jsdom for components, node
+for doc guards), existing OKLCh helpers in `src/lib/cssColor.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md`
+
+## Global Constraints
+
+Copied verbatim from the spec and from `CLAUDE.md`. Every task's requirements
+implicitly include these.
+
+- **Node 22 + pnpm.** Not npm, not yarn. The assistant's Bash tool does not
+  inherit an interactive shell rc — invoke as `~/Library/pnpm/pnpm`.
+- **This worktree has no `node_modules` until `pnpm install` has run.** Do that
+  once before Task 1.
+- **`@/` is the path alias for `src/`.** Use it for cross-feature imports; use
+  relative paths inside `features/settings/theme/`, matching the files already
+  there.
+- **Lightness is held, never recomputed.** `o.l` from `rgbToOklch` goes straight
+  back into `oklchToRgb`. This is what the contrast guarantee rests on.
+- **Chroma is additive over the base's own and clamped to
+  `srgbChromaCeiling(l, h)`.** Never a bare multiplier — a multiplier cannot tint
+  an achromatic ramp, and an unclamped chroma gets per-channel clipped, which
+  shifts the hue silently.
+- **Hue is a rotation by `groundHue − familyHue`, never an assignment** — except
+  when `familyHue` is `null`, where assignment is the only option and the slots
+  are grey anyway.
+- **`TINT_REACH = 0.06`**, **`CHROMA_FLOOR = 0.004`**, **harmony inference
+  tolerance `±15°`**, **seed roll bands L `[0.52, 0.78]` / C `[0.06, 0.19]`**,
+  **strength roll band `[0.15, 0.70]`**, **default rule `analogous` at strength
+  `0.35`**.
+- **Icons come from `PGIcon`.** `src/design/icons.tsx` is the ONLY file that may
+  import `lucide-react`, and every icon name written as a string literal must be
+  a member of `IconName`. `test/iconSet.test.ts` fails the build for both.
+- **No native `<select>`/`<option>` and no `<input type="color">` in shipped
+  `src/`.** Use `PGSelect` and `PGColorSwatch`. Guard tests enforce both.
+- **Contrast advises, never blocks.** No Save is ever disabled by a finding.
+- **Commit style:** `feat(scope): …` / `fix(scope): …` / `test: …` / `docs: …`,
+  short imperative subject under 72 chars. End assistant-driven commits with
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+- **Never put a backtick in a `git commit -m` message** — the Bash tool evals the
+  command and the backtick runs as a subshell that blocks forever. Use plain
+  words, or `git commit -F <file>`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/features/settings/theme/palette.ts` | **New.** All palette arithmetic: family hue, ramp tinting, harmony offsets, generation, trait inference, trait rolling. Pure — no React, no DOM, no store. |
+| `src/features/settings/theme/palette.test.ts` | **New.** The three measured guarantees, swept over all nine built-ins, plus roll bands and inference round-trip. |
+| `src/design/icons.tsx` | Add `dice`, `lockOpen`, `palette` to the map and to `IconName`. |
+| `src/design/color-picker.tsx` | Rename the private `Slider` to `PGSlider` and export it. |
+| `src/features/settings/theme/deriveTheme.ts` | Export `inkFor` so the generator reuses the one ink rule. Nothing else changes. |
+| `src/features/settings/theme/useThemeEditorStore.ts` | Four trait fields, four locks, `setTrait`, `toggleLock`, `shuffle`. `applyBase` becomes a trait write. |
+| `src/features/settings/theme/ThemeEditorDialog.tsx` | The Palette section replaces the "Start from" and "Accent" rows. |
+| `docs/dev/frontend.md` | The "deliberately not a palette generator" sentence is now wrong. |
+| `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md` | Its non-goal gets a line pointing at the new spec. |
+
+---
+
+### Task 1: Expose the slider and add the three icons
+
+The only changes to the design system. Reviewed on their own because they widen
+a public surface that the rest of the app can then reach for.
+
+**Files:**
+- Modify: `src/design/color-picker.tsx` (the `Slider` function at ~line 622, and
+  its two call sites in `ValueSlider` and `ChannelSlider`)
+- Modify: `src/design/icons.tsx`
+- Test: `test/iconSet.test.ts` (existing — must keep passing), and a new case in
+  `src/design/color-picker.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `PGSlider` exported from `@/design`, props
+    `{ name: string; valueText: string; min: number; max: number; step: number; value: number; shownValue?: number; vertical?: boolean; trackCss: string; onChange: (next: number) => void }`
+  - `IconName` gains the literals `"dice"`, `"lockOpen"`, `"palette"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/design/color-picker.test.tsx`:
+
+```tsx
+import { PGSlider } from "./color-picker";
+
+describe("PGSlider", () => {
+  it("is exported for reuse and reports the full slider value trio", () => {
+    render(
+      <PGSlider
+        name="Tint"
+        valueText="35%"
+        min={0}
+        max={1}
+        step={0.01}
+        value={0.35}
+        trackCss="linear-gradient(90deg, #000, #fff)"
+        onChange={() => {}}
+      />,
+    );
+    const slider = screen.getByRole("slider", { name: "Tint" });
+    expect(slider).toHaveAttribute("aria-valuemin", "0");
+    expect(slider).toHaveAttribute("aria-valuemax", "1");
+    expect(slider).toHaveAttribute("aria-valuenow", "0.35");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/design/color-picker.test.tsx -t "exported for reuse"`
+
+Expected: FAIL — `PGSlider` is not exported from `./color-picker` (the function
+is named `Slider` and is module-private).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/design/color-picker.tsx`, rename the function and export it:
+
+```tsx
+export function PGSlider({
+  name,
+  valueText,
+  min,
+  max,
+  step,
+  value,
+  shownValue,
+  vertical,
+  trackCss,
+  onChange,
+}: {
+```
+
+Update its two call sites in the same file — `<Slider` becomes `<PGSlider` in
+both `ValueSlider` and `ChannelSlider`. There are exactly two; grep to confirm:
+
+```bash
+grep -c "<Slider" src/design/color-picker.tsx   # expect 0 after the change
+grep -c "<PGSlider" src/design/color-picker.tsx # expect 2 (3 counting the test file separately)
+```
+
+In `src/design/icons.tsx`, add the three lucide imports to the existing
+alphabetical import block:
+
+```tsx
+  Dices,
+  LockOpen,
+  Palette,
+```
+
+Add the literals to the `IconName` union, on the line that already carries
+`"lock"`:
+
+```tsx
+  | "download" | "upload" | "link" | "lock" | "lockOpen" | "dice" | "palette"
+```
+
+And the three map entries beside the existing `lock: Lock,`:
+
+```tsx
+  lockOpen: LockOpen,
+  dice: Dices,
+  palette: Palette,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+~/Library/pnpm/pnpm vitest run src/design/color-picker.test.tsx test/iconSet.test.ts
+```
+
+Expected: PASS. `iconSet.test.ts` matters as much as the new case — it is the
+guard that fails the build if a lucide import escapes `icons.tsx` or a call-site
+literal is not in the union.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/design/color-picker.tsx src/design/icons.tsx src/design/color-picker.test.tsx
+git commit -m "feat(design): export PGSlider and add dice, lockOpen, palette icons"
+```
+
+---
+
+### Task 2: The ramp tint — `familyHue` and `tintRamp`
+
+The core arithmetic, and the two measured guarantees that make reversing the old
+non-goal defensible. Write the tests first and let them carry the real numbers —
+they are the argument, not decoration.
+
+**Files:**
+- Create: `src/features/settings/theme/palette.ts`
+- Test: `src/features/settings/theme/palette.test.ts`
+
+**Interfaces:**
+- Consumes: `ThemeColors` from `@/features/settings/useSettingsStore`;
+  `hexToRgb`, `rgbToHex` from `@/lib/color`; `oklchToRgb`, `rgbToOklch`,
+  `srgbChromaCeiling` from `@/lib/cssColor`.
+- Produces:
+  - `RAMP_SLOTS: readonly (keyof ThemeColors)[]` — the fourteen tinted slots.
+  - `familyHue(colors: ThemeColors): number | null`
+  - `tintRamp(colors: ThemeColors, groundHue: number, strength: number): ThemeColors`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/settings/theme/palette.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+import { hexToRgb } from "@/lib/color";
+import { rgbToOklch, srgbChromaCeiling } from "@/lib/cssColor";
+
+import { contrastRatio } from "./contrast";
+import { RAMP_SLOTS, familyHue, tintRamp } from "./palette";
+
+const oklch = (hex: string) => rgbToOklch(hexToRgb(hex)!);
+
+/** The three ramp pairs. accentInk/accent is excluded: the accent is a seed and is never tinted. */
+const RAMP_PAIRS = [
+  ["fg0", "bg0"],
+  ["fg1", "bg1"],
+  ["fg2", "bg1"],
+] as const;
+
+const band = (r: number) => (r < 3 ? "bad" : r < 4.5 ? "low" : "ok");
+
+describe("familyHue", () => {
+  it("is null only for a fully achromatic ramp", () => {
+    // Measured: of the nine built-ins, dark-neutral alone has no slot above the
+    // chroma floor. light, gruvbox-dark and github-light have achromatic
+    // BACKGROUNDS but still resolve a hue from the rest of the ramp.
+    for (const t of BUILTIN_THEMES) {
+      const hue = familyHue(t.colors);
+      if (t.id === "dark-neutral") expect(hue, t.id).toBeNull();
+      else expect(hue, t.id).not.toBeNull();
+    }
+  });
+
+  it("lands on the hue the ramp actually reads as", () => {
+    // Measured means, to the nearest degree.
+    const expected: Record<string, number> = {
+      "dark-cool": 264,
+      "dark-warm": 68,
+      light: 259,
+      nord: 264,
+      dracula: 273,
+      "solarized-dark": 215,
+      "gruvbox-dark": 79,
+      "github-light": 251,
+    };
+    for (const [id, want] of Object.entries(expected)) {
+      const t = BUILTIN_THEMES.find((x) => x.id === id)!;
+      expect(familyHue(t.colors)!, id).toBeCloseTo(want, -0.5);
+    }
+  });
+});
+
+describe("tintRamp", () => {
+  it("is the exact identity at strength 0 on the family hue", () => {
+    // The guarantee the whole panel rests on: opening the editor and touching
+    // nothing must not move a single byte. Measured 0/14 slots differ on all
+    // nine built-ins, worst channel error 0.
+    for (const t of BUILTIN_THEMES) {
+      const hue = familyHue(t.colors) ?? 0;
+      const out = tintRamp(t.colors, hue, 0);
+      for (const key of RAMP_SLOTS) {
+        expect(out[key], `${t.id}.${key}`).toBe(t.colors[key]);
+      }
+    }
+  });
+
+  it("never changes a contrast verdict, at any hue or strength", () => {
+    // 9 themes x 24 hues x 5 strengths x 3 pairs = 3240 checks, measured at
+    // 0 band changes. This is what replaces the old non-goal's argument.
+    let checks = 0;
+    for (const t of BUILTIN_THEMES) {
+      for (let hue = 0; hue < 360; hue += 15) {
+        for (const strength of [0, 0.25, 0.5, 0.75, 1]) {
+          const out = tintRamp(t.colors, hue, strength);
+          for (const [a, b] of RAMP_PAIRS) {
+            const before = band(contrastRatio(t.colors[a], t.colors[b]));
+            const after = band(contrastRatio(out[a], out[b]));
+            expect(after, `${t.id} hue=${hue} strength=${strength} ${a}/${b}`).toBe(before);
+            checks++;
+          }
+        }
+      }
+    }
+    expect(checks).toBe(3240);
+  });
+
+  it("holds every slot's lightness exactly", () => {
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!.colors;
+    const out = tintRamp(base, 300, 0.6);
+    for (const key of RAMP_SLOTS) {
+      // 8-bit quantization is the only source of drift, so a tight bound.
+      expect(oklch(out[key]).l, key).toBeCloseTo(oklch(base[key]).l, 2);
+    }
+  });
+
+  it("never asks for more chroma than sRGB can show", () => {
+    // Guarantee 3. Without the ceiling clamp the conversion clips per channel,
+    // and a clipped channel shifts the hue silently — the exact failure the
+    // ceiling exists to prevent, and one that no contrast check would catch.
+    for (const t of BUILTIN_THEMES) {
+      for (const hue of [0, 90, 180, 270]) {
+        const out = tintRamp(t.colors, hue, 1);
+        for (const key of RAMP_SLOTS) {
+          const o = oklch(out[key]);
+          // The slack is one 8-bit step's worth of round-trip error, nothing more.
+          expect(o.c, `${t.id}.${key} at hue ${hue}`).toBeLessThanOrEqual(
+            srgbChromaCeiling(o.l, o.h) + 0.002,
+          );
+        }
+      }
+    }
+  });
+
+  it("tints a ramp that has no hue of its own", () => {
+    // A multiplier cannot do this: dark-neutral is chroma 0 in all 14 slots.
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-neutral")!.colors;
+    expect(tintRamp(base, 300, 0).bg0).toBe(base.bg0);
+    expect(tintRamp(base, 300, 1).bg0).not.toBe(base.bg0);
+    expect(oklch(tintRamp(base, 300, 1).bg0).c).toBeGreaterThan(0.01);
+  });
+
+  it("rotates rather than assigns, so a theme keeps its own hue split", () => {
+    // dracula puts its text 171 degrees from its backgrounds on purpose.
+    // Assigning one hue flattens that; rotating preserves it.
+    const base = BUILTIN_THEMES.find((t) => t.id === "dracula")!.colors;
+    const split = (c: typeof base) => {
+      const d = oklch(c.fg0).h - oklch(c.bg0).h;
+      return Math.abs(((((d % 360) + 540) % 360) - 180));
+    };
+    for (const target of [0, 120, 210]) {
+      expect(split(tintRamp(base, target, 0.4)), `target ${target}`).toBeCloseTo(
+        split(base),
+        -0.5,
+      );
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts`
+
+Expected: FAIL — cannot resolve `./palette`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/features/settings/theme/palette.ts`:
+
+```ts
+import type { ThemeColors } from "@/features/settings/useSettingsStore";
+
+import { hexToRgb, rgbToHex } from "@/lib/color";
+import { oklchToRgb, rgbToOklch, srgbChromaCeiling } from "@/lib/cssColor";
+
+/**
+ * Palette generation, in OKLCh, as pure arithmetic.
+ *
+ * The 2026-09-09 spec ruled a palette generator out, and it was right to: in
+ * HSL, hue and lightness are one knob, so a generated ramp's contrast lands
+ * wherever it lands and the user can neither predict nor correct it. OKLCh
+ * separates them. Everything here rewrites HUE and CHROMA while holding each
+ * slot's LIGHTNESS exactly, which is what lets the base theme's hand-tuned ramp
+ * — the part that takes longest to build by hand and that nobody has the
+ * vocabulary to repair — survive generation intact.
+ *
+ * Two properties are pinned by `palette.test.ts` rather than by this comment:
+ * strength 0 reproduces the base byte-for-byte, and no hue at any strength
+ * moves a contrast pair across an AA boundary (measured 0 changes in 3240).
+ *
+ * `deriveTheme.ts` next door is NOT superseded. It is still the accent swap the
+ * eighteen-slot path uses, and this module calls its `inkFor` rather than
+ * growing a second rule about what is readable on a button.
+ */
+
+/**
+ * The fourteen slots the ground tint rewrites.
+ *
+ * `accent` is a seed, `accentInk` is computed from it, and the two logo slots
+ * are placed by the harmony rule — so none of the four belongs here.
+ */
+export const RAMP_SLOTS = [
+  "bg0",
+  "bg1",
+  "bg2",
+  "bg3",
+  "bg4",
+  "titlebar",
+  "fg0",
+  "fg1",
+  "fg2",
+  "fg3",
+  "fg4",
+  "border0",
+  "border1",
+  "border2",
+] as const satisfies readonly (keyof ThemeColors)[];
+
+/**
+ * Below this chroma a slot is grey, and the hue `rgbToOklch` reports for it is
+ * numerical noise rather than a colour. Averaging that noise into the family
+ * hue is how a neutral ramp acquires an arbitrary tint.
+ */
+const CHROMA_FLOOR = 0.004;
+
+/** Chroma added on top of a slot's own at strength 1. */
+const TINT_REACH = 0.06;
+
+const norm360 = (deg: number) => ((deg % 360) + 360) % 360;
+
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+function oklchOf(hex: string) {
+  const rgb = hexToRgb(hex);
+  return rgb ? rgbToOklch(rgb) : null;
+}
+
+/**
+ * The hue this ramp reads as: the CHROMA-WEIGHTED circular mean over the slots
+ * that carry any colour at all.
+ *
+ * Weighted, not plain, because the slots differ by an order of magnitude —
+ * solarized-dark's `bg4` carries chroma 0.066 against its `fg2`'s 0.016 — and
+ * the strongly tinted slots are the ones that decide what family a theme reads
+ * as. Circular, not arithmetic, because hue wraps and a plain mean of 350 and
+ * 10 is 180: the exact opposite of both.
+ *
+ * `null` when no slot clears the floor. Of the nine built-ins that is
+ * `dark-neutral` alone.
+ */
+export function familyHue(colors: ThemeColors): number | null {
+  let x = 0;
+  let y = 0;
+  for (const key of RAMP_SLOTS) {
+    const o = oklchOf(colors[key]);
+    if (!o || o.c < CHROMA_FLOOR) continue;
+    const rad = (o.h * Math.PI) / 180;
+    x += Math.cos(rad) * o.c;
+    y += Math.sin(rad) * o.c;
+  }
+  if (x === 0 && y === 0) return null;
+  return norm360((Math.atan2(y, x) * 180) / Math.PI);
+}
+
+/**
+ * Move the ramp to `groundHue`, holding every slot's lightness.
+ *
+ * The hue is applied as a ROTATION by `groundHue - familyHue`, not as an
+ * assignment. Five of the nine built-ins run one hue across the whole ramp, so
+ * for those the two are the same thing — but dracula puts its text 171 degrees
+ * from its backgrounds, solarized-dark 130, gruvbox-dark 170, all three on
+ * purpose. Assigning one absolute hue flattens that and throws away what makes
+ * those themes look like themselves.
+ *
+ * The chroma is ADDITIVE over the slot's own, because a multiplier cannot tint
+ * an achromatic ramp: `dark-neutral` is chroma 0 in all fourteen slots and any
+ * multiple of zero is zero. The `srgbChromaCeiling` clamp is the normal path
+ * near the ends of the ramp, not an edge case — at `fg0`'s L of 0.957 the
+ * ceiling is 0.024 at hue 300 against 0.141 at hue 120 — and skipping it means
+ * a per-channel clip that shifts the hue silently.
+ */
+export function tintRamp(
+  colors: ThemeColors,
+  groundHue: number,
+  strength: number,
+): ThemeColors {
+  const family = familyHue(colors);
+  const delta = family === null ? 0 : groundHue - family;
+  const amount = clamp01(strength);
+  const out = { ...colors };
+  for (const key of RAMP_SLOTS) {
+    const o = oklchOf(colors[key]);
+    if (!o) continue;
+    const h = norm360(family === null ? groundHue : o.h + delta);
+    const c = Math.min(o.c + amount * TINT_REACH, srgbChromaCeiling(o.l, h));
+    out[key] = rgbToHex(oklchToRgb(o.l, c, h));
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts`
+
+Expected: PASS, 7 tests. The contrast sweep asserts `checks === 3240`; if that
+number is wrong the built-in set has changed and the guarantee needs re-measuring
+rather than the assertion relaxing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/settings/theme/palette.ts src/features/settings/theme/palette.test.ts
+git commit -m "feat(theme): tint a theme's ramp in OKLCh without moving its contrast"
+```
+
+---
+
+### Task 3: Harmony offsets and `generate`
+
+**Files:**
+- Modify: `src/features/settings/theme/deriveTheme.ts` (export `inkFor`)
+- Modify: `src/features/settings/theme/palette.ts`
+- Test: `src/features/settings/theme/palette.test.ts`
+
+**Interfaces:**
+- Consumes: `RAMP_SLOTS`, `familyHue`, `tintRamp` from Task 2; `inkFor` from
+  `./deriveTheme`; `normalizeHex` from `@/lib/color`.
+- Produces:
+  - `type HarmonyRule = "mono" | "analogous" | "triadic" | "split" | "complementary"`
+  - `HARMONY_RULES: readonly { id: HarmonyRule; label: string; ground: number; logo: number; logo2: number }[]`
+  - `harmonyOffsets(rule: HarmonyRule)` → one `HARMONY_RULES` entry
+  - `type PaletteTraits = { baseId: string; seed: string; rule: HarmonyRule; strength: number }`
+  - `DEFAULT_TRAIT_RULE: HarmonyRule` (`"analogous"`) and `DEFAULT_TRAIT_STRENGTH` (`0.35`)
+  - `generate(base: ThemeDef, traits: PaletteTraits): ThemeColors`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/theme/palette.test.ts` (and extend the import
+from `./palette` to include `HARMONY_RULES`, `generate`, `harmonyOffsets`):
+
+```ts
+describe("harmony", () => {
+  it("never gives the two logo slots the same hue", () => {
+    // A literal mirror collapses at 0 and at 180, which is why Monochrome and
+    // Complementary are nudged. Without this the mark loses one of its colours
+    // on exactly two of the five rules.
+    for (const rule of HARMONY_RULES) {
+      expect(norm(rule.logo), rule.id).not.toBeCloseTo(norm(rule.logo2), 0);
+    }
+  });
+
+  it("keeps Monochrome's ground on the seed and defaults to Analogous", () => {
+    expect(harmonyOffsets("mono").ground).toBe(0);
+    expect(HARMONY_RULES[1].id).toBe("analogous");
+  });
+});
+
+describe("generate", () => {
+  const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+  const traits = {
+    baseId: base.id,
+    seed: "#5aa8e8",
+    rule: "analogous" as const,
+    strength: 0.35,
+  };
+
+  it("puts the seed in the accent slot untouched", () => {
+    expect(generate(base, traits).accent).toBe("#5aa8e8");
+  });
+
+  it("reproduces the base exactly at strength 0 with the base's own accent", () => {
+    // This is what makes opening the editor safe: the generator's neutral
+    // position IS the theme you started from.
+    const hue = familyHue(base.colors)!;
+    const rule = HARMONY_RULES.find(
+      (r) => Math.abs(r.ground - (hue - oklch(base.colors.accent).h)) < 15,
+    )!;
+    const out = generate(base, {
+      baseId: base.id,
+      seed: base.colors.accent,
+      rule: rule.id,
+      strength: 0,
+    });
+    for (const key of RAMP_SLOTS) expect(out[key], key).toBe(base.colors[key]);
+  });
+
+  it("moves the ground with the rule but never the accent", () => {
+    const mono = generate(base, { ...traits, rule: "mono" });
+    const comp = generate(base, { ...traits, rule: "complementary" });
+    expect(mono.accent).toBe(comp.accent);
+    const apart = Math.abs(
+      ((((familyHue(comp)! - familyHue(mono)!) % 360) + 540) % 360) - 180,
+    );
+    expect(apart).toBeGreaterThan(150);
+  });
+
+  it("keeps the button label readable on every generated accent", () => {
+    for (const seed of ["#ffee00", "#0b1020", "#5aa8e8", "#7a7a7a", "#808080"]) {
+      const out = generate(base, { ...traits, seed });
+      expect(contrastRatio(out.accentInk, out.accent), seed).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("returns the base untouched for a seed that is not a colour", () => {
+    const out = generate(base, { ...traits, seed: "not a colour" });
+    expect(out).toEqual(base.colors);
+  });
+});
+```
+
+Add this helper beside `oklch` at the top of the file:
+
+```ts
+const norm = (deg: number) => ((deg % 360) + 360) % 360;
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts`
+
+Expected: FAIL — `HARMONY_RULES`, `harmonyOffsets` and `generate` are not
+exported from `./palette`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+First, in `src/features/settings/theme/deriveTheme.ts`, add `export` to the
+existing `inkFor` function — change `function inkFor(` to
+`export function inkFor(`. Nothing else in that file changes.
+
+Then append to `src/features/settings/theme/palette.ts`:
+
+```ts
+import type { ThemeDef } from "@/features/settings/useSettingsStore";
+import { normalizeHex } from "@/lib/color";
+
+import { inkFor } from "./deriveTheme";
+
+export type HarmonyRule =
+  | "mono"
+  | "analogous"
+  | "triadic"
+  | "split"
+  | "complementary";
+
+/**
+ * How far the ground and the two logo colours sit from the seed.
+ *
+ * The ground takes the rule's angle. `logo` and `logo2` sit on opposite sides of
+ * the seed wherever the rule allows, so the mark always carries two
+ * distinguishable colours — Monochrome and Complementary are nudged off the
+ * literal mirror because the mirror of 0 is 0 and the mirror of 180 is 180, and
+ * either one would collapse the pair.
+ *
+ * Analogous is the default because it is what the built-ins do. Measured, every
+ * one of the nine places its surface hue within 46 degrees of its accent — five
+ * within 20 — and not one is complementary or triadic. The wide angles stay on
+ * offer because exploring past the built-ins is the point of the feature, but
+ * they are the adventurous setting rather than the one you get for free.
+ */
+export const HARMONY_RULES = [
+  { id: "mono", label: "Monochrome", ground: 0, logo: -30, logo2: 30 },
+  { id: "analogous", label: "Analogous", ground: 30, logo: -30, logo2: 60 },
+  { id: "triadic", label: "Triadic", ground: 120, logo: 120, logo2: -120 },
+  { id: "split", label: "Split-complement", ground: 150, logo: 150, logo2: -150 },
+  { id: "complementary", label: "Complementary", ground: 180, logo: 180, logo2: -60 },
+] as const satisfies readonly {
+  id: HarmonyRule;
+  label: string;
+  ground: number;
+  logo: number;
+  logo2: number;
+}[];
+
+export const DEFAULT_TRAIT_RULE: HarmonyRule = "analogous";
+export const DEFAULT_TRAIT_STRENGTH = 0.35;
+
+export function harmonyOffsets(rule: HarmonyRule) {
+  return HARMONY_RULES.find((r) => r.id === rule) ?? HARMONY_RULES[1];
+}
+
+/** The four values a generated palette is a pure function of. */
+export type PaletteTraits = {
+  /** Which theme supplies the lightness ramp and its baseline chroma. */
+  baseId: string;
+  /** One colour. Becomes `accent` verbatim. */
+  seed: string;
+  rule: HarmonyRule;
+  /** 0 to 1. 0 is the identity. */
+  strength: number;
+};
+
+/** Keep a slot's lightness and chroma, move it to `hue`. */
+function rotateTo(hex: string, hue: number): string {
+  const o = oklchOf(hex);
+  if (!o) return hex;
+  const h = norm360(hue);
+  return rgbToHex(oklchToRgb(o.l, Math.min(o.c, srgbChromaCeiling(o.l, h)), h));
+}
+
+/**
+ * The whole palette, from four values.
+ *
+ * `accent` is the seed verbatim and is never tinted — it is the one colour the
+ * user chose outright, and rewriting it would make the swatch lie. `accentInk`
+ * goes through `deriveTheme`'s `inkFor` so there is still exactly one rule in
+ * the tree about what can be read on a button.
+ */
+export function generate(base: ThemeDef, traits: PaletteTraits): ThemeColors {
+  const seed = normalizeHex(traits.seed);
+  const o = seed ? oklchOf(seed) : null;
+  // A half-typed hex is not a palette. Hand back the base rather than
+  // generating from noise — the editor's own field keeps the user's text.
+  if (!seed || !o) return { ...base.colors };
+
+  const off = harmonyOffsets(traits.rule);
+  const colors = tintRamp(base.colors, norm360(o.h + off.ground), traits.strength);
+  colors.accent = seed;
+  colors.accentInk = inkFor(colors, seed);
+  colors.logo = rotateTo(base.colors.logo, o.h + off.logo);
+  colors.logo2 = rotateTo(base.colors.logo2, o.h + off.logo2);
+  return colors;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts src/features/settings/theme/deriveTheme.test.ts
+```
+
+Expected: PASS. `deriveTheme.test.ts` is in the run because Task 3 touches that
+file; adding `export` must not change any behaviour it pins.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/settings/theme/palette.ts src/features/settings/theme/palette.test.ts src/features/settings/theme/deriveTheme.ts
+git commit -m "feat(theme): place a palette from one seed and a harmony rule"
+```
+
+---
+
+### Task 4: Trait inference and the dice
+
+**Files:**
+- Modify: `src/features/settings/theme/palette.ts`
+- Test: `src/features/settings/theme/palette.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2 and 3.
+- Produces:
+  - `type TraitLocks = { base: boolean; seed: boolean; rule: boolean; strength: boolean }`
+  - `NO_LOCKS: TraitLocks`
+  - `inferTraits(theme: ThemeDef): PaletteTraits`
+  - `isGenerated(colors: ThemeColors, base: ThemeDef, traits: PaletteTraits): boolean`
+  - `rollTraits(current: PaletteTraits, locks: TraitLocks, mode: "dark" | "light", pool: readonly ThemeDef[], rand?: () => number): PaletteTraits`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/theme/palette.test.ts` (extending the `./palette`
+import with `NO_LOCKS`, `inferTraits`, `isGenerated`, `rollTraits`):
+
+```ts
+describe("inferTraits", () => {
+  it("round-trips every built-in to itself", () => {
+    // No new file format: the traits are read back out of the palette, and
+    // because strength 0 is the identity, opening any theme regenerates it
+    // exactly. This test is what lets themePayload stay untouched.
+    for (const t of BUILTIN_THEMES) {
+      const traits = inferTraits(t);
+      expect(traits.seed, t.id).toBe(t.colors.accent);
+      expect(traits.strength, t.id).toBe(0);
+      expect(traits.baseId, t.id).toBe(t.id);
+      expect(isGenerated(t.colors, t, traits), t.id).toBe(true);
+    }
+  });
+
+  it("names the rule the theme actually uses", () => {
+    // Measured surface-to-accent angles: dark-warm 1, dark-cool 19,
+    // dracula -29, solarized-dark -30. The last two are what pin the
+    // magnitude match — signed matching would call both of them Custom.
+    const rule = (id: string) => inferTraits(BUILTIN_THEMES.find((t) => t.id === id)!).rule;
+    expect(rule("dark-warm")).toBe("mono");
+    expect(rule("dark-cool")).toBe("analogous");
+    expect(rule("dracula")).toBe("analogous");
+    expect(rule("solarized-dark")).toBe("analogous");
+  });
+
+  it("falls back to the default rule when the ramp has no hue", () => {
+    const neutral = BUILTIN_THEMES.find((t) => t.id === "dark-neutral")!;
+    expect(inferTraits(neutral).rule).toBe("analogous");
+  });
+});
+
+describe("isGenerated", () => {
+  it("goes false as soon as a slot is hand-edited", () => {
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+    const traits = inferTraits(base);
+    expect(isGenerated(base.colors, base, traits)).toBe(true);
+    expect(isGenerated({ ...base.colors, border1: "#ff00ff" }, base, traits)).toBe(false);
+  });
+});
+
+describe("rollTraits", () => {
+  const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+  const traits = inferTraits(base);
+  /** A scripted source, so a roll is a fixture rather than a coin toss. */
+  const scripted = (...xs: number[]) => {
+    let i = 0;
+    return () => xs[i++ % xs.length];
+  };
+
+  it("respects every lock", () => {
+    const locked = { base: true, seed: true, rule: true, strength: true };
+    expect(rollTraits(traits, locked, "dark", BUILTIN_THEMES, scripted(0.5))).toEqual(traits);
+  });
+
+  it("changes what is not locked", () => {
+    const locks = { ...NO_LOCKS, seed: true };
+    const out = rollTraits(traits, locks, "dark", BUILTIN_THEMES, scripted(0.1, 0.9, 0.4, 0.7));
+    expect(out.seed).toBe(traits.seed);
+    expect(out.strength).not.toBe(traits.strength);
+  });
+
+  it("keeps the seed inside the band the built-in accents occupy", () => {
+    // L 0.52-0.78 and C 0.06-0.19 are the measured span of the nine built-in
+    // accents, which is why a rolled theme never lands somewhere unusable.
+    for (let i = 0; i < 200; i++) {
+      const out = rollTraits(traits, NO_LOCKS, "dark", BUILTIN_THEMES);
+      const o = oklch(out.seed);
+      expect(o.l).toBeGreaterThanOrEqual(0.51);
+      expect(o.l).toBeLessThanOrEqual(0.79);
+      expect(out.strength).toBeGreaterThanOrEqual(0.15);
+      expect(out.strength).toBeLessThanOrEqual(0.7);
+    }
+  });
+
+  it("only rolls built-in bases of the draft's own mode", () => {
+    for (let i = 0; i < 100; i++) {
+      const out = rollTraits(traits, NO_LOCKS, "light", BUILTIN_THEMES);
+      const picked = BUILTIN_THEMES.find((t) => t.id === out.baseId)!;
+      expect(picked.mode).toBe("light");
+      expect(picked.builtin).toBe(true);
+    }
+  });
+
+  it("never rolls a strength of zero", () => {
+    // A dice press that changes nothing visible reads as a broken button.
+    for (let i = 0; i < 100; i++) {
+      expect(rollTraits(traits, NO_LOCKS, "dark", BUILTIN_THEMES).strength).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts`
+
+Expected: FAIL — `inferTraits`, `isGenerated`, `rollTraits`, `NO_LOCKS` are not
+exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/features/settings/theme/palette.ts`:
+
+```ts
+export type TraitLocks = {
+  base: boolean;
+  seed: boolean;
+  rule: boolean;
+  strength: boolean;
+};
+
+export const NO_LOCKS: TraitLocks = {
+  base: false,
+  seed: false,
+  rule: false,
+  strength: false,
+};
+
+/** An angle folded into [-180, 180), so 350 and -10 are the same distance. */
+function signed180(deg: number): number {
+  return (((deg % 360) + 540) % 360) - 180;
+}
+
+/** How near a measured angle has to be before a rule claims it. */
+const RULE_TOLERANCE = 15;
+
+/**
+ * The traits that regenerate this theme, read back out of its own palette.
+ *
+ * There is no persisted trait format on purpose: the moment traits are stored, a
+ * theme has two sources of truth and every importer has to decide which wins.
+ * Reading them back works because `strength: 0` is the exact identity — base is
+ * the theme itself, so opening any theme for edit regenerates it byte-for-byte
+ * and nothing moves until the user moves something.
+ */
+export function inferTraits(theme: ThemeDef): PaletteTraits {
+  const family = familyHue(theme.colors);
+  const accent = oklchOf(theme.colors.accent);
+  let rule: HarmonyRule = DEFAULT_TRAIT_RULE;
+  if (family !== null && accent) {
+    // MAGNITUDE, not the signed angle: a rule's offsets are written one way
+    // round (+30) but a theme is equally analogous 30 degrees the other way.
+    // Measured, dracula sits at -29 and solarized-dark at -30; matching on the
+    // signed value would call both of them Custom.
+    const delta = Math.abs(signed180(family - accent.h));
+    const near = HARMONY_RULES.find((r) => Math.abs(delta - r.ground) <= RULE_TOLERANCE);
+    if (near) rule = near.id;
+  }
+  return { baseId: theme.id, seed: theme.colors.accent, rule, strength: 0 };
+}
+
+/**
+ * Whether this palette is still exactly what the traits produce.
+ *
+ * False the moment a slot is hand-edited, which is what flips the editor's
+ * harmony readout to "Custom". Hand editing is never blocked — a generated slot
+ * is a plain hex string like every other, and the next trait change regenerates
+ * over it, which is what Revert is for.
+ */
+export function isGenerated(
+  colors: ThemeColors,
+  base: ThemeDef,
+  traits: PaletteTraits,
+): boolean {
+  const want = generate(base, traits);
+  return (Object.keys(want) as (keyof ThemeColors)[]).every(
+    (key) => want[key] === colors[key],
+  );
+}
+
+/** The measured span of the nine built-in accents: L 0.518-0.775, C 0.062-0.191. */
+const SEED_L: [number, number] = [0.52, 0.78];
+const SEED_C: [number, number] = [0.06, 0.19];
+/** Never 0: a dice press that changes nothing visible reads as a broken button. */
+const ROLL_STRENGTH: [number, number] = [0.15, 0.7];
+
+/**
+ * Monochrome and Analogous at twice the weight of the rest.
+ *
+ * Not arbitrary: all nine built-ins sit in those two bands, so the near angles
+ * are what reads as a designed theme and the dice should land there more often.
+ */
+const ROLL_RULES: readonly HarmonyRule[] = [
+  "mono",
+  "mono",
+  "analogous",
+  "analogous",
+  "triadic",
+  "split",
+  "complementary",
+];
+
+/**
+ * Re-roll every unlocked trait.
+ *
+ * It cannot produce an unusable theme, because the four traits are the only
+ * inputs and each rolls inside a measured band — the ramp still comes from a
+ * calibrated built-in, and `tintRamp` cannot move a contrast verdict.
+ *
+ * `rand` is injected so a test can script a roll. Every trait draws in a fixed
+ * order whether or not it is locked, so a scripted sequence lines up the same
+ * way regardless of which locks are set.
+ */
+export function rollTraits(
+  current: PaletteTraits,
+  locks: TraitLocks,
+  mode: "dark" | "light",
+  pool: readonly ThemeDef[],
+  rand: () => number = Math.random,
+): PaletteTraits {
+  const between = ([lo, hi]: [number, number]) => lo + rand() * (hi - lo);
+
+  const bases = pool.filter((t) => t.builtin && t.mode === mode);
+  const baseRoll = rand();
+  const seedH = rand() * 360;
+  const seedL = between(SEED_L);
+  const seedC = Math.min(between(SEED_C), srgbChromaCeiling(seedL, seedH));
+  const ruleRoll = rand();
+  const strength = between(ROLL_STRENGTH);
+
+  return {
+    baseId:
+      locks.base || bases.length === 0
+        ? current.baseId
+        : bases[Math.min(bases.length - 1, Math.floor(baseRoll * bases.length))].id,
+    seed: locks.seed ? current.seed : rgbToHex(oklchToRgb(seedL, seedC, seedH)),
+    rule: locks.rule
+      ? current.rule
+      : ROLL_RULES[Math.min(ROLL_RULES.length - 1, Math.floor(ruleRoll * ROLL_RULES.length))],
+    strength: locks.strength ? current.strength : strength,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/palette.test.ts`
+
+Expected: PASS. If `inferTraits` names a rule the second test does not expect,
+do NOT widen `RULE_TOLERANCE` to make it pass — re-measure the theme's
+`familyHue` minus its accent hue and fix whichever of the two is wrong.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/settings/theme/palette.ts src/features/settings/theme/palette.test.ts
+git commit -m "feat(theme): infer palette traits from a theme and roll new ones"
+```
+
+---
+
+### Task 5: Traits, locks and shuffle in the editor store
+
+**Files:**
+- Modify: `src/features/settings/theme/useThemeEditorStore.ts`
+- Test: `src/features/settings/theme/useThemeEditorStore.test.ts`
+
+**Interfaces:**
+- Consumes: `DEFAULT_TRAIT_STRENGTH`, `NO_LOCKS`, `PaletteTraits`, `TraitLocks`,
+  `generate`, `inferTraits`, `rollTraits` from `./palette`.
+- Produces, on `ThemeEditorState`:
+  - `traits: PaletteTraits`
+  - `locks: TraitLocks`
+  - `setTrait: <K extends keyof PaletteTraits>(key: K, value: PaletteTraits[K]) => void`
+  - `toggleLock: (key: keyof TraitLocks) => void`
+  - `shuffle: () => void`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/theme/useThemeEditorStore.test.ts`:
+
+```ts
+import {
+  BUILTIN_THEMES,
+} from "@/features/settings/useSettingsStore";
+
+import { useThemeEditorStore } from "./useThemeEditorStore";
+
+describe("palette traits", () => {
+  const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+
+  it("opens a draft on traits that regenerate it unchanged", () => {
+    useThemeEditorStore.getState().openEdit(dark);
+    const s = useThemeEditorStore.getState();
+    expect(s.traits.baseId).toBe(dark.id);
+    expect(s.traits.seed).toBe(dark.colors.accent);
+    expect(s.traits.strength).toBe(0);
+    expect(s.colors).toEqual(dark.colors);
+  });
+
+  it("regenerates the palette when a trait moves", () => {
+    useThemeEditorStore.getState().openEdit(dark);
+    useThemeEditorStore.getState().setTrait("strength", 0.6);
+    expect(useThemeEditorStore.getState().colors.bg0).not.toBe(dark.colors.bg0);
+    // The ramp moved; the accent the user picked did not.
+    expect(useThemeEditorStore.getState().colors.accent).toBe(dark.colors.accent);
+  });
+
+  it("leaves a locked trait alone through a shuffle", () => {
+    useThemeEditorStore.getState().openEdit(dark);
+    useThemeEditorStore.getState().toggleLock("seed");
+    const seed = useThemeEditorStore.getState().traits.seed;
+    for (let i = 0; i < 20; i++) useThemeEditorStore.getState().shuffle();
+    expect(useThemeEditorStore.getState().traits.seed).toBe(seed);
+    expect(useThemeEditorStore.getState().colors.accent).toBe(seed);
+  });
+
+  it("actually changes the palette when nothing is locked", () => {
+    useThemeEditorStore.getState().openEdit(dark);
+    const before = { ...useThemeEditorStore.getState().colors };
+    useThemeEditorStore.getState().shuffle();
+    expect(useThemeEditorStore.getState().colors).not.toEqual(before);
+  });
+
+  it("does not regenerate over a hand-edited slot", () => {
+    // patchColors is the eighteen-slot path. It writes, and nothing more.
+    useThemeEditorStore.getState().openEdit(dark);
+    useThemeEditorStore.getState().patchColors({ border1: "#ff00ff" });
+    expect(useThemeEditorStore.getState().colors.border1).toBe("#ff00ff");
+  });
+
+  it("clears traits and locks on close", () => {
+    useThemeEditorStore.getState().openEdit(dark);
+    useThemeEditorStore.getState().toggleLock("rule");
+    useThemeEditorStore.getState().close();
+    expect(useThemeEditorStore.getState().locks).toEqual(NO_LOCKS);
+  });
+});
+```
+
+Add `NO_LOCKS` to the file's imports from `./palette`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/useThemeEditorStore.test.ts`
+
+Expected: FAIL — `setTrait`, `toggleLock` and `shuffle` are not on the store.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/features/settings/theme/useThemeEditorStore.ts`:
+
+Add the imports:
+
+```ts
+import {
+  DEFAULT_TRAIT_STRENGTH,
+  NO_LOCKS,
+  generate,
+  inferTraits,
+  rollTraits,
+  type PaletteTraits,
+  type TraitLocks,
+} from "./palette";
+```
+
+Add to the `ThemeEditorState` type, beside `baseId`:
+
+```ts
+  /** The four values the palette is generated from. See `palette.ts`. */
+  traits: PaletteTraits;
+  /** Which traits a shuffle must leave alone. Session state, never persisted. */
+  locks: TraitLocks;
+
+  setTrait: <K extends keyof PaletteTraits>(key: K, value: PaletteTraits[K]) => void;
+  toggleLock: (key: keyof TraitLocks) => void;
+  /** Re-roll every unlocked trait and regenerate. */
+  shuffle: () => void;
+```
+
+Extend `EMPTY_DRAFT`:
+
+```ts
+const EMPTY_DRAFT = {
+  open: null,
+  name: "",
+  themeMode: "dark" as const,
+  colors: BUILTIN_THEMES[0].colors,
+  originalTheme: null,
+  baseId: BUILTIN_THEMES[0].id,
+  traits: inferTraits(BUILTIN_THEMES[0]),
+  locks: NO_LOCKS,
+};
+```
+
+Inside the store factory, beside `preview()`, add a regenerate helper:
+
+```ts
+  /**
+   * Write the traits' palette into the draft and repaint.
+   *
+   * Keeps `baseId` in step with `traits.baseId`: the "Start from" select and the
+   * base-ramp trait are the same choice wearing two names, and letting them
+   * drift is how the dialog ends up showing one theme while generating from
+   * another.
+   */
+  const regenerate = (traits: PaletteTraits) => {
+    const base = allThemes().find((t) => t.id === traits.baseId);
+    if (!base) return;
+    set({ traits, baseId: base.id, themeMode: base.mode, colors: generate(base, traits) });
+    preview();
+  };
+```
+
+In `openNew` and `openEdit`, add the trait fields to the `set(...)` call. For
+`openNew(source)` and `openEdit(theme)` alike the argument is the theme the draft
+starts from, so both read:
+
+```ts
+        traits: inferTraits(source),
+        locks: NO_LOCKS,
+```
+
+(in `openEdit` the variable is `theme`, so `inferTraits(theme)`).
+
+Add the three actions:
+
+```ts
+    setTrait(key, value) {
+      const s = get();
+      if (!s.open) return;
+      regenerate({ ...s.traits, [key]: value });
+    },
+
+    toggleLock(key) {
+      set((s) => ({ locks: { ...s.locks, [key]: !s.locks[key] } }));
+    },
+
+    shuffle() {
+      const s = get();
+      if (!s.open) return;
+      regenerate(
+        rollTraits(s.traits, s.locks, s.themeMode, allThemes(), Math.random),
+      );
+    },
+```
+
+Rewrite `applyBase` to route through the traits, keeping its existing signature
+so the dialog's light/dark re-base flow is unchanged:
+
+```ts
+    applyBase(baseId, accent) {
+      const s = get();
+      const base = allThemes().find((t) => t.id === baseId);
+      if (!base) return;
+      // A NEW draft is named after the palette it starts from, so re-basing has
+      // to move the name too — otherwise "Add theme" leaves you with a
+      // "Dracula (custom)" built out of Solarized. Only while the name is still
+      // the automatic one: nothing overwrites what the user typed, and an
+      // existing theme being edited already has a name of its own.
+      const from = allThemes().find((t) => t.id === s.baseId);
+      const auto = s.open?.mode === "new" && !!from && s.name === autoName(from);
+      if (auto) set({ name: autoName(base) });
+      regenerate({ ...s.traits, baseId, seed: accent ?? base.colors.accent });
+    },
+```
+
+Leave `patchColors`, `setColors`, `revert`, `close` and `save` exactly as they
+are. `patchColors` writing without regenerating is the point: a hand edit is a
+hand edit, and `isGenerated` is what notices.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+~/Library/pnpm/pnpm vitest run src/features/settings/theme/useThemeEditorStore.test.ts
+```
+
+Expected: PASS, including every pre-existing case in that file — `applyBase` was
+rewritten and the old tests are what prove the re-base flow still behaves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/settings/theme/useThemeEditorStore.ts src/features/settings/theme/useThemeEditorStore.test.ts
+git commit -m "feat(theme): hold palette traits and their locks in the editor store"
+```
+
+---
+
+### Task 6: The Palette section in the editor dialog
+
+**Files:**
+- Modify: `src/features/settings/theme/ThemeEditorDialog.tsx`
+- Test: `src/features/settings/theme/ThemeEditorDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: the store surface from Task 5; `HARMONY_RULES`, `isGenerated` from
+  `./palette`; `PGSlider` and the `dice`/`lock`/`lockOpen` icons from Task 1.
+- Produces: no exports. Test ids `theme-trait-base`, `theme-trait-rule`,
+  `theme-trait-tint`, `theme-shuffle`, and `theme-lock-<trait>` per lock.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/theme/ThemeEditorDialog.test.tsx`:
+
+```tsx
+describe("palette section", () => {
+  it("shuffles the palette and leaves a locked seed alone", () => {
+    const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+    useThemeEditorStore.getState().openEdit(dark);
+    render(<ThemeEditorDialog />);
+
+    fireEvent.click(screen.getByTestId("theme-lock-seed"));
+    const seed = useThemeEditorStore.getState().traits.seed;
+    fireEvent.click(screen.getByTestId("theme-shuffle"));
+
+    expect(useThemeEditorStore.getState().traits.seed).toBe(seed);
+    expect(useThemeEditorStore.getState().colors.bg0).not.toBe(dark.colors.bg0);
+  });
+
+  it("says Custom once a slot is hand-edited", () => {
+    const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+    useThemeEditorStore.getState().openEdit(dark);
+    render(<ThemeEditorDialog />);
+    expect(screen.queryByText("Custom")).toBeNull();
+
+    // act() because this drives the store directly rather than through an
+    // event — without it React has not flushed the re-render when the
+    // assertion runs, and the test fails for a reason that is not the feature.
+    act(() => {
+      useThemeEditorStore.getState().patchColors({ border1: "#ff00ff" });
+    });
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("has no native select and no native colour input", () => {
+    // Both are guard-tested repo-wide, but the section is where a new one would
+    // land, so assert it here too rather than finding out from a guard.
+    const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+    useThemeEditorStore.getState().openEdit(dark);
+    const { container } = render(<ThemeEditorDialog />);
+    expect(container.querySelector("select")).toBeNull();
+    expect(container.querySelector('input[type="color"]')).toBeNull();
+  });
+});
+```
+
+Use `fireEvent`, not `userEvent`: `userEvent.setup()` swaps
+`navigator.clipboard` for its own stub, and `fireEvent` is this repo's house
+pattern for these dialogs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemeEditorDialog.test.tsx`
+
+Expected: FAIL — no element with test id `theme-lock-seed`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/features/settings/theme/ThemeEditorDialog.tsx`, add to the imports:
+
+```tsx
+import { PGSlider } from "@/design";
+
+import { HARMONY_RULES, isGenerated, type HarmonyRule, type TraitLocks } from "./palette";
+```
+
+`act` joins the test file's existing `@testing-library/react` import.
+
+Delete the existing `<Field label="Start from">` block and the
+`<div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>` block that
+holds the Accent `ColorField` and its hint. Replace both with:
+
+```tsx
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                padding: "10px 12px",
+                border: "1px solid var(--border-0)",
+                borderRadius: "var(--r-3)",
+                background: "var(--bg-1)",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <PGIcon name="palette" size={12} style={{ color: "var(--accent)" }} />
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-10)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    color: "var(--fg-2)",
+                    fontWeight: 600,
+                  }}
+                >
+                  Palette
+                </div>
+                <div style={{ flex: 1 }} />
+                {!generated && (
+                  <span style={{ fontSize: "var(--fs-10)", color: "var(--fg-3)" }}>
+                    Custom
+                  </span>
+                )}
+              </div>
+
+              <TraitRow label="Base ramp" trait="base" locks={ed.locks} onLock={ed.toggleLock}>
+                <PGSelect
+                  data-testid="theme-trait-base"
+                  title="Which theme supplies the lightness ramp"
+                  value={ed.traits.baseId}
+                  onChange={(v) => ed.setTrait("baseId", v)}
+                  options={baseOptions}
+                  size="sm"
+                  style={{ flex: 1 }}
+                />
+              </TraitRow>
+
+              <TraitRow label="Seed" trait="seed" locks={ed.locks} onLock={ed.toggleLock}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <ColorField
+                    label="Seed"
+                    hint="One colour. It becomes the accent, and the rest of the palette is placed around it."
+                    value={ed.traits.seed}
+                    onChange={(v) => ed.setTrait("seed", v)}
+                    badge={<RatioBadge a="accentInk" b="accent" colors={ed.colors} />}
+                    palette={ed.colors}
+                    slot="accent"
+                  />
+                </div>
+              </TraitRow>
+
+              <TraitRow label="Harmony" trait="rule" locks={ed.locks} onLock={ed.toggleLock}>
+                <PGSelect
+                  data-testid="theme-trait-rule"
+                  title="Where the ground and the logo colours sit, relative to the seed"
+                  value={ed.traits.rule}
+                  onChange={(v) => ed.setTrait("rule", v as HarmonyRule)}
+                  options={HARMONY_RULES.map((r) => ({ value: r.id, label: r.label }))}
+                  size="sm"
+                  style={{ flex: 1 }}
+                />
+              </TraitRow>
+
+              <TraitRow label="Tint" trait="strength" locks={ed.locks} onLock={ed.toggleLock}>
+                <div style={{ flex: 1, minWidth: 0 }} data-testid="theme-trait-tint">
+                  <PGSlider
+                    name="Tint"
+                    valueText={`${Math.round(ed.traits.strength * 100)}%`}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={ed.traits.strength}
+                    trackCss={`linear-gradient(90deg, ${ed.colors.bg1}, ${ed.colors.accent})`}
+                    onChange={(v) => ed.setTrait("strength", v)}
+                  />
+                </div>
+              </TraitRow>
+
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <PGButton
+                  data-testid="theme-shuffle"
+                  size="sm"
+                  icon="dice"
+                  onClick={ed.shuffle}
+                  title="Re-roll every unlocked trait"
+                >
+                  Shuffle
+                </PGButton>
+                <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+                  Lock what you want to keep. All 18 colours stay editable below.
+                </div>
+              </div>
+            </div>
+```
+
+Add `generated` beside the existing `findings` computation near the top of the
+component:
+
+```tsx
+  const base = [...BUILTIN_THEMES, ...customThemes].find((t) => t.id === ed.traits.baseId);
+  const generated = base ? isGenerated(ed.colors, base, ed.traits) : true;
+```
+
+Add the `TraitRow` helper beside the existing `Field` and `RatioBadge` helpers at
+the bottom of the file:
+
+```tsx
+/**
+ * One trait, with the lock that decides whether a shuffle may touch it.
+ *
+ * The lock is a button and not a checkbox because its state is the icon: a
+ * closed padlock reads as "keep this" at a glance in a row of four, where a
+ * ticked box reads as "this is on" and leaves you working out what "on" meant.
+ */
+function TraitRow({
+  label,
+  trait,
+  locks,
+  onLock,
+  children,
+}: {
+  label: string;
+  trait: keyof TraitLocks;
+  locks: TraitLocks;
+  onLock: (key: keyof TraitLocks) => void;
+  children: React.ReactNode;
+}) {
+  const locked = locks[trait];
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <label
+        style={{
+          fontSize: "var(--fs-12)",
+          color: "var(--fg-2)",
+          width: 76,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+      <button
+        type="button"
+        data-testid={`theme-lock-${trait}`}
+        onClick={() => onLock(trait)}
+        aria-pressed={locked}
+        title={locked ? `${label} is locked — shuffle will keep it` : `Lock ${label}`}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          background: "transparent",
+          border: "none",
+          padding: 2,
+          cursor: "pointer",
+          color: locked ? "var(--accent)" : "var(--fg-3)",
+          flexShrink: 0,
+        }}
+      >
+        <PGIcon name={locked ? "lock" : "lockOpen"} size={12} />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+~/Library/pnpm/pnpm vitest run src/features/settings/theme/ThemeEditorDialog.test.tsx
+~/Library/pnpm/pnpm exec tsc --noEmit
+```
+
+Expected: PASS on both, including every pre-existing case in
+`ThemeEditorDialog.test.tsx` — two blocks were deleted from the component and
+those tests are what prove nothing else depended on them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/settings/theme/ThemeEditorDialog.tsx src/features/settings/theme/ThemeEditorDialog.test.tsx
+git commit -m "feat(theme): add the palette section with locks and a shuffle"
+```
+
+---
+
+### Task 7: Bring the docs back in line
+
+The 2026-09-09 spec and `docs/dev/frontend.md` both state a non-goal this feature
+reverses. Leaving either one contradicting the code is how the next session
+re-litigates a decision that has already been made and measured.
+
+**Files:**
+- Modify: `docs/dev/frontend.md`
+- Modify: `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Run the doc guards first, to see them green before the edit**
+
+```bash
+~/Library/pnpm/pnpm vitest run --project docs
+```
+
+Expected: PASS. `docs.test.ts` does not read `docs/superpowers/`, so only the
+`docs/dev/frontend.md` edit is in its scope — but a green baseline is what tells
+you afterwards that a failure is yours.
+
+- [ ] **Step 2: Edit `docs/dev/frontend.md`**
+
+In the "Contrast warnings advise, never block" bullet, replace this sentence:
+
+> `deriveTheme` is the guided start (base + accent) and recalculates
+> `accentInk` alone, preferring the base theme's own inks so derived themes stay
+> in the family — it is deliberately not a palette generator, because shifting
+> the greys too produces palettes nobody can predict or correct.
+
+with:
+
+> `deriveTheme` is the accent swap the eighteen-slot path uses and recalculates
+> `accentInk` alone, preferring the base theme's own inks so derived themes stay
+> in the family.
+
+Then add a new bullet immediately after it:
+
+> - **The palette generator holds LIGHTNESS and rewrites hue and chroma**
+>   (`theme/palette.ts`). The editor's four traits — base ramp, seed colour,
+>   harmony rule, tint strength — are the only inputs, each one lockable so the
+>   shuffle re-rolls the rest. The earlier "deliberately not a palette
+>   generator" rule was about HSL, where hue and lightness are one knob; OKLCh
+>   separates them, and holding `l` is what keeps the base's hand-tuned ramp and
+>   its contrast intact. Three properties are pinned by `palette.test.ts` and
+>   are the reason the reversal is defensible: strength 0 reproduces the base
+>   BYTE-FOR-BYTE (so opening the editor moves nothing), no hue at any strength
+>   changes an AA verdict (measured 0 changes in 3240), and every output lands
+>   in sRGB via `srgbChromaCeiling`. The hue is a ROTATION, not an assignment —
+>   dracula, solarized-dark and gruvbox-dark put their text at a different hue
+>   from their surfaces on purpose, and assigning one hue flattens that. Traits
+>   are INFERRED from the palette on open, never persisted, so the theme file
+>   format is unchanged; a hand-edited slot simply flips the readout to
+>   "Custom". `SEMANTIC_TOKENS` and `SYNTAX_TOKENS` stay out of it: diff green
+>   carries meaning and a palette choice must not change what a diff says.
+
+- [ ] **Step 3: Amend the superseded non-goal**
+
+In `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md`, under
+"What this deliberately does not do", replace the bullet:
+
+> - No hue-shifting palette generator. `deriveTheme` swaps the accent and fixes
+>   the ink; anything cleverer produces palettes the user cannot predict or
+>   correct.
+
+with:
+
+> - ~~No hue-shifting palette generator.~~ **Superseded 2026-09-11** by
+>   `2026-09-11-theme-palette-harmony-design.md`. The objection was about HSL,
+>   where hue and lightness are one knob; OKLCh landed since, for the colour
+>   picker, and separates them. Holding lightness makes a generator both
+>   predictable (strength 0 reproduces the base byte-for-byte) and correctable
+>   (it writes plain hex into the same eighteen slots). Both were measured
+>   across all nine built-ins before the reversal.
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+~/Library/pnpm/pnpm test
+```
+
+Expected: PASS, all projects. This is the last verification in the plan and it
+must come after the last edit — a green number is only evidence for the tree it
+ran on. Note the total test count for the PR body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/dev/frontend.md docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
+git commit -m "docs(theme): record the palette generator and retire its old non-goal"
+```
+
+---
+
+## Finishing
+
+- [ ] Push the branch and open a PR against `main`. The branch is
+      `feat/theme-palette-harmony`; do not commit to `main` directly.
+- [ ] PR body: what the four traits are, the three measured guarantees with their
+      numbers, and that it reverses the 2026-09-09 non-goal deliberately. End
+      with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- [ ] Merge with `gh pr merge <N> --rebase` once GitHub reports the PR mergeable.
+      Verify the ruleset still lists `rebase` in `allowed_merge_methods` first —
+      the docs and the ruleset have disagreed before.
+- [ ] No e2e run is needed: this adds no IPC, no window and no native dialog. CI
+      runs the full suite anyway.

--- a/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
+++ b/docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md
@@ -335,9 +335,13 @@ Import:  openTextFile ──open()──> read_user_file ──json──> impor
 ## What this deliberately does not do
 
 - No new built-in themes. Nine is enough to fork from.
-- No hue-shifting palette generator. `deriveTheme` swaps the accent and fixes
-  the ink; anything cleverer produces palettes the user cannot predict or
-  correct.
+- ~~No hue-shifting palette generator.~~ **Superseded 2026-09-11** by
+  `2026-09-11-theme-palette-harmony-design.md`. The objection was about HSL,
+  where hue and lightness are one knob; OKLCh landed since, for the colour
+  picker, and separates them. Holding lightness makes a generator both
+  predictable (tint 0 reproduces the base byte-for-byte) and correctable (it
+  writes plain hex into the same eighteen slots). Both were measured across all
+  nine built-ins before the reversal.
 - No blocking on contrast. Warn, never refuse.
 - No `tauri-plugin-fs`. Two thin commands match how every other backend
   capability in this app is exposed, and the plugin's scope config would be a

--- a/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
+++ b/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
@@ -133,11 +133,21 @@ For each of the fourteen ramp slots (`bg0`–`bg4`, `titlebar`, `fg0`–`fg4`,
 `border0`–`border2`):
 
 ```
+if strength == 0: return colors unchanged                            // see below
 o = rgbToOklch(slot)
 h = familyHue === null ? groundHue : o.h + (groundHue − familyHue)   // ROTATE
 c = min(o.c + strength × 0.06, srgbChromaCeiling(o.l, h))
 out = oklchToRgb(o.l, c, h)                                          // o.l HELD
 ```
+
+**The `strength == 0` short-circuit is load-bearing, and was added during
+implementation.** Without it the identity holds only when the ground hue happens
+to equal the base's own family hue — and it almost never does, because the
+ground is `seed + the rule's quantised angle` while a base's real offset is
+whatever it is (dark-cool's is 18.6°, and no rule has that). Rotating a ramp
+that still carries its own chroma changes every slot, so merely opening the
+editor moved `bg0` from `#1a1d24` to `#1b1d24` before the user touched anything.
+The cost is a step at the very bottom of a slider that defaults to 0.35.
 
 Three things in there are load-bearing, and each one is a measurement, not a
 preference.
@@ -170,22 +180,35 @@ ground  = seed.h + rule.groundΔ
 colors  = tintRamp(base.colors, ground, strength)
 accent  = seed                                       // verbatim, never tinted
 accentInk = inkFor(colors, accent)                   // deriveTheme.ts
-logo    = base.logo  at hue seed.h + rule.logoΔ,  chroma clamped to its ceiling
-logo2   = base.logo2 at hue seed.h + rule.logo2Δ, chroma clamped to its ceiling
+if strength > 0:                                     // see below
+  logo  = base.logo  at hue seed.h + rule.logoΔ,  chroma clamped to its ceiling
+  logo2 = base.logo2 at hue seed.h + rule.logo2Δ, chroma clamped to its ceiling
 ```
 
 The logo pair keeps the base's own lightness and chroma and moves only in hue,
-for the same reason the ramp does.
+for the same reason the ramp does — and it is gated on strength for the same
+reason too. A rule places the mark at angles a theme's own logo was never drawn
+at, so without the gate every built-in read as "Custom" the instant it opened.
+
+Gating it buys a property worth stating on its own: **at tint 0 this function
+degenerates to exactly `deriveTheme`**, the accent swap that shipped before it,
+and at tint 1 it is a fully generated palette. Tint is the one master control,
+and `palette.test.ts` asserts the equality against `deriveTheme` itself so the
+two cannot drift into two answers.
 
 ## Measured guarantees
 
 Three properties. Each one is a test in `palette.test.ts`, not a claim in prose.
 
-**1. `strength = 0` at the family hue is the identity.** Verified against all
-nine built-ins: 0 of 14 slots differ, worst channel error 0. Byte-for-byte. The
-generator's neutral position *is* the theme you started from, which is what makes
-the whole panel safe to touch — there is no way to open the editor and silently
-be somewhere else.
+**1. Tint 0 is the identity, under every rule.** Verified against all nine
+built-ins × all five rules: 0 of 14 slots differ, worst channel error 0.
+Byte-for-byte. The generator's neutral position *is* the theme you started from,
+which is what makes the whole panel safe to touch — there is no way to open the
+editor and silently be somewhere else.
+
+The "under every rule" half is not decoration. Written the weak way — picking
+the rule nearest the base's own offset — this test passes against a generator
+that rotates the ramp at tint 0, which is the bug described above.
 
 **2. Tinting never changes a contrast verdict.** Across 9 themes × 24 hues × 5
 strengths × the 3 ramp pairs in `CONTRAST_PAIRS` — **0 band changes out of
@@ -273,6 +296,12 @@ The `"Custom"` readout is **not** a sixth rule and does not come from inference.
 It is `isGenerated(colors, base, traits)` going false — the palette is no longer
 exactly what the traits produce, because a slot was hand-edited.
 
+`isGenerated` compares every slot **except `accentInk`**, which is a consequence
+rather than a choice. The built-ins ship hand-authored inks that `inkFor` would
+not pick off their own ramps — dark-cool carries `#0e1a26` where `inkFor` picks
+`#1a1d24` — so comparing it made every built-in read as "Custom" the moment it
+was opened, which is the opposite of what the readout is for.
+
 Base = the theme itself and tint = 0 means the generator is the identity on
 open. Nothing moves until the user moves something. `themePayload`,
 `normalizeCustomThemes` and `validateTheme` are untouched.
@@ -290,17 +319,24 @@ ramp *is* "Start from" and seed *is* "Accent", grown a harmony picker, a tint
 slider, four locks and a dice.
 
 ```
-┌─ Palette ──────────────────────────────────┐
-│  Base ramp   [ Dark · Cool      ▾ ]     🔓 │
-│  Seed        [ ● #5aa8e8        ]       🔓 │
-│  Harmony     [ Analogous        ▾ ]     🔓 │
-│  Tint        ●────────●────────  35%    🔓 │
-│                                            │
-│  [ 🎲 Shuffle ]                            │
-└────────────────────────────────────────────┘
+┌─ Palette ──────────────────────────  Custom ┐
+│  Base ramp   [ Dark · Cool      ▾ ]      🔓 │
+│  Accent      [ ● #5aa8e8        ]        🔓 │
+│  Harmony     [ Analogous        ▾ ]      🔓 │
+│  Tint        ●────────●────────  35%     🔓 │
+│                                             │
+│  [ 🎲 Shuffle ]  Lock what you want to keep │
+└─────────────────────────────────────────────┘
 
 ▸ All colours (18)
 ```
+
+The seed's row is labelled **Accent**, not "Seed". The seed *becomes* the accent
+verbatim, so the app's own vocabulary is the clearer one and the generator's
+jargon buys nothing; the row's hint carries the "everything else is placed
+around it" meaning. It also keeps the base select on its existing
+`theme-editor-base` test id, so the two dialog tests that already drive the
+guided start keep testing it.
 
 Existing house rules this inherits rather than reinvents: the seed uses
 `PGColorSwatch` (no native `<input type="color">` — guard-tested), the base ramp

--- a/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
+++ b/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
@@ -261,9 +261,17 @@ there, which works out exactly because of guarantee 1:
   tracks as `baseId`.
 - **Seed** — `colors.accent`.
 - **Tint** — 0.
-- **Harmony** — the rule whose ground offset is nearest to
-  `familyHue(colors) − hue(accent)`, within ±15°; `"Custom"` when nothing is
-  within that, or when `familyHue` is `null`.
+- **Harmony** — the rule whose ground offset is nearest the **magnitude** of
+  `familyHue(colors) − hue(accent)`, within ±15°, falling back to the default
+  rule when nothing is that near or when `familyHue` is `null`. Magnitude and
+  not the signed angle, because a rule's offsets are written one way round
+  (+30°) while a theme is equally analogous 30° the other way — measured,
+  `dracula` sits at −29.0° and `solarized-dark` at −30.1°, and signed matching
+  would fail to name either.
+
+The `"Custom"` readout is **not** a sixth rule and does not come from inference.
+It is `isGenerated(colors, base, traits)` going false — the palette is no longer
+exactly what the traits produce, because a slot was hand-edited.
 
 Base = the theme itself and tint = 0 means the generator is the identity on
 open. Nothing moves until the user moves something. `themePayload`,

--- a/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
+++ b/docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md
@@ -1,0 +1,367 @@
+# Palette harmony + shuffle for the theme editor — spec
+
+No issue: requested directly, with Arc's theme creator named as the reference —
+"you add some colours to a common palette and then they are complementary to
+each other" — plus a shuffle button, "like a character creator with traits in a
+game".
+
+## What the editor does today, and why that is not enough
+
+`ThemeEditorDialog` offers a guided start: pick a base theme, pick an accent.
+`deriveTheme(base, accent)` copies the base's eighteen slots, replaces `accent`,
+and recalculates `accentInk` so the button label stays readable. Everything else
+is the base's, unchanged. Behind a disclosure sit all eighteen slots as hex
+fields.
+
+So the only way to get a window that does not look like one of the nine
+built-ins is to hand-edit fourteen greys, one at a time, in a list, against a
+preview — and to know, while doing it, which of them is a background and which
+is a border and how far apart two steps of the ramp should be. Nobody does that.
+In practice every custom theme is a built-in with a different accent.
+
+## The decision this reverses
+
+Both the 2026-09-09 spec and `docs/dev/frontend.md` record a deliberate
+non-goal:
+
+> No hue-shifting palette generator. `deriveTheme` swaps the accent and fixes
+> the ink; anything cleverer produces palettes the user cannot predict or
+> correct.
+
+That was correct when written and it is worth being precise about why it no
+longer is. The objection is about **HSL**, where hue and lightness are the same
+knob wearing two hats: rotating hue in HSL moves perceived lightness with it, so
+a generated ramp's contrast lands wherever it lands, and the user has no way to
+see it coming or walk it back.
+
+Since then `src/lib/cssColor.ts` landed **OKLCh** for the colour picker —
+`rgbToOklch`, `oklchToRgb`, `srgbChromaCeiling`, `inSrgbGamut`. In OKLCh
+lightness is separable. A generator can rewrite hue and chroma while holding
+every slot's lightness **exactly**, and the ramp the built-in hand-tuned survives
+the rewrite. That is not a hope; the Measured guarantees section below is three
+properties with numbers against all nine built-ins.
+
+The "correct" half of the objection never needed an argument, and this design
+keeps it literally true: generation writes plain hex into the same eighteen
+slots. There is no hidden layer, no derived-value indirection, no second source
+of truth. Every slot stays editable, Revert still reverts, the theme file format
+does not change.
+
+## The model: four traits
+
+A generated palette is a pure function of four values. They are the character
+sheet: each has a lock, and the shuffle re-rolls every unlocked one.
+
+| Trait | Type | What it decides |
+| --- | --- | --- |
+| **Base ramp** | theme id | Supplies every slot's lightness and its baseline chroma |
+| **Seed** | one colour | Becomes `accent` verbatim |
+| **Harmony** | one of five | Hue offsets for the ground and the logo pair |
+| **Tint** | 0 → 1 | How far the ground's chroma is pushed past the base's own |
+
+`Tint = 0` is the identity (see below), so "no generation" is a position on the
+slider rather than a mode.
+
+### Harmony offsets
+
+The ground takes the rule's angle. `logo` and `logo2` sit on opposite sides of
+the seed wherever the rule allows, so the mark always carries two
+distinguishable colours; Monochrome and Complementary are nudged because a
+literal mirror would collapse the pair (the mirror of 0° is 0°, and of 180° is
+180°).
+
+| Rule | ground Δ | `logo` Δ | `logo2` Δ |
+| --- | --- | --- | --- |
+| Monochrome | 0° | −30° | +30° |
+| **Analogous** (default) | +30° | −30° | +60° |
+| Triadic | +120° | +120° | −120° |
+| Split-complement | +150° | +150° | −150° |
+| Complementary | +180° | +180° | −60° |
+
+These exact numbers are the spec, but the implementation may tune them against
+the live preview within three invariants: Monochrome's ground offset is 0,
+Analogous is the default, and no rule may give `logo` and `logo2` the same hue.
+
+**Why Analogous is the default.** Measured across the nine built-ins, every one
+places its surface hue close to its accent — five within 20°, three within 46°,
+and `dark-neutral` has no surface hue at all. Not one is complementary or
+triadic:
+
+```
+theme            family  accent   delta   nearest
+dark-cool           264     245      19   mono
+dark-warm            68      67       1   mono
+dark-neutral        n/a     252     n/a   (achromatic ramp)
+light               259     260      -1   mono
+nord                264     217      46   analogous
+dracula             273     302     -29   analogous
+solarized-dark      215     245     -30   analogous
+gruvbox-dark         79      78       1   mono
+github-light        251     257      -7   mono
+```
+
+The wide angles stay on offer — a warm ground under a cool accent is a good look
+that none of the nine happens to use, and exploring past the built-ins is the
+whole point of the feature. But it is the adventurous setting, not the one you
+get for free.
+
+## The engine
+
+One new pure module, `src/features/settings/theme/palette.ts`. No React, no DOM,
+no store — the same reasoning `colorWheel.ts` and `contrast.ts` give.
+
+`deriveTheme.ts` **stays as it is.** It is still the right answer for "swap the
+accent on a theme I am hand-editing", it is what the eighteen-slot path uses, and
+the generator calls its `inkFor` rather than growing a second ink rule.
+
+### `familyHue(colors): number | null`
+
+The base ramp's own hue: the chroma-weighted circular mean over the fourteen
+ramp slots, skipping any with chroma below 0.004. `null` only when no slot clears the floor, which of the
+nine is `dark-neutral` alone. `light`, `gruvbox-dark` and `github-light` have
+achromatic *background* slots that the floor skips, and still resolve a family
+hue from the rest of the ramp.
+
+Weighting by chroma and not taking a plain mean matters because the slots differ
+by an order of magnitude — `solarized-dark`'s `bg4` carries chroma 0.066 while
+its `fg2` carries 0.016 — and the strongly-tinted slots are the ones that decide
+what family the theme reads as.
+
+### `tintRamp(colors, groundHue, strength): ThemeColors`
+
+For each of the fourteen ramp slots (`bg0`–`bg4`, `titlebar`, `fg0`–`fg4`,
+`border0`–`border2`):
+
+```
+o = rgbToOklch(slot)
+h = familyHue === null ? groundHue : o.h + (groundHue − familyHue)   // ROTATE
+c = min(o.c + strength × 0.06, srgbChromaCeiling(o.l, h))
+out = oklchToRgb(o.l, c, h)                                          // o.l HELD
+```
+
+Three things in there are load-bearing, and each one is a measurement, not a
+preference.
+
+**The hue is a rotation, not an assignment.** Five of the nine built-ins run a
+single hue across the whole ramp (spread 8–16°) and a sixth, `dark-neutral`, has
+no hue at all — for those six the two are the same thing. The other three are
+not: `dracula` puts its text at 107° and its
+backgrounds at 278°, `solarized-dark` at 90° against 220°, `gruvbox-dark` at 76–96°
+against 49–61°. Assigning one absolute hue flattens that split and throws away
+what makes those themes look like themselves. Rotating preserves it — measured,
+dracula's 171° text-versus-surface split is preserved to within 2° at every
+rotation target tested.
+
+**The chroma is additive over the base's own, not a replacement.** A multiplier
+cannot tint an achromatic ramp: `dark-neutral` is chroma 0 in all fourteen slots,
+and any multiple of zero is zero. Measured, the additive form takes
+`dark-neutral`'s `#1c1c1c` to `#211434` at full strength while leaving it exactly
+`#1c1c1c` at zero.
+
+**The lightness is held, never recomputed.** This is what makes the contrast
+guarantee hold, and it is also what preserves the spacing of the ramp's steps —
+the part of a theme that takes the longest to tune by hand and that a user has
+no vocabulary to fix once it is wrong.
+
+### `generate({ baseId, seed, rule, strength }): ThemeColors`
+
+```
+ground  = seed.h + rule.groundΔ
+colors  = tintRamp(base.colors, ground, strength)
+accent  = seed                                       // verbatim, never tinted
+accentInk = inkFor(colors, accent)                   // deriveTheme.ts
+logo    = base.logo  at hue seed.h + rule.logoΔ,  chroma clamped to its ceiling
+logo2   = base.logo2 at hue seed.h + rule.logo2Δ, chroma clamped to its ceiling
+```
+
+The logo pair keeps the base's own lightness and chroma and moves only in hue,
+for the same reason the ramp does.
+
+## Measured guarantees
+
+Three properties. Each one is a test in `palette.test.ts`, not a claim in prose.
+
+**1. `strength = 0` at the family hue is the identity.** Verified against all
+nine built-ins: 0 of 14 slots differ, worst channel error 0. Byte-for-byte. The
+generator's neutral position *is* the theme you started from, which is what makes
+the whole panel safe to touch — there is no way to open the editor and silently
+be somewhere else.
+
+**2. Tinting never changes a contrast verdict.** Across 9 themes × 24 hues × 5
+strengths × the 3 ramp pairs in `CONTRAST_PAIRS` — **0 band changes out of
+3240**. No hue at any strength moves a pair across the AA 4.5 or the AA-large 3
+boundary. Worst absolute drift anywhere was 1.101, on `solarized-dark`'s
+`fg1`/`bg1` moving 10.76 → 11.86.
+
+```
+theme            worst drift   band changes
+dark-cool              0.266        0/360
+dark-warm              0.266        0/360
+dark-neutral           0.170        0/360
+light                  0.455        0/360
+nord                   0.337        0/360
+dracula                0.738        0/360
+solarized-dark         1.101        0/360
+gruvbox-dark           0.317        0/360
+github-light           0.472        0/360
+```
+
+The fourth pair, `accentInk`/`accent`, is excluded from that sweep because the
+accent is a seed and is never tinted; its ink goes through the existing
+`inkFor`, which is already tested.
+
+**3. Every output is inside sRGB by construction**, via the `srgbChromaCeiling`
+clamp. The ceiling is strongly hue- and lightness-dependent — at `fg0`'s
+L = 0.957 it is 0.024 at hue 300 but 0.141 at hue 120 — so the clamp is the
+normal path near the ends of the ramp, not an edge case.
+
+## What was tried and cut
+
+A luminance-matched variant: after tinting, binary-search lightness so each
+slot's WCAG relative luminance matches the base slot's exactly, making contrast
+preservation exact rather than merely measured. Built, measured, **cut**.
+
+It is *worse* than holding lightness across the useful range — worst drift 0.178
+against 0.126 at strength 0.01, 0.181 against 0.100 at 0.02 — and only wins above
+strength 0.08, where the drift it beats is already invisible. The reason is that
+8-bit quantization sets a floor around 0.15 ratio points that the search cannot
+get under, and the search's own convergence error sits on top of it. It would
+have been thirty lines of bisection buying nothing. Holding lightness is the
+whole algorithm.
+
+## Shuffle and locks
+
+One dice re-rolls every unlocked trait. It cannot produce an unusable theme,
+because the four traits are the only inputs and each rolls inside a band:
+
+- **Seed** — hue uniform over [0, 360); lightness uniform over [0.52, 0.78];
+  chroma uniform over [0.06, 0.19], clamped to `srgbChromaCeiling`. Those two
+  ranges are the measured span of the nine built-in accents (L 0.518–0.775,
+  C 0.062–0.191), so a rolled accent sits where a hand-picked one sits.
+- **Base ramp** — uniform over the **built-ins** matching the draft's current
+  mode. Not custom themes: rolling into someone's half-finished draft is a
+  surprise, and the built-ins are the ones with a calibrated ramp.
+- **Harmony** — weighted, with Monochrome and Analogous at twice the weight of
+  the other three. The measured evidence above is that the near angles are what
+  reads as a designed theme; the dice should land there more often.
+- **Tint** — uniform over [0.15, 0.70]. Never 0, because a roll that changes
+  nothing visible reads as a broken button.
+
+A lock is per-trait, lives in the editor store, and is session state — it is not
+persisted and not part of the theme.
+
+The default on a fresh draft is Analogous at tint 0.35.
+
+## Where the traits come from when the editor opens
+
+No new persisted format. The traits are inferred from the palette that is already
+there, which works out exactly because of guarantee 1:
+
+- **Base ramp** — the theme being edited, which `useThemeEditorStore` already
+  tracks as `baseId`.
+- **Seed** — `colors.accent`.
+- **Tint** — 0.
+- **Harmony** — the rule whose ground offset is nearest to
+  `familyHue(colors) − hue(accent)`, within ±15°; `"Custom"` when nothing is
+  within that, or when `familyHue` is `null`.
+
+Base = the theme itself and tint = 0 means the generator is the identity on
+open. Nothing moves until the user moves something. `themePayload`,
+`normalizeCustomThemes` and `validateTheme` are untouched.
+
+Hand-editing any generated slot afterwards is just editing a slot. The harmony
+readout flips to `"Custom"` when the palette stops matching what the traits
+would generate, and the next shuffle or trait change regenerates over the hand
+edits — which is inherent to any generator and is what Revert is for.
+
+## UI
+
+The palette section **replaces** the existing "Start from" and "Accent" rows in
+`ThemeEditorDialog`'s left column. It is not a second panel beside them: base
+ramp *is* "Start from" and seed *is* "Accent", grown a harmony picker, a tint
+slider, four locks and a dice.
+
+```
+┌─ Palette ──────────────────────────────────┐
+│  Base ramp   [ Dark · Cool      ▾ ]     🔓 │
+│  Seed        [ ● #5aa8e8        ]       🔓 │
+│  Harmony     [ Analogous        ▾ ]     🔓 │
+│  Tint        ●────────●────────  35%    🔓 │
+│                                            │
+│  [ 🎲 Shuffle ]                            │
+└────────────────────────────────────────────┘
+
+▸ All colours (18)
+```
+
+Existing house rules this inherits rather than reinvents: the seed uses
+`PGColorSwatch` (no native `<input type="color">` — guard-tested), the base ramp
+uses `PGSelect` (no native `<select>` — guard-tested), the live `:root` preview
+and the `ThemePreview` pane both already repaint from the draft, and the
+contrast findings under the preview keep advising and never block.
+
+The tint slider needs a real control; `design/color-picker.tsx` already has the
+slider used for its channel tracks, and the implementation should reuse it
+rather than add a second slider to the design system.
+
+## Files
+
+**New**
+- `src/features/settings/theme/palette.ts` — `familyHue`, `tintRamp`,
+  `harmonyOffsets`, `generate`, `inferTraits`, `rollTraits`.
+- `src/features/settings/theme/palette.test.ts` — the three guarantees above,
+  each swept over all nine built-ins, plus the roll bands and the inference
+  round-trip.
+
+**Changed**
+- `src/features/settings/theme/ThemeEditorDialog.tsx` — the palette section.
+- `src/features/settings/theme/useThemeEditorStore.ts` — four trait fields, four
+  locks, `setTrait`, `shuffle`; `applyBase` becomes a trait write.
+- `docs/dev/frontend.md` — the "deliberately not a palette generator" sentence
+  in the contrast bullet is now wrong and must change in the same commit.
+- `docs/superpowers/specs/2026-09-09-theme-editor-revamp-spec.md` — its
+  "No hue-shifting palette generator" non-goal gets a line pointing here, rather
+  than being left contradicting the code.
+
+`CLAUDE.md` gets **no new bullet.** The rules that matter here are already
+written (one colour picker, no native `<select>`, contrast advises and never
+blocks) and this feature obeys them rather than adding one. A pointer that
+`docs/dev/frontend.md` already serves does not earn a line in a file that was cut
+from 2,456 lines.
+
+## Testing
+
+- **`palette.test.ts`** (vitest `unit`) — the three guarantees, swept. These are
+  the tests that make the reversal of the old non-goal defensible, so they assert
+  the *numbers*, not just "it returns a colour": identity is byte equality across
+  all nine built-ins, and the contrast sweep asserts 0 band changes over the full
+  9 × 24 × 5 × 3 grid.
+- **`ThemeEditorDialog.test.tsx`** — a shuffle with the seed locked leaves
+  `colors.accent` untouched and changes at least one ramp slot; tint 0 leaves the
+  draft byte-identical to the base; changing harmony moves the ground hue and not
+  the accent.
+- **No new e2e.** The editor already has coverage for open/edit/save, and this
+  adds no new IPC, no new window, and no native dialog. The arithmetic is where
+  the risk is and it is unit-testable.
+
+## What this deliberately does not do
+
+- **No change to `SEMANTIC_TOKENS` or `SYNTAX_TOKENS`.** Diff green stays green:
+  those colours carry meaning, and harmonising them would make a palette choice
+  change what a diff says. `--graph-1..7` are the one arguable exception — they
+  are already `oklch(0.72 0.15 h)` at seven hues, so a rigid rotation would keep
+  them mutually distinguishable while letting the palette reach the log graph.
+  Left out on purpose; it is a separate change with its own argument to make.
+- **No new theme file format.** Traits are inferred, not stored. The moment
+  traits are persisted, a theme has two sources of truth and every importer has
+  to decide which wins.
+- **No blocking on contrast.** Unchanged from the 2026-09-09 spec: the editor
+  warns, Save is never disabled, and a deliberately low-contrast theme is the
+  user's own call. Guarantee 2 means the generator never *causes* a finding that
+  the base did not already have.
+- **No gamut-mapping beyond the chroma clamp.** `srgbChromaCeiling` ends the
+  chroma at the right place; there is no perceptual gamut compression, because
+  the alternative to clamping here is a per-channel clamp that shifts the hue
+  silently, and that is the bug the ceiling exists to prevent.
+- **No palette import from an image or a URL.** Out of scope, and it would be the
+  app's first network call — see the privacy build gate.

--- a/src/design/color-picker.test.tsx
+++ b/src/design/color-picker.test.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 
-import { PGColorSwatch } from "./color-picker";
+import { PGColorSwatch, PGSlider } from "./color-picker";
 import { PGModal } from "./modal";
 import { useFocusStore } from "@/features/keymap/useFocusStore";
 import { useKeymapStore } from "@/features/keymap/useKeymapStore";
@@ -443,5 +443,30 @@ describe("PGColorSwatch — dismissal", () => {
     fireEvent.keyDown(slider(/hsv hue/i), { key: "ArrowRight" });
     fireEvent.keyDown(popover()!, { key: "Escape" });
     expect(onCommit).not.toHaveBeenCalled();
+  });
+});
+
+describe("PGSlider", () => {
+  it("is exported for reuse and reports the full slider value trio", () => {
+    // The theme editor's tint control is this slider, not a second one: a
+    // design system with two sliders is a design system where one of them is
+    // subtly wrong.
+    render(
+      <PGSlider
+        name="Tint"
+        valueText="35%"
+        min={0}
+        max={1}
+        step={0.01}
+        value={0.35}
+        trackCss="linear-gradient(90deg, #000, #fff)"
+        onChange={() => {}}
+      />,
+    );
+    const slider = screen.getByRole("slider", { name: "Tint" });
+    expect(slider).toHaveAttribute("aria-valuemin", "0");
+    expect(slider).toHaveAttribute("aria-valuemax", "1");
+    expect(slider).toHaveAttribute("aria-valuenow", "0.35");
+    expect(slider).toHaveAttribute("aria-valuetext", "35%");
   });
 });

--- a/src/design/color-picker.tsx
+++ b/src/design/color-picker.tsx
@@ -619,7 +619,7 @@ function ColorWheel({
  * `role="slider"` with the full value trio, so what a screen reader gets is a
  * named channel with a range — not an unlabelled div.
  */
-function Slider({
+export function PGSlider({
   name,
   valueText,
   min,
@@ -753,7 +753,7 @@ function gradient(stops: string[], vertical = false): string {
 function ValueSlider({ hsv, onChange }: { hsv: Hsv; onChange: (v: number) => void }) {
   const top = hsvToHex({ ...hsv, v: 1 });
   return (
-    <Slider
+    <PGSlider
       name="Brightness"
       valueText={`${Math.round(hsv.v * 100)}%`}
       min={0}
@@ -798,7 +798,7 @@ function ChannelSlider({
       >
         {channel.label}
       </span>
-      <Slider
+      <PGSlider
         // Prefixed with the model, because four models are one click apart and
         // "Hue" alone does not say whether you are moving HSV's or OKLCh's —
         // which are different angles on the same colour.

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -42,6 +42,7 @@ import {
   Combine,
   Copy,
   Database,
+  Dices,
   Download,
   Ellipsis,
   ExternalLink,
@@ -79,8 +80,10 @@ import {
   List,
   ListTree,
   Lock,
+  LockOpen,
   Minus,
   PanelBottom,
+  Palette,
   PanelRight,
   Pause,
   Pencil,
@@ -118,7 +121,7 @@ export type IconName =
   | "pull" | "push" | "fetch" | "sync" | "refresh" | "stash" | "rebase"
   | "dot" | "circle" | "warn" | "error" | "info" | "clock" | "bug"
   | "user" | "eye" | "terminal" | "history" | "kbd"
-  | "download" | "upload" | "link" | "lock"
+  | "download" | "upload" | "link" | "lock" | "lockOpen" | "dice" | "palette"
   | "play" | "pause" | "star" | "copy" | "external" | "pin"
   | "edit" | "trash" | "conflict" | "squash" | "drag" | "bell"
   | "diff" | "undo" | "fix" | "expandAll" | "collapseAll"
@@ -205,6 +208,9 @@ const ICONS: Record<IconName, LucideIcon> = {
   upload: Upload,
   link: Link,
   lock: Lock,
+  lockOpen: LockOpen,
+  dice: Dices,
+  palette: Palette,
   play: Play,
   pause: Pause,
   star: Star,

--- a/src/features/settings/theme/ThemeEditorDialog.test.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.test.tsx
@@ -320,4 +320,53 @@ describe("ThemeEditorDialog — the colour picker", () => {
       screen.getByRole("button", { name: /^Background · panel \(#1e222a\)$/ }),
     ).toBeTruthy();
   });
+
+  it("shuffles the palette and leaves a locked accent alone", () => {
+    ed().openEdit(dark);
+    mount();
+
+    fireEvent.click(screen.getByTestId("theme-lock-seed"));
+    const seed = ed().traits.seed;
+    fireEvent.click(screen.getByTestId("theme-shuffle"));
+
+    expect(ed().traits.seed).toBe(seed);
+    expect(ed().colors.accent).toBe(seed);
+    // Something has to actually move, or the dice reads as a broken button.
+    expect(ed().colors.bg0).not.toBe(dark.colors.bg0);
+  });
+
+  it("says Custom once a slot is hand-edited, and not before", () => {
+    ed().openEdit(dark);
+    mount();
+    expect(screen.queryByText("Custom")).toBeNull();
+
+    // act() because this drives the store directly rather than through an
+    // event — without it React has not flushed the re-render when the
+    // assertion runs, and the test fails for a reason that is not the feature.
+    act(() => {
+      ed().patchColors({ border1: "#ff00ff" });
+    });
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("has no native select and no native colour input in the palette section", () => {
+    // Both are guard-tested repo-wide, but this section is where a new one
+    // would land, so assert it here rather than finding out from a guard.
+    ed().openEdit(dark);
+    const { container } = mount();
+    expect(container.querySelector("select")).toBeNull();
+    expect(container.querySelector('input[type="color"]')).toBeNull();
+  });
+
+  it("moves the whole ramp when the tint is raised", () => {
+    ed().openEdit(dark);
+    mount();
+    act(() => {
+      ed().setTrait("strength", 0.7);
+    });
+    expect(ed().colors.bg0).not.toBe(dark.colors.bg0);
+    expect(ed().colors.fg0).not.toBe(dark.colors.fg0);
+    // The accent is the seed, and a seed is never tinted.
+    expect(ed().colors.accent).toBe(dark.colors.accent);
+  });
 });

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -7,6 +7,7 @@ import {
   PGInput,
   PGModal,
   PGSelect,
+  PGSlider,
   pgConfirm,
   pgFlash,
 } from "@/design";
@@ -23,6 +24,12 @@ import { appErrorMessage } from "@/lib/errors";
 
 import { ColorEditor, ColorField } from "./ColorEditor";
 import { CONTRAST_PAIRS, contrastRatio, contrastReport } from "./contrast";
+import {
+  HARMONY_RULES,
+  isGenerated,
+  type HarmonyRule,
+  type TraitLocks,
+} from "./palette";
 import { ThemePreview } from "./ThemePreview";
 import { useThemeEditorStore } from "./useThemeEditorStore";
 
@@ -56,6 +63,17 @@ export function ThemeEditorDialog() {
     ...BUILTIN_THEMES.map((t) => ({ value: t.id, label: t.name })),
     ...customThemes.map((t) => ({ value: t.id, label: `★ ${t.name}` })),
   ];
+
+  /**
+   * Whether the palette is still exactly what the four traits produce.
+   *
+   * False is not an error state — it is the normal consequence of editing one
+   * of the eighteen by hand, and all it does is say so.
+   */
+  const baseTheme = [...BUILTIN_THEMES, ...customThemes].find(
+    (t) => t.id === ed.traits.baseId,
+  );
+  const generated = baseTheme ? isGenerated(ed.colors, baseTheme, ed.traits) : true;
 
   /** True while the draft still holds exactly the colours it opened with. */
   const untouched = (Object.keys(ed.colors) as (keyof ThemeColors)[]).every(
@@ -180,43 +198,130 @@ export function ThemeEditorDialog() {
               />
             </Field>
 
-            <Field label="Start from">
-              <PGSelect
-                data-testid="theme-editor-base"
-                title="Take the palette from another theme"
-                value={ed.baseId}
-                onChange={(v) => ed.applyBase(v, ed.colors.accent)}
-                options={baseOptions}
-                size="sm"
-                style={{ flex: 1 }}
-              />
-            </Field>
-
-            <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
-              <span style={{ width: 76, flexShrink: 0 }} />
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <ColorField
-                  label="Accent"
-                  hint="Primary actions, active tabs, focus rings. Everything else comes from the base."
-                  value={ed.colors.accent}
-                  onChange={(v) => ed.applyBase(ed.baseId, v)}
-                  badge={<RatioBadge a="accentInk" b="accent" colors={ed.colors} />}
-                  // The guided start's one field gets the same picker as the
-                  // eighteen behind the disclosure — a wheel that appeared on
-                  // the collapsed rows but not on the field everybody edits
-                  // would be missing from where it matters most.
-                  palette={ed.colors}
-                  slot="accent"
-                />
+            {/* ── Palette ─────────────────────────────────────────────────
+                Four traits, each lockable, that generate all eighteen slots.
+                This IS the guided start — base ramp is "Start from" and the
+                accent is the seed — grown a harmony rule, a tint and a dice.
+                The eighteen stay editable below; a hand edit there simply
+                flips the readout to "Custom". */}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                padding: "10px 12px",
+                border: "1px solid var(--border-0)",
+                borderRadius: "var(--r-3)",
+                background: "var(--bg-1)",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <PGIcon name="palette" size={12} style={{ color: "var(--accent)" }} />
                 <div
                   style={{
-                    marginTop: 4,
-                    fontSize: "var(--fs-11)",
-                    color: "var(--fg-3)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-10)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    color: "var(--fg-2)",
+                    fontWeight: 600,
                   }}
                 >
-                  Takes the palette from another theme and keeps your accent — the
-                  button text is recalculated so it stays readable.
+                  Palette
+                </div>
+                <div style={{ flex: 1 }} />
+                {!generated && (
+                  <span
+                    title="A colour has been edited by hand, so the palette is no longer exactly what these four traits produce."
+                    style={{ fontSize: "var(--fs-10)", color: "var(--fg-3)" }}
+                  >
+                    Custom
+                  </span>
+                )}
+              </div>
+
+              <TraitRow
+                label="Base ramp"
+                trait="base"
+                locks={ed.locks}
+                onLock={ed.toggleLock}
+              >
+                <PGSelect
+                  data-testid="theme-editor-base"
+                  title="Which theme supplies the lightness ramp"
+                  value={ed.baseId}
+                  onChange={(v) => ed.applyBase(v, ed.traits.seed)}
+                  options={baseOptions}
+                  size="sm"
+                  style={{ flex: 1 }}
+                />
+              </TraitRow>
+
+              <TraitRow label="Accent" trait="seed" locks={ed.locks} onLock={ed.toggleLock}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <ColorField
+                    label="Accent"
+                    hint="The one colour you pick. It becomes the accent, and the rest of the palette is placed around it."
+                    value={ed.colors.accent}
+                    onChange={(v) => ed.setTrait("seed", v)}
+                    badge={<RatioBadge a="accentInk" b="accent" colors={ed.colors} />}
+                    // The guided start's one field gets the same picker as the
+                    // eighteen behind the disclosure — a wheel that appeared on
+                    // the collapsed rows but not on the field everybody edits
+                    // would be missing from where it matters most.
+                    palette={ed.colors}
+                    slot="accent"
+                  />
+                </div>
+              </TraitRow>
+
+              <TraitRow label="Harmony" trait="rule" locks={ed.locks} onLock={ed.toggleLock}>
+                <PGSelect
+                  data-testid="theme-trait-rule"
+                  title="Where the surfaces and the logo colours sit, relative to the accent"
+                  value={ed.traits.rule}
+                  onChange={(v) => ed.setTrait("rule", v as HarmonyRule)}
+                  options={HARMONY_RULES.map((r) => ({ value: r.id, label: r.label }))}
+                  size="sm"
+                  style={{ flex: 1 }}
+                />
+              </TraitRow>
+
+              <TraitRow label="Tint" trait="strength" locks={ed.locks} onLock={ed.toggleLock}>
+                <div style={{ flex: 1, minWidth: 0 }} data-testid="theme-trait-tint">
+                  <PGSlider
+                    name="Tint"
+                    valueText={`${Math.round(ed.traits.strength * 100)}%`}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={ed.traits.strength}
+                    trackCss={`linear-gradient(90deg, ${ed.colors.bg1}, ${ed.colors.accent})`}
+                    onChange={(v) => ed.setTrait("strength", v)}
+                  />
+                </div>
+              </TraitRow>
+
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <PGButton
+                  data-testid="theme-shuffle"
+                  size="sm"
+                  icon="dice"
+                  onClick={ed.shuffle}
+                  title="Re-roll every unlocked trait"
+                >
+                  Shuffle
+                </PGButton>
+                <div
+                  style={{
+                    fontSize: "var(--fs-11)",
+                    color: "var(--fg-3)",
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                >
+                  Lock what you want to keep. At 0% tint the surfaces stay exactly
+                  as the base theme drew them.
                 </div>
               </div>
             </div>
@@ -353,6 +458,66 @@ function Field({
         {label}
       </label>
       {children}
+    </div>
+  );
+}
+
+/**
+ * One trait, with the lock that decides whether a shuffle may touch it.
+ *
+ * The lock is a button and not a checkbox because its state IS the icon: a
+ * closed padlock reads as "keep this" at a glance down a column of four, where
+ * a ticked box reads as "this is on" and leaves you working out what on meant.
+ */
+function TraitRow({
+  label,
+  trait,
+  locks,
+  onLock,
+  children,
+}: {
+  label: string;
+  trait: keyof TraitLocks;
+  locks: TraitLocks;
+  onLock: (key: keyof TraitLocks) => void;
+  children: React.ReactNode;
+}) {
+  const locked = locks[trait];
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <label
+        style={{
+          fontSize: "var(--fs-12)",
+          color: "var(--fg-2)",
+          width: 76,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+      <button
+        type="button"
+        data-testid={`theme-lock-${trait}`}
+        onClick={() => onLock(trait)}
+        aria-pressed={locked}
+        aria-label={locked ? `Unlock ${label}` : `Lock ${label}`}
+        title={
+          locked ? `${label} is locked — Shuffle will keep it` : `Lock ${label}`
+        }
+        style={{
+          display: "flex",
+          alignItems: "center",
+          background: "transparent",
+          border: "none",
+          padding: 2,
+          cursor: "pointer",
+          color: locked ? "var(--accent)" : "var(--fg-3)",
+          flexShrink: 0,
+        }}
+      >
+        <PGIcon name={locked ? "lock" : "lockOpen"} size={12} />
+      </button>
     </div>
   );
 }

--- a/src/features/settings/theme/deriveTheme.ts
+++ b/src/features/settings/theme/deriveTheme.ts
@@ -30,7 +30,7 @@ const READABLE = 4.5;
  * The pure extremes are the fallback for a mid-tone accent, where neither of
  * the base's own inks clears the bar.
  */
-function inkFor(base: ThemeColors, accent: string): string {
+export function inkFor(base: ThemeColors, accent: string): string {
   const candidates = [base.fg0, base.bg0, "#ffffff", "#000000"];
   const readable = candidates.find((ink) => contrastRatio(ink, accent) >= READABLE);
   if (readable) return readable;

--- a/src/features/settings/theme/palette.test.ts
+++ b/src/features/settings/theme/palette.test.ts
@@ -17,12 +17,17 @@ import { hexToRgb } from "@/lib/color";
 import { rgbToOklch } from "@/lib/cssColor";
 
 import { contrastRatio } from "./contrast";
+import { deriveTheme } from "./deriveTheme";
 import {
   HARMONY_RULES,
+  NO_LOCKS,
   RAMP_SLOTS,
   familyHue,
   generate,
   harmonyOffsets,
+  inferTraits,
+  isGenerated,
+  rollTraits,
   tintRamp,
 } from "./palette";
 
@@ -241,5 +246,127 @@ describe("generate", () => {
   it("returns the base untouched for a seed that is not a colour", () => {
     // A half-typed hex is not a palette. The editor's own field keeps the text.
     expect(generate(base, { ...traits, seed: "not a colour" })).toEqual(base.colors);
+  });
+
+  it("degenerates to deriveTheme at tint 0", () => {
+    // Tint is the one master control: at 0 this is exactly the accent swap that
+    // shipped before it, at 1 a fully generated palette. Asserting it against
+    // `deriveTheme` itself is what stops the two drifting into two answers.
+    for (const t of BUILTIN_THEMES) {
+      for (const rule of HARMONY_RULES) {
+        for (const seed of ["#5aa8e8", "#ffee00", "#7a7a7a"]) {
+          expect(
+            generate(t, { baseId: t.id, seed, rule: rule.id, strength: 0 }),
+            `${t.id} / ${rule.id} / ${seed}`,
+          ).toEqual(deriveTheme(t, seed));
+        }
+      }
+    }
+  });
+});
+
+describe("inferTraits", () => {
+  it("round-trips every built-in's ramp to itself", () => {
+    // No new file format: the traits are read back out of the palette, and
+    // because strength 0 leaves the ramp alone, opening any theme regenerates
+    // its surfaces exactly. This is what lets themePayload stay untouched.
+    for (const t of BUILTIN_THEMES) {
+      const traits = inferTraits(t);
+      expect(traits.seed, t.id).toBe(t.colors.accent);
+      expect(traits.strength, t.id).toBe(0);
+      expect(traits.baseId, t.id).toBe(t.id);
+      const out = generate(t, traits);
+      for (const key of RAMP_SLOTS) expect(out[key], `${t.id}.${key}`).toBe(t.colors[key]);
+    }
+  });
+
+  it("names the rule the theme actually uses", () => {
+    // Measured surface-to-accent angles: dark-warm 1.1, dark-cool 18.6,
+    // dracula -29.0, solarized-dark -30.1. The last two are what pin the
+    // MAGNITUDE match — signed matching would call both of them Custom.
+    const rule = (id: string) => inferTraits(BUILTIN_THEMES.find((t) => t.id === id)!).rule;
+    expect(rule("dark-warm")).toBe("mono");
+    expect(rule("dark-cool")).toBe("analogous");
+    expect(rule("dracula")).toBe("analogous");
+    expect(rule("solarized-dark")).toBe("analogous");
+  });
+
+  it("falls back to the default rule when the ramp has no hue", () => {
+    const neutral = BUILTIN_THEMES.find((t) => t.id === "dark-neutral")!;
+    expect(inferTraits(neutral).rule).toBe("analogous");
+  });
+});
+
+describe("isGenerated", () => {
+  it("is true for every built-in as it opens", () => {
+    // All nine, not one: the bug this caught was theme-specific. A built-in's
+    // hand-authored `accentInk` is not what `inkFor` would pick off its ramp,
+    // so comparing that slot made every theme read as "Custom" on open.
+    for (const t of BUILTIN_THEMES) {
+      expect(isGenerated(t.colors, t, inferTraits(t)), t.id).toBe(true);
+    }
+  });
+
+  it("goes false as soon as a slot is hand-edited", () => {
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+    const traits = inferTraits(base);
+    expect(isGenerated({ ...base.colors, border1: "#ff00ff" }, base, traits)).toBe(false);
+    expect(isGenerated({ ...base.colors, bg0: "#ff00ff" }, base, traits)).toBe(false);
+    expect(isGenerated({ ...base.colors, accent: "#ff00ff" }, base, traits)).toBe(false);
+  });
+});
+
+describe("rollTraits", () => {
+  const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+  const traits = inferTraits(base);
+  /** A scripted source, so a roll is a fixture rather than a coin toss. */
+  const scripted = (...xs: number[]) => {
+    let i = 0;
+    return () => xs[i++ % xs.length];
+  };
+
+  it("respects every lock", () => {
+    const locked = { base: true, seed: true, rule: true, strength: true };
+    expect(rollTraits(traits, locked, "dark", BUILTIN_THEMES, scripted(0.5))).toEqual(
+      traits,
+    );
+  });
+
+  it("changes what is not locked", () => {
+    const locks = { ...NO_LOCKS, seed: true };
+    const out = rollTraits(traits, locks, "dark", BUILTIN_THEMES, scripted(0.1, 0.9, 0.4, 0.7));
+    expect(out.seed).toBe(traits.seed);
+    expect(out.strength).not.toBe(traits.strength);
+  });
+
+  it("keeps the seed inside the band the built-in accents occupy", () => {
+    // L 0.52-0.78 and C 0.06-0.19 are the measured span of the nine built-in
+    // accents, which is why a rolled theme never lands somewhere unusable.
+    for (let i = 0; i < 200; i++) {
+      const out = rollTraits(traits, NO_LOCKS, "dark", BUILTIN_THEMES);
+      const o = oklch(out.seed);
+      expect(o.l).toBeGreaterThanOrEqual(0.51);
+      expect(o.l).toBeLessThanOrEqual(0.79);
+      expect(out.strength).toBeGreaterThanOrEqual(0.15);
+      expect(out.strength).toBeLessThanOrEqual(0.7);
+    }
+  });
+
+  it("only rolls built-in bases of the draft's own mode", () => {
+    for (let i = 0; i < 100; i++) {
+      const out = rollTraits(traits, NO_LOCKS, "light", BUILTIN_THEMES);
+      const picked = BUILTIN_THEMES.find((t) => t.id === out.baseId)!;
+      expect(picked.mode).toBe("light");
+      expect(picked.builtin).toBe(true);
+    }
+  });
+
+  it("never rolls a strength of zero", () => {
+    // A dice press that changes nothing visible reads as a broken button.
+    for (let i = 0; i < 100; i++) {
+      expect(
+        rollTraits(traits, NO_LOCKS, "dark", BUILTIN_THEMES).strength,
+      ).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/features/settings/theme/palette.test.ts
+++ b/src/features/settings/theme/palette.test.ts
@@ -17,7 +17,14 @@ import { hexToRgb } from "@/lib/color";
 import { rgbToOklch } from "@/lib/cssColor";
 
 import { contrastRatio } from "./contrast";
-import { RAMP_SLOTS, familyHue, tintRamp } from "./palette";
+import {
+  HARMONY_RULES,
+  RAMP_SLOTS,
+  familyHue,
+  generate,
+  harmonyOffsets,
+  tintRamp,
+} from "./palette";
 
 const oklch = (hex: string) => rgbToOklch(hexToRgb(hex)!);
 
@@ -161,5 +168,78 @@ describe("tintRamp", () => {
         -0.5,
       );
     }
+  });
+});
+
+describe("harmony", () => {
+  it("never gives the two logo slots the same hue", () => {
+    // A literal mirror collapses at 0 and at 180, which is why Monochrome and
+    // Complementary are nudged. Without the nudge the mark loses one of its two
+    // colours on exactly those rules.
+    for (const rule of HARMONY_RULES) {
+      expect(hueApart(rule.logo, rule.logo2), rule.id).toBeGreaterThan(1);
+    }
+  });
+
+  it("keeps Monochrome's ground on the seed and defaults to Analogous", () => {
+    expect(harmonyOffsets("mono").ground).toBe(0);
+    expect(HARMONY_RULES[1].id).toBe("analogous");
+  });
+});
+
+describe("generate", () => {
+  const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+  const traits = {
+    baseId: base.id,
+    seed: "#5aa8e8",
+    rule: "analogous" as const,
+    strength: 0.35,
+  };
+
+  it("puts the seed in the accent slot untouched", () => {
+    expect(generate(base, traits).accent).toBe("#5aa8e8");
+  });
+
+  it("reproduces every base's ramp exactly at strength 0, under every rule", () => {
+    // What makes opening the editor safe: the generator's neutral position IS
+    // the theme you started from, whatever rule happens to be selected.
+    //
+    // This has to hold for EVERY rule, not just the nearest one. A rule's ground
+    // offset is a quantised angle while a base's own offset is whatever it is —
+    // dark-cool sits at 18.6 degrees and no rule has that — so a version that
+    // rotated the ramp at strength 0 moved bg0 from #1a1d24 to #1b1d24 before
+    // the user touched anything. Caught by this test being written the strong way.
+    for (const t of BUILTIN_THEMES) {
+      for (const rule of HARMONY_RULES) {
+        const out = generate(t, {
+          baseId: t.id,
+          seed: t.colors.accent,
+          rule: rule.id,
+          strength: 0,
+        });
+        for (const key of RAMP_SLOTS) {
+          expect(out[key], `${t.id} under ${rule.id}: ${key}`).toBe(t.colors[key]);
+        }
+      }
+    }
+  });
+
+  it("moves the ground with the rule but never the accent", () => {
+    const mono = generate(base, { ...traits, rule: "mono" });
+    const comp = generate(base, { ...traits, rule: "complementary" });
+    expect(mono.accent).toBe(comp.accent);
+    expect(hueApart(familyHue(comp)!, familyHue(mono)!)).toBeGreaterThan(150);
+  });
+
+  it("keeps the button label readable on every generated accent", () => {
+    for (const seed of ["#ffee00", "#0b1020", "#5aa8e8", "#7a7a7a", "#808080"]) {
+      const out = generate(base, { ...traits, seed });
+      expect(contrastRatio(out.accentInk, out.accent), seed).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("returns the base untouched for a seed that is not a colour", () => {
+    // A half-typed hex is not a palette. The editor's own field keeps the text.
+    expect(generate(base, { ...traits, seed: "not a colour" })).toEqual(base.colors);
   });
 });

--- a/src/features/settings/theme/palette.test.ts
+++ b/src/features/settings/theme/palette.test.ts
@@ -1,0 +1,165 @@
+// The palette generator's arithmetic.
+//
+// These tests are the ARGUMENT, not decoration. The 2026-09-09 spec ruled a
+// palette generator out because one "produces palettes the user cannot predict
+// or correct", and the reversal is only defensible if the two properties that
+// objection names are measurable: strength 0 reproduces the base byte-for-byte
+// (predictable), and tinting cannot move a contrast pair across an AA boundary
+// (correct, in the sense that it never silently breaks the theme).
+//
+// So the numbers here are load-bearing. A failure is a re-measurement, never a
+// loosened bound.
+
+import { describe, expect, it } from "vitest";
+
+import { BUILTIN_THEMES } from "@/features/settings/useSettingsStore";
+import { hexToRgb } from "@/lib/color";
+import { rgbToOklch } from "@/lib/cssColor";
+
+import { contrastRatio } from "./contrast";
+import { RAMP_SLOTS, familyHue, tintRamp } from "./palette";
+
+const oklch = (hex: string) => rgbToOklch(hexToRgb(hex)!);
+
+/**
+ * The three ramp pairs.
+ *
+ * `accentInk`/`accent` is deliberately absent: the accent is a seed and is never
+ * tinted, so sweeping it here would measure `inkFor`, which `deriveTheme.test.ts`
+ * already pins.
+ */
+const RAMP_PAIRS = [
+  ["fg0", "bg0"],
+  ["fg1", "bg1"],
+  ["fg2", "bg1"],
+] as const;
+
+const CHROMA_FLOOR = 0.004;
+
+/** Circular distance between two hues, in degrees, 0 to 180. */
+const hueApart = (a: number, b: number) =>
+  Math.abs(((((a - b) % 360) + 540) % 360) - 180);
+
+const band = (r: number) => (r < 3 ? "bad" : r < 4.5 ? "low" : "ok");
+
+describe("familyHue", () => {
+  it("is null only for a fully achromatic ramp", () => {
+    // Measured: of the nine built-ins, dark-neutral alone has no slot above the
+    // chroma floor. light, gruvbox-dark and github-light have achromatic
+    // BACKGROUNDS but still resolve a hue from the rest of the ramp.
+    for (const t of BUILTIN_THEMES) {
+      const hue = familyHue(t.colors);
+      if (t.id === "dark-neutral") expect(hue, t.id).toBeNull();
+      else expect(hue, t.id).not.toBeNull();
+    }
+  });
+
+  it("lands on the hue the ramp actually reads as", () => {
+    // Measured chroma-weighted circular means, to the nearest degree.
+    const expected: Record<string, number> = {
+      "dark-cool": 264,
+      "dark-warm": 68,
+      light: 259,
+      nord: 264,
+      dracula: 273,
+      "solarized-dark": 215,
+      "gruvbox-dark": 79,
+      "github-light": 251,
+    };
+    for (const [id, want] of Object.entries(expected)) {
+      const t = BUILTIN_THEMES.find((x) => x.id === id)!;
+      expect(familyHue(t.colors)!, id).toBeCloseTo(want, -0.5);
+    }
+  });
+});
+
+describe("tintRamp", () => {
+  it("is the exact identity at strength 0 on the family hue", () => {
+    // The guarantee the whole panel rests on: opening the editor and touching
+    // nothing must not move a single byte. Measured 0/14 slots differ across
+    // all nine built-ins, worst channel error 0.
+    for (const t of BUILTIN_THEMES) {
+      const hue = familyHue(t.colors) ?? 0;
+      const out = tintRamp(t.colors, hue, 0);
+      for (const key of RAMP_SLOTS) {
+        expect(out[key], `${t.id}.${key}`).toBe(t.colors[key]);
+      }
+    }
+  });
+
+  it("never changes a contrast verdict, at any hue or strength", () => {
+    // 9 themes x 24 hues x 5 strengths x 3 pairs = 3240 checks, measured at
+    // 0 band changes. This is what replaces the old non-goal's argument, so a
+    // failure here means re-measuring the model, not relaxing the assertion.
+    let checks = 0;
+    for (const t of BUILTIN_THEMES) {
+      for (let hue = 0; hue < 360; hue += 15) {
+        for (const strength of [0, 0.25, 0.5, 0.75, 1]) {
+          const out = tintRamp(t.colors, hue, strength);
+          for (const [a, b] of RAMP_PAIRS) {
+            const before = band(contrastRatio(t.colors[a], t.colors[b]));
+            const after = band(contrastRatio(out[a], out[b]));
+            expect(after, `${t.id} hue=${hue} strength=${strength} ${a}/${b}`).toBe(
+              before,
+            );
+            checks++;
+          }
+        }
+      }
+    }
+    expect(checks).toBe(3240);
+  });
+
+  it("holds every slot's lightness exactly", () => {
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!.colors;
+    const out = tintRamp(base, 300, 0.6);
+    for (const key of RAMP_SLOTS) {
+      // 8-bit quantization is the only source of drift, so a tight bound.
+      expect(oklch(out[key]).l, key).toBeCloseTo(oklch(base[key]).l, 2);
+    }
+  });
+
+  it("delivers the hue it was asked for rather than letting a clip shift it", () => {
+    // The ceiling clamp's real job. Asserting the OUTPUT's chroma is under the
+    // ceiling proves nothing — every 8-bit colour is in gamut by construction,
+    // so that assertion cannot fail even with the clamp deleted. What a missing
+    // clamp actually does is clip per channel, and an unevenly clipped channel
+    // moves the HUE. Verified by planting it: removing the clamp fails this.
+    //
+    // dark-neutral is the clean case: it has no family hue, so every slot is
+    // asked for exactly `hue` and there is no rotation to account for.
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-neutral")!.colors;
+    for (const hue of [0, 90, 180, 270]) {
+      const out = tintRamp(base, hue, 1);
+      for (const key of RAMP_SLOTS) {
+        const o = oklch(out[key]);
+        if (o.c < CHROMA_FLOOR) continue; // near-black and near-white carry none
+        // Circular distance, not a raw compare: hue wraps, and 359.8 is two
+        // tenths of a degree from 0, not 359.8 of them.
+        expect(hueApart(o.h, hue), `${key} at hue ${hue}`).toBeLessThan(2.5);
+      }
+    }
+  });
+
+  it("tints a ramp that has no hue of its own", () => {
+    // A multiplier cannot do this: dark-neutral is chroma 0 in all 14 slots,
+    // and any multiple of zero is zero.
+    const base = BUILTIN_THEMES.find((t) => t.id === "dark-neutral")!.colors;
+    expect(tintRamp(base, 300, 0).bg0).toBe(base.bg0);
+    expect(tintRamp(base, 300, 1).bg0).not.toBe(base.bg0);
+    expect(oklch(tintRamp(base, 300, 1).bg0).c).toBeGreaterThan(0.01);
+  });
+
+  it("rotates rather than assigns, so a theme keeps its own hue split", () => {
+    // dracula puts its text 171 degrees from its backgrounds on purpose.
+    // Assigning one hue flattens that; rotating preserves it.
+    const base = BUILTIN_THEMES.find((t) => t.id === "dracula")!.colors;
+    const split = (c: typeof base) => hueApart(oklch(c.fg0).h, oklch(c.bg0).h);
+    for (const target of [0, 120, 210]) {
+      expect(split(tintRamp(base, target, 0.4)), `target ${target}`).toBeCloseTo(
+        split(base),
+        -0.5,
+      );
+    }
+  });
+});

--- a/src/features/settings/theme/palette.ts
+++ b/src/features/settings/theme/palette.ts
@@ -1,0 +1,129 @@
+import type { ThemeColors } from "@/features/settings/useSettingsStore";
+
+import { hexToRgb, rgbToHex } from "@/lib/color";
+import { oklchToRgb, rgbToOklch, srgbChromaCeiling } from "@/lib/cssColor";
+
+/**
+ * Palette generation, in OKLCh, as pure arithmetic.
+ *
+ * The 2026-09-09 spec ruled a palette generator out, and it was right to: in
+ * HSL, hue and lightness are one knob, so a generated ramp's contrast lands
+ * wherever it lands and the user can neither predict nor correct it. OKLCh
+ * separates them. Everything here rewrites HUE and CHROMA while holding each
+ * slot's LIGHTNESS exactly, which is what lets the base theme's hand-tuned ramp
+ * — the part that takes longest to build by hand and that nobody has the
+ * vocabulary to repair — survive generation intact.
+ *
+ * Two properties are pinned by `palette.test.ts` rather than by this comment:
+ * strength 0 reproduces the base byte-for-byte, and no hue at any strength
+ * moves a contrast pair across an AA boundary (measured 0 changes in 3240).
+ *
+ * `deriveTheme.ts` next door is NOT superseded. It is still the accent swap the
+ * eighteen-slot path uses, and this module calls its `inkFor` rather than
+ * growing a second rule about what is readable on a button.
+ */
+
+/**
+ * The fourteen slots the ground tint rewrites.
+ *
+ * `accent` is a seed, `accentInk` is computed from it, and the two logo slots
+ * are placed by the harmony rule — so none of the four belongs here.
+ */
+export const RAMP_SLOTS = [
+  "bg0",
+  "bg1",
+  "bg2",
+  "bg3",
+  "bg4",
+  "titlebar",
+  "fg0",
+  "fg1",
+  "fg2",
+  "fg3",
+  "fg4",
+  "border0",
+  "border1",
+  "border2",
+] as const satisfies readonly (keyof ThemeColors)[];
+
+/**
+ * Below this chroma a slot is grey, and the hue `rgbToOklch` reports for it is
+ * numerical noise rather than a colour. Averaging that noise into the family
+ * hue is how a neutral ramp acquires an arbitrary tint.
+ */
+const CHROMA_FLOOR = 0.004;
+
+/** Chroma added on top of a slot's own at strength 1. */
+const TINT_REACH = 0.06;
+
+const norm360 = (deg: number) => ((deg % 360) + 360) % 360;
+
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+function oklchOf(hex: string) {
+  const rgb = hexToRgb(hex);
+  return rgb ? rgbToOklch(rgb) : null;
+}
+
+/**
+ * The hue this ramp reads as: the CHROMA-WEIGHTED circular mean over the slots
+ * that carry any colour at all.
+ *
+ * Weighted, not plain, because the slots differ by an order of magnitude —
+ * solarized-dark's `bg4` carries chroma 0.066 against its `fg2`'s 0.016 — and
+ * the strongly tinted slots are the ones that decide what family a theme reads
+ * as. Circular, not arithmetic, because hue wraps and a plain mean of 350 and
+ * 10 is 180: the exact opposite of both.
+ *
+ * `null` when no slot clears the floor. Of the nine built-ins that is
+ * `dark-neutral` alone.
+ */
+export function familyHue(colors: ThemeColors): number | null {
+  let x = 0;
+  let y = 0;
+  for (const key of RAMP_SLOTS) {
+    const o = oklchOf(colors[key]);
+    if (!o || o.c < CHROMA_FLOOR) continue;
+    const rad = (o.h * Math.PI) / 180;
+    x += Math.cos(rad) * o.c;
+    y += Math.sin(rad) * o.c;
+  }
+  if (x === 0 && y === 0) return null;
+  return norm360((Math.atan2(y, x) * 180) / Math.PI);
+}
+
+/**
+ * Move the ramp to `groundHue`, holding every slot's lightness.
+ *
+ * The hue is applied as a ROTATION by `groundHue - familyHue`, not as an
+ * assignment. Five of the nine built-ins run one hue across the whole ramp, so
+ * for those the two are the same thing — but dracula puts its text 171 degrees
+ * from its backgrounds, solarized-dark 130, gruvbox-dark 170, all three on
+ * purpose. Assigning one absolute hue flattens that and throws away what makes
+ * those themes look like themselves.
+ *
+ * The chroma is ADDITIVE over the slot's own, because a multiplier cannot tint
+ * an achromatic ramp: `dark-neutral` is chroma 0 in all fourteen slots and any
+ * multiple of zero is zero. The `srgbChromaCeiling` clamp is the normal path
+ * near the ends of the ramp, not an edge case — at `fg0`'s L of 0.957 the
+ * ceiling is 0.024 at hue 300 against 0.141 at hue 120 — and skipping it means
+ * a per-channel clip that shifts the hue silently.
+ */
+export function tintRamp(
+  colors: ThemeColors,
+  groundHue: number,
+  strength: number,
+): ThemeColors {
+  const family = familyHue(colors);
+  const delta = family === null ? 0 : groundHue - family;
+  const amount = clamp01(strength);
+  const out = { ...colors };
+  for (const key of RAMP_SLOTS) {
+    const o = oklchOf(colors[key]);
+    if (!o) continue;
+    const h = norm360(family === null ? groundHue : o.h + delta);
+    const c = Math.min(o.c + amount * TINT_REACH, srgbChromaCeiling(o.l, h));
+    out[key] = rgbToHex(oklchToRgb(o.l, c, h));
+  }
+  return out;
+}

--- a/src/features/settings/theme/palette.ts
+++ b/src/features/settings/theme/palette.ts
@@ -1,7 +1,9 @@
-import type { ThemeColors } from "@/features/settings/useSettingsStore";
+import type { ThemeColors, ThemeDef } from "@/features/settings/useSettingsStore";
 
-import { hexToRgb, rgbToHex } from "@/lib/color";
+import { hexToRgb, normalizeHex, rgbToHex } from "@/lib/color";
 import { oklchToRgb, rgbToOklch, srgbChromaCeiling } from "@/lib/cssColor";
+
+import { inkFor } from "./deriveTheme";
 
 /**
  * Palette generation, in OKLCh, as pure arithmetic.
@@ -114,9 +116,20 @@ export function tintRamp(
   groundHue: number,
   strength: number,
 ): ThemeColors {
+  const amount = clamp01(strength);
+  // Tint 0 means the surfaces are left alone — not "rotated to the ground hue
+  // but no extra chroma". Without this the identity holds only when the ground
+  // hue happens to equal the base's own family hue, which it almost never does:
+  // the ground is `seed + rule.ground`, a quantised angle, while a base's real
+  // offset is whatever it is (dark-cool's is 18.6 degrees, and no rule has
+  // that). Rotating a ramp that still carries its own chroma changes every
+  // slot, so opening the editor would silently move `bg0` from #1a1d24 to
+  // #1b1d24 before the user touched anything. The cost is a step at the very
+  // bottom of the slider, which defaults to 0.35 and is never sat on.
+  if (amount === 0) return { ...colors };
+
   const family = familyHue(colors);
   const delta = family === null ? 0 : groundHue - family;
-  const amount = clamp01(strength);
   const out = { ...colors };
   for (const key of RAMP_SLOTS) {
     const o = oklchOf(colors[key]);
@@ -126,4 +139,90 @@ export function tintRamp(
     out[key] = rgbToHex(oklchToRgb(o.l, c, h));
   }
   return out;
+}
+
+export type HarmonyRule =
+  | "mono"
+  | "analogous"
+  | "triadic"
+  | "split"
+  | "complementary";
+
+/**
+ * How far the ground and the two logo colours sit from the seed.
+ *
+ * The ground takes the rule's angle. `logo` and `logo2` sit on opposite sides of
+ * the seed wherever the rule allows, so the mark always carries two
+ * distinguishable colours — Monochrome and Complementary are nudged off the
+ * literal mirror, because the mirror of 0 is 0 and the mirror of 180 is 180, and
+ * either would collapse the pair.
+ *
+ * Analogous is the default because it is what the built-ins do. Measured, every
+ * one of the nine places its surface hue within 46 degrees of its accent — five
+ * within 20 — and not one is complementary or triadic. The wide angles stay on
+ * offer because exploring past the built-ins is the point of the feature, but
+ * they are the adventurous setting rather than the one you get for free.
+ */
+export const HARMONY_RULES = [
+  { id: "mono", label: "Monochrome", ground: 0, logo: -30, logo2: 30 },
+  { id: "analogous", label: "Analogous", ground: 30, logo: -30, logo2: 60 },
+  { id: "triadic", label: "Triadic", ground: 120, logo: 120, logo2: -120 },
+  { id: "split", label: "Split-complement", ground: 150, logo: 150, logo2: -150 },
+  { id: "complementary", label: "Complementary", ground: 180, logo: 180, logo2: -60 },
+] as const satisfies readonly {
+  id: HarmonyRule;
+  label: string;
+  ground: number;
+  logo: number;
+  logo2: number;
+}[];
+
+export const DEFAULT_TRAIT_RULE: HarmonyRule = "analogous";
+export const DEFAULT_TRAIT_STRENGTH = 0.35;
+
+export function harmonyOffsets(rule: HarmonyRule) {
+  return HARMONY_RULES.find((r) => r.id === rule) ?? HARMONY_RULES[1];
+}
+
+/** The four values a generated palette is a pure function of. */
+export type PaletteTraits = {
+  /** Which theme supplies the lightness ramp and its baseline chroma. */
+  baseId: string;
+  /** One colour. Becomes `accent` verbatim. */
+  seed: string;
+  rule: HarmonyRule;
+  /** 0 to 1. 0 is the identity. */
+  strength: number;
+};
+
+/** Keep a slot's lightness and chroma, move it to `hue`. */
+function rotateTo(hex: string, hue: number): string {
+  const o = oklchOf(hex);
+  if (!o) return hex;
+  const h = norm360(hue);
+  return rgbToHex(oklchToRgb(o.l, Math.min(o.c, srgbChromaCeiling(o.l, h)), h));
+}
+
+/**
+ * The whole palette, from four values.
+ *
+ * `accent` is the seed verbatim and is never tinted — it is the one colour the
+ * user chose outright, and rewriting it would make the swatch lie. `accentInk`
+ * goes through `deriveTheme`'s `inkFor`, so there is still exactly one rule in
+ * this tree about what can be read on a button.
+ */
+export function generate(base: ThemeDef, traits: PaletteTraits): ThemeColors {
+  const seed = normalizeHex(traits.seed);
+  const o = seed ? oklchOf(seed) : null;
+  // A half-typed hex is not a palette. Hand back the base rather than
+  // generating from noise — the editor's own field keeps the user's text.
+  if (!seed || !o) return { ...base.colors };
+
+  const off = harmonyOffsets(traits.rule);
+  const colors = tintRamp(base.colors, norm360(o.h + off.ground), traits.strength);
+  colors.accent = seed;
+  colors.accentInk = inkFor(colors, seed);
+  colors.logo = rotateTo(base.colors.logo, o.h + off.logo);
+  colors.logo2 = rotateTo(base.colors.logo2, o.h + off.logo2);
+  return colors;
 }

--- a/src/features/settings/theme/palette.ts
+++ b/src/features/settings/theme/palette.ts
@@ -219,10 +219,152 @@ export function generate(base: ThemeDef, traits: PaletteTraits): ThemeColors {
   if (!seed || !o) return { ...base.colors };
 
   const off = harmonyOffsets(traits.rule);
-  const colors = tintRamp(base.colors, norm360(o.h + off.ground), traits.strength);
+  const amount = clamp01(traits.strength);
+  const colors = tintRamp(base.colors, norm360(o.h + off.ground), amount);
   colors.accent = seed;
   colors.accentInk = inkFor(colors, seed);
-  colors.logo = rotateTo(base.colors.logo, o.h + off.logo);
-  colors.logo2 = rotateTo(base.colors.logo2, o.h + off.logo2);
+  // The logo pair is a surface like the ramp, so tint 0 leaves it alone too.
+  // That makes tint the one master control — at 0 this function degenerates
+  // EXACTLY to `deriveTheme`, the accent swap that shipped before it, and at 1
+  // it is a fully generated palette. Without the gate, opening any built-in
+  // read as "Custom" immediately, because a rule places the logo pair at
+  // angles the theme's own mark was never drawn at.
+  if (amount > 0) {
+    colors.logo = rotateTo(base.colors.logo, o.h + off.logo);
+    colors.logo2 = rotateTo(base.colors.logo2, o.h + off.logo2);
+  }
   return colors;
+}
+
+export type TraitLocks = {
+  base: boolean;
+  seed: boolean;
+  rule: boolean;
+  strength: boolean;
+};
+
+export const NO_LOCKS: TraitLocks = {
+  base: false,
+  seed: false,
+  rule: false,
+  strength: false,
+};
+
+/** An angle folded into [-180, 180), so 350 and -10 are the same distance. */
+function signed180(deg: number): number {
+  return (((deg % 360) + 540) % 360) - 180;
+}
+
+/** How near a measured angle has to be before a rule claims it. */
+const RULE_TOLERANCE = 15;
+
+/**
+ * The traits that regenerate this theme, read back out of its own palette.
+ *
+ * There is no persisted trait format on purpose: the moment traits are stored, a
+ * theme has two sources of truth and every importer has to decide which wins.
+ * Reading them back works because strength 0 leaves the ramp alone — base is the
+ * theme itself, so opening any theme for edit regenerates its surfaces
+ * byte-for-byte and nothing moves until the user moves something.
+ */
+export function inferTraits(theme: ThemeDef): PaletteTraits {
+  const family = familyHue(theme.colors);
+  const accent = oklchOf(theme.colors.accent);
+  let rule: HarmonyRule = DEFAULT_TRAIT_RULE;
+  if (family !== null && accent) {
+    // MAGNITUDE, not the signed angle: a rule's offsets are written one way
+    // round (+30) but a theme is equally analogous 30 degrees the other way.
+    // Measured, dracula sits at -29.0 and solarized-dark at -30.1, and matching
+    // on the signed value would name neither.
+    const delta = Math.abs(signed180(family - accent.h));
+    const near = HARMONY_RULES.find((r) => Math.abs(delta - r.ground) <= RULE_TOLERANCE);
+    if (near) rule = near.id;
+  }
+  return { baseId: theme.id, seed: theme.colors.accent, rule, strength: 0 };
+}
+
+/**
+ * Whether this palette is still exactly what the traits produce.
+ *
+ * False the moment a slot is hand-edited, which is what flips the editor's
+ * harmony readout to "Custom". Hand editing is never blocked — a generated slot
+ * is a plain hex string like every other, and the next trait change regenerates
+ * over it, which is what Revert is for.
+ */
+export function isGenerated(
+  colors: ThemeColors,
+  base: ThemeDef,
+  traits: PaletteTraits,
+): boolean {
+  const want = generate(base, traits);
+  return (Object.keys(want) as (keyof ThemeColors)[]).every(
+    // `accentInk` is excluded because it is a CONSEQUENCE, not a choice. The
+    // built-ins ship hand-authored inks that predate the generator — dark-cool
+    // carries #0e1a26 where `inkFor` picks #1a1d24 off its own ramp — so
+    // comparing it would make every built-in read as "Custom" the moment it was
+    // opened, which is the opposite of what the readout is for.
+    (key) => key === "accentInk" || want[key] === colors[key],
+  );
+}
+
+/** The measured span of the nine built-in accents: L 0.518-0.775, C 0.062-0.191. */
+const SEED_L: [number, number] = [0.52, 0.78];
+const SEED_C: [number, number] = [0.06, 0.19];
+/** Never 0: a dice press that changes nothing visible reads as a broken button. */
+const ROLL_STRENGTH: [number, number] = [0.15, 0.7];
+
+/**
+ * Monochrome and Analogous at twice the weight of the rest.
+ *
+ * Not arbitrary: all nine built-ins sit in those two bands, so the near angles
+ * are what reads as a designed theme and the dice should land there more often.
+ */
+const ROLL_RULES: readonly HarmonyRule[] = [
+  "mono",
+  "mono",
+  "analogous",
+  "analogous",
+  "triadic",
+  "split",
+  "complementary",
+];
+
+/**
+ * Re-roll every unlocked trait.
+ *
+ * It cannot produce an unusable theme, because the four traits are the only
+ * inputs and each rolls inside a measured band — the ramp still comes from a
+ * calibrated built-in, and `tintRamp` cannot move a contrast verdict.
+ *
+ * `rand` is injected so a test can script a roll. Every trait draws in a fixed
+ * order whether or not it is locked, so a scripted sequence lines up the same
+ * way regardless of which locks are set.
+ */
+export function rollTraits(
+  current: PaletteTraits,
+  locks: TraitLocks,
+  mode: "dark" | "light",
+  pool: readonly ThemeDef[],
+  rand: () => number = Math.random,
+): PaletteTraits {
+  const between = ([lo, hi]: [number, number]) => lo + rand() * (hi - lo);
+
+  const bases = pool.filter((t) => t.builtin && t.mode === mode);
+  const baseRoll = rand();
+  const seedH = rand() * 360;
+  const seedL = between(SEED_L);
+  const seedC = Math.min(between(SEED_C), srgbChromaCeiling(seedL, seedH));
+  const ruleRoll = rand();
+  const strength = between(ROLL_STRENGTH);
+
+  const pick = <T,>(xs: readonly T[], roll: number) =>
+    xs[Math.min(xs.length - 1, Math.floor(roll * xs.length))];
+
+  return {
+    baseId:
+      locks.base || bases.length === 0 ? current.baseId : pick(bases, baseRoll).id,
+    seed: locks.seed ? current.seed : rgbToHex(oklchToRgb(seedL, seedC, seedH)),
+    rule: locks.rule ? current.rule : pick(ROLL_RULES, ruleRoll),
+    strength: locks.strength ? current.strength : strength,
+  };
 }

--- a/src/features/settings/theme/useThemeEditorStore.test.ts
+++ b/src/features/settings/theme/useThemeEditorStore.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { BUILTIN_THEMES, useSettingsStore } from "@/features/settings/useSettingsStore";
 
+import { NO_LOCKS, inferTraits } from "./palette";
 import { useThemeEditorStore } from "./useThemeEditorStore";
 
 const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
@@ -182,5 +183,82 @@ describe("useThemeEditorStore", () => {
     expect(ed().colors).toEqual(dark.colors);
     expect(ed().themeMode).toBe("dark");
     expect(rootVar("--bg-0")).toBe(dark.colors.bg0);
+  });
+});
+
+describe("palette traits", () => {
+  beforeEach(() => {
+    useThemeEditorStore.getState().close();
+    useSettingsStore.getState().reset();
+  });
+
+  it("opens a draft on traits that regenerate it unchanged", () => {
+    ed().openEdit(dark);
+    expect(ed().traits.baseId).toBe(dark.id);
+    expect(ed().traits.seed).toBe(dark.colors.accent);
+    expect(ed().traits.strength).toBe(0);
+    expect(ed().colors).toEqual(dark.colors);
+  });
+
+  it("regenerates the palette when a trait moves", () => {
+    ed().openEdit(dark);
+    ed().setTrait("strength", 0.6);
+    expect(ed().colors.bg0).not.toBe(dark.colors.bg0);
+    // The ramp moved; the accent the user picked did not.
+    expect(ed().colors.accent).toBe(dark.colors.accent);
+  });
+
+  it("leaves a locked trait alone through a shuffle", () => {
+    ed().openEdit(dark);
+    ed().toggleLock("seed");
+    const seed = ed().traits.seed;
+    for (let i = 0; i < 20; i++) ed().shuffle();
+    expect(ed().traits.seed).toBe(seed);
+    expect(ed().colors.accent).toBe(seed);
+  });
+
+  it("actually changes the palette when nothing is locked", () => {
+    ed().openEdit(dark);
+    const before = { ...ed().colors };
+    ed().shuffle();
+    expect(ed().colors).not.toEqual(before);
+  });
+
+  it("paints a shuffled palette straight onto :root", () => {
+    ed().openEdit(dark);
+    ed().shuffle();
+    expect(rootVar("--bg-0")).toBe(ed().colors.bg0);
+  });
+
+  it("does not regenerate over a hand-edited slot", () => {
+    // patchColors is the eighteen-slot path. It writes, and nothing more.
+    ed().openEdit(dark);
+    ed().patchColors({ border1: "#ff00ff" });
+    expect(ed().colors.border1).toBe("#ff00ff");
+  });
+
+  it("keeps the shuffled base in step with the mode the draft is in", () => {
+    ed().openEdit(light);
+    for (let i = 0; i < 20; i++) ed().shuffle();
+    expect(ed().themeMode).toBe("light");
+  });
+
+  it("revert puts the traits back too, not just the colours", () => {
+    // Otherwise the palette is the source's again while the traits still
+    // describe the abandoned generation, and the section reads "Custom" against
+    // a palette it could regenerate exactly.
+    ed().openEdit(dark);
+    ed().setTrait("strength", 0.8);
+    ed().setTrait("rule", "complementary");
+    ed().revert();
+    expect(ed().colors).toEqual(dark.colors);
+    expect(ed().traits).toEqual(inferTraits(dark));
+  });
+
+  it("clears traits and locks on close", () => {
+    ed().openEdit(dark);
+    ed().toggleLock("rule");
+    ed().close();
+    expect(ed().locks).toEqual(NO_LOCKS);
   });
 });

--- a/src/features/settings/theme/useThemeEditorStore.ts
+++ b/src/features/settings/theme/useThemeEditorStore.ts
@@ -8,7 +8,14 @@ import {
   type ThemeDef,
 } from "@/features/settings/useSettingsStore";
 
-import { deriveTheme } from "./deriveTheme";
+import {
+  NO_LOCKS,
+  generate,
+  inferTraits,
+  rollTraits,
+  type PaletteTraits,
+  type TraitLocks,
+} from "./palette";
 
 /**
  * The theme editor's draft, in a store rather than in the component.
@@ -40,6 +47,10 @@ export type ThemeEditorState = {
   originalTheme: ThemeDef | null;
   /** Which theme the guided "Start from" picker is pointing at. */
   baseId: string;
+  /** The four values the palette is generated from. See `palette.ts`. */
+  traits: PaletteTraits;
+  /** Which traits a shuffle must leave alone. Session state, never persisted. */
+  locks: TraitLocks;
 
   openNew: (source: ThemeDef) => void;
   openEdit: (theme: ThemeDef) => void;
@@ -51,6 +62,10 @@ export type ThemeEditorState = {
   setColors: (colors: ThemeColors) => void;
   /** The guided start: take a base theme's palette, keep an accent. */
   applyBase: (baseId: string, accent?: string) => void;
+  setTrait: <K extends keyof PaletteTraits>(key: K, value: PaletteTraits[K]) => void;
+  toggleLock: (key: keyof TraitLocks) => void;
+  /** Re-roll every unlocked trait and regenerate. */
+  shuffle: () => void;
   /** Back to the theme this draft was opened from. */
   revert: () => void;
   /** Persist and leave. Returns the saved theme, or `null` for an empty name. */
@@ -74,6 +89,8 @@ const EMPTY_DRAFT = {
   colors: BUILTIN_THEMES[0].colors,
   originalTheme: null,
   baseId: BUILTIN_THEMES[0].id,
+  traits: inferTraits(BUILTIN_THEMES[0]),
+  locks: NO_LOCKS,
 };
 
 export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
@@ -95,6 +112,26 @@ export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
     });
   };
 
+  /**
+   * Write the traits' palette into the draft and repaint.
+   *
+   * Keeps `baseId` in step with `traits.baseId`: the "Start from" select and the
+   * base-ramp trait are the same choice wearing two names, and letting them
+   * drift is how the dialog ends up showing one theme while generating from
+   * another.
+   */
+  const regenerate = (traits: PaletteTraits) => {
+    const base = allThemes().find((t) => t.id === traits.baseId);
+    if (!base) return;
+    set({
+      traits,
+      baseId: base.id,
+      themeMode: base.mode,
+      colors: generate(base, traits),
+    });
+    preview();
+  };
+
   return {
     ...EMPTY_DRAFT,
 
@@ -105,6 +142,8 @@ export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
         themeMode: source.mode,
         colors: { ...source.colors },
         baseId: source.id,
+        traits: inferTraits(source),
+        locks: NO_LOCKS,
         // Read BEFORE anything is applied, or the "original" is already the draft.
         originalTheme: useSettingsStore.getState().getActiveTheme(),
       });
@@ -118,6 +157,8 @@ export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
         themeMode: theme.mode,
         colors: { ...theme.colors },
         baseId: theme.id,
+        traits: inferTraits(theme),
+        locks: NO_LOCKS,
         originalTheme: useSettingsStore.getState().getActiveTheme(),
       });
       preview();
@@ -163,13 +204,28 @@ export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
       // an existing theme being edited already has a name of its own.
       const from = allThemes().find((t) => t.id === s.baseId);
       const auto = s.open?.mode === "new" && !!from && s.name === autoName(from);
-      set({
-        baseId,
-        themeMode: base.mode,
-        colors: deriveTheme(base, accent ?? base.colors.accent),
-        ...(auto ? { name: autoName(base) } : null),
-      });
-      preview();
+      if (auto) set({ name: autoName(base) });
+      // Through the traits rather than `deriveTheme` directly: the base ramp IS
+      // a trait, and a second path that wrote `colors` without moving
+      // `traits.baseId` would leave the palette section describing a theme the
+      // draft is no longer built from.
+      regenerate({ ...s.traits, baseId, seed: accent ?? base.colors.accent });
+    },
+
+    setTrait(key, value) {
+      const s = get();
+      if (!s.open) return;
+      regenerate({ ...s.traits, [key]: value });
+    },
+
+    toggleLock(key) {
+      set((s) => ({ locks: { ...s.locks, [key]: !s.locks[key] } }));
+    },
+
+    shuffle() {
+      const s = get();
+      if (!s.open) return;
+      regenerate(rollTraits(s.traits, s.locks, s.themeMode, allThemes(), Math.random));
     },
 
     revert() {
@@ -180,6 +236,10 @@ export const useThemeEditorStore = create<ThemeEditorState>((set, get) => {
         themeMode: open.sourceTheme.mode,
         colors: { ...open.sourceTheme.colors },
         baseId: open.sourceTheme.id,
+        // The traits go back too. Restoring only the colours leaves them
+        // describing the abandoned generation, so the palette section reads
+        // "Custom" against a palette it could regenerate exactly.
+        traits: inferTraits(open.sourceTheme),
       });
       preview();
     },


### PR DESCRIPTION
An Arc-style palette for the theme editor, plus a character-creator shuffle.

Four traits generate all eighteen colour slots. Each one has a lock, and one dice re-rolls everything unlocked:

| Trait | What it decides |
| --- | --- |
| **Base ramp** | Supplies every slot's lightness and its baseline chroma |
| **Accent** | The one colour you pick; becomes `accent` verbatim |
| **Harmony** | Mono / Analogous / Triadic / Split / Complementary — where the surfaces and the logo pair sit relative to the accent |
| **Tint** | 0 → 1. How far the palette's hue reaches the surfaces |

The eighteen slots stay hand-editable underneath; a hand edit just flips the readout to "Custom".

## This reverses a written non-goal, deliberately

The 2026-09-09 spec and `docs/dev/frontend.md` both said:

> No hue-shifting palette generator. `deriveTheme` swaps the accent and fixes the ink; anything cleverer produces palettes the user cannot predict or correct.

That objection was about **HSL**, where hue and lightness are one knob, so a generated ramp's contrast lands wherever it lands. OKLCh landed since (for the colour picker) and separates them. Holding lightness and rewriting only hue and chroma makes a generator predictable *and* correctable. Both halves are measured, not asserted — `palette.test.ts` pins three properties:

1. **Tint 0 is the identity, under every rule.** All nine built-ins × all five rules: 0 of 14 slots differ, worst channel error 0. Byte-for-byte.
2. **Tinting never changes a contrast verdict.** 9 themes × 24 hues × 5 strengths × 3 pairs = **0 band changes in 3240 checks**. Worst absolute drift 1.101, on a ratio moving 10.76 → 11.86.
3. **Every output lands in sRGB**, via `srgbChromaCeiling`.

Both docs are updated in this PR rather than left contradicting the code.

## Three traps, each a bug that shipped and was caught

- **The hue is a ROTATION, not an assignment.** dracula, solarized-dark and gruvbox-dark put their text at a different hue from their surfaces on purpose (dracula's split is 171°). Assigning one hue flattens all three.
- **The chroma is ADDITIVE over the base's own.** A multiplier cannot tint `dark-neutral`, which is chroma 0 in all fourteen slots.
- **Tint 0 short-circuits the ramp and the logo pair.** Without it the ground is `seed + the rule's quantised angle` while a base's real offset is whatever it is — dark-cool sits at 18.6°, which no rule has — so merely opening a theme rotated every slot and moved `bg0` from `#1a1d24` to `#1b1d24`. Gating the logo pair too buys a nice property: **at tint 0 `generate` degenerates to exactly `deriveTheme`**, asserted against `deriveTheme` itself so the two cannot drift.

`isGenerated` skips `accentInk`: the built-ins ship hand-authored inks that `inkFor` would not pick off their own ramps, so comparing it made every theme read as "Custom" the moment it opened.

## Shuffle

The dice cannot produce an unusable theme, because the four traits are its only inputs and each rolls inside a measured band — the accent's lightness and chroma sample the built-in accents' own span (L 0.518–0.775, C 0.062–0.191), the base ramp rolls among built-ins matching the draft's mode, and the harmony roll is weighted toward Mono and Analogous because that is where all nine built-ins sit.

## No format change

Traits are **inferred** from the palette on open, never persisted. `themePayload`, `normalizeCustomThemes` and `validateTheme` are untouched.

`SEMANTIC_TOKENS` and `SYNTAX_TOKENS` stay out of scope: diff green carries meaning, and a palette choice must not change what a diff says.

## Verification

- `pnpm test` — **4088 passed / 400 files**
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — both clean
- `settings.e2e.ts` in Docker against a rebuilt snapshot — **14 passing**, including the two cases that drive this surface ("duplicates a built-in theme into a custom one and keeps it" and "picks a colour with the wheel instead of the host's colour dialog"). The spec clicks `button[aria-label^="Accent — "]`, which is why the seed's row stayed labelled *Accent*.
- Rendered 24 generated palettes to pixels and read them: the tint travel is smooth, all 24 hold fg0/bg0 at 14.6–15.6:1, and the logo pair stays distinguishable on every rule

Spec: `docs/superpowers/specs/2026-09-11-theme-palette-harmony-design.md`
Plan: `docs/superpowers/plans/2026-09-11-theme-palette-harmony.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
