### PR TITLE
fix(branches): check out a remote branch so it actually tracks the remote

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -675,7 +675,10 @@ features/            Components + Zustand store colocated per feature:
 │                    parentFolderPath, branchesInFolder), useBranchFolders
 │                    (per-repo collapsed set in localStorage), deleteMerged
 │                    (candidates + `ahead_behind` merge check + summary),
-│                    fastForward (#246)
+│                    fastForward (#246), checkoutRemote — THE way a remote ref
+│                    becomes a local branch (menu, commit menu, Branches pane
+│                    all call it; a bare checkoutRef would DETACH), with the
+│                    name-collision dialog pure beside it
 ├── commits/         Pure log logic, all tested: graphLayout, laneColors,
 │                    graphAncestry, rowIdentity, buildRebasePlan /
 │                    buildPreservePlan / withPlanBase / runRebasePlan /

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -730,6 +730,41 @@ escape hatch from becoming the uncapped path #385 removed.
   other copy anywhere. Crash-safety needs a journal and its own spec; do not
   stub an affordance meanwhile.
 
+## A branch off a remote ref TRACKS it — `create_branch`'s quiet half
+
+`create_branch(name, from)` sets the new branch's upstream when `from` names a
+remote-tracking branch, and only then. This is git's `branch.autoSetupMerge`
+default, measured rather than assumed: `git branch x origin/main` prints
+"branch 'x' set up to track 'origin/main'", while `git branch x main` and
+`git branch x <oid>` set up nothing.
+
+It used to set up nothing at all, and "check out `origin/x` as a new local
+branch" — whose whole prompt says *Tracking origin/x* — produced a branch that
+tracked NOTHING. No ahead/behind, no pull, no fast-forward, and the second
+attempt at the same remote branch hit the name collision instead, so the user
+sat on a local branch that had never seen the remote and had no way to say so.
+
+- **The question is "does this revspec RESOLVE to a ref under
+  `refs/remotes/`"** — answered by `upstream_for_start_point` resolving it, not
+  by looking for a slash. A local branch may perfectly well be called
+  `origin/main`, and `refs/remotes/origin/main` is the spelling a ref picker
+  hands over. `resolve_reference_from_short_name` is libgit2's
+  `git_reference_dwim` *plus* symref resolution, which is exactly the pair
+  wanted: an oid or `HEAD~3` is not a ref and comes back `Err`.
+- **`origin/HEAD` yields what it points AT.** It is symbolic, so it resolves to
+  `origin/main` — again what git does (`git branch foo origin/HEAD` prints "set
+  up to track 'origin/main'"). The literal name is never written: a
+  `branch.<name>.merge = refs/heads/HEAD` matches no fetch refspec that has ever
+  existed, so a `…/HEAD` that survives resolution (an older tool may leave a
+  direct ref there) tracks nothing.
+- **A failed `set_upstream` un-creates the branch.** Shipping the half is the
+  exact bug above, so the arm deletes the ref and propagates — the same rule as
+  the signing chain.
+
+`src-tauri/tests/branches_tags.rs` pins all five cases, the negative ones
+included: a commit and a local branch start point must still track nothing, or
+every "branch from here" on a commit silently adopts an upstream.
+
 ## Fast-forwarding a branch you are not on (#246)
 
 `pull <remote> <branch>` never could do this: the branch argument is a

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1180,6 +1180,51 @@ that is only partly here — which is the whole reason the notice exists.
   included, resets on a closed→open transition — a `--depth 1` chosen for one
   enormous repository must not quietly truncate the next.
 
+## Checking out a remote branch — `features/branches/checkoutRemote.ts`
+
+A remote-tracking ref is not a branch you can be ON. `checkoutRef("origin/x")`
+detaches HEAD, so every surface that offers a remote ref goes through
+`checkoutRemoteAsLocalBranch` instead: the remote-branch context menu, the
+commit menu's remote entry (#179), the Branches detail pane's Check out button
+and Enter on a remote row. A second copy of that flow is how one of those four
+comes to detach — which is why it moved out of `design/context-menu.tsx`, where
+two of the four could not reach it.
+
+- **The create and the checkout are ONE store action
+  (`createAndSwitchBranch`), never two calls.** As two they were not atomic in
+  the way that mattered: the store's `createBranch` reports failure by setting
+  the banner and returning, so the `checkoutBranch` that unconditionally
+  followed it SUCCEEDED — on whatever unrelated local branch already held that
+  name — and its own `refreshAll` cleared the banner on the way past. The user
+  asked for `origin/x` and silently landed on a stale `x` that had never seen
+  the remote, with nothing on screen to say so.
+- **`createAndSwitchBranch`'s catch arm refreshes FIRST and sets the error
+  LAST.** It had them the other way round, and since `refreshAll` clears `error`
+  as its first act, the one thing a caller could see when a name was taken wiped
+  itself. This is the house order for every danger-op catch arm.
+- **`from` is the REMOTE ref, not the commit it points at.** That string is what
+  the backend reads to decide the upstream (see backend.md) — an oid tracks
+  nothing, and the tracking is the whole point.
+- **A taken name is a QUESTION, not an accident** (`existingBranchPrompt`, pure
+  and tested without a repository). It names the collision, says where the
+  existing branch sits relative to the remote ref — asked explicitly via
+  `ahead_behind`, because `BranchInfo.ahead/behind` is measured against its OWN
+  upstream, which in this case is typically nothing — and says what it tracks.
+- **The update offer is deliberately narrow.** "Check out and update to
+  `origin/x`" appears only when the existing branch is STRICTLY behind *and* the
+  ref it would be advanced along is the one the user named: a branch tracking
+  something else would move along a ref the dialog never mentioned, and a branch
+  with commits of its own cannot be fast-forwarded at all. Everything else gets
+  the plain checkout and keeps its commits.
+- **The ref moves BEFORE the branch becomes HEAD.** A fast-forward of the
+  checked-out branch needs a working-tree update, which is `pull`'s job under
+  the user's own pull mode — `fastForwardBranch` reroutes it there, which is not
+  what the dialog offered. So: set upstream → fast-forward → check out.
+- **An upstream that is already right is left alone,** and so is one pointing
+  somewhere else: re-pointing a branch's tracking is a different decision from
+  the one this dialog asked. Only a branch tracking NOTHING is given the
+  upstream, because that is precisely what the user came here for.
+
 ## Branch pins (#238)
 
 - **A pin is a TIER in `orderBranches`, and it outranks the default branch.**

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2987,6 +2987,41 @@ fn is_default_branch_name(name: &str, is_remote: bool, default: Option<&str>) ->
     }
 }
 
+/// The remote-tracking branch a start point names, if it names one — the
+/// upstream a new branch off it should be given.
+///
+/// This is git's `branch.autoSetupMerge` default, measured rather than assumed:
+/// `git branch x origin/main` prints "set up to track 'origin/main'", while
+/// `git branch x main` and `git branch x <oid>` set up nothing. Without it,
+/// "check out `origin/x` as a new local branch" produced a branch that tracked
+/// NOTHING — no ahead/behind, no pull, and a second attempt at the same remote
+/// branch ran into the name collision instead.
+///
+/// The question is "does this revspec RESOLVE to a ref under `refs/remotes/`",
+/// answered by resolving it, not by looking for a slash: a local branch may
+/// perfectly well be called `origin/main`, and `refs/remotes/origin/main` is
+/// the spelling a ref picker hands over.
+///
+/// `origin/HEAD` is a symbolic ref and resolves through to the branch it points
+/// at, so it yields `origin/main` — again what git does. The literal name is
+/// never used: `branch.<name>.merge = refs/heads/HEAD` matches no fetch
+/// refspec that has ever existed.
+fn upstream_for_start_point(repo: &Repository, rev: &str) -> Option<String> {
+    // `resolve_reference_from_short_name` is libgit2's `git_reference_dwim`
+    // plus symref resolution, which is the pair of behaviours wanted here. An
+    // oid or a revspec like `HEAD~3` is simply not a ref and comes back Err.
+    let reference = repo.resolve_reference_from_short_name(rev).ok()?;
+    let full = reference.name().ok()?;
+    let short = full.strip_prefix("refs/remotes/")?;
+    // A resolved symref cannot still BE `…/HEAD`, but a repository may carry a
+    // literal `refs/remotes/origin/HEAD` written as a direct ref by an older
+    // tool. Tracking that would write the unmatchable refspec above.
+    if short == "HEAD" || short.ends_with("/HEAD") {
+        return None;
+    }
+    Some(short.to_string())
+}
+
 // ─── Fast-forwarding a branch that is not checked out (#246) ─────────────────
 //
 // Every function here takes an ALREADY-BORROWED `&Repository`, exactly like the
@@ -5695,7 +5730,20 @@ impl GitBackend for Libgit2Backend {
                     Err(e) => return Err(e.into()),
                 },
             };
-            repo.branch(name, &target_commit, false)?;
+            // Resolved BEFORE the ref is written, so a start point that is not a
+            // remote-tracking branch costs the same lookup either way and the
+            // only work left after `branch()` is config.
+            let upstream = from.and_then(|rev| upstream_for_start_point(repo, rev));
+            let mut created = repo.branch(name, &target_commit, false)?;
+            if let Some(up) = upstream {
+                // A branch that exists but tracks nothing is the bug this whole
+                // change is about, so a failure here un-creates it rather than
+                // shipping the half — same rule as the signing chain.
+                if let Err(e) = created.set_upstream(Some(&up)) {
+                    let _ = created.delete();
+                    return Err(e.into());
+                }
+            }
             Ok(())
         })
     }

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -365,6 +365,128 @@ fn set_upstream_unknown_local_branch_is_invalid_ref() {
     );
 }
 
+/// Branching off a remote-tracking ref sets it as the upstream — git's own
+/// `branch.autoSetupMerge` default, and the whole point of "check out
+/// `origin/x` as a new local branch".
+///
+/// Without it the new branch tracked NOTHING: no ahead/behind, no pull, and a
+/// second attempt at the same remote branch hit the name collision instead,
+/// leaving the user on a local branch that had never seen the remote.
+#[test]
+fn create_branch_from_a_remote_ref_sets_it_as_the_upstream() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .create_branch(&handle.id, "mirror", Some("origin/main"))
+        .expect("create branch");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let made = branches
+        .iter()
+        .find(|b| b.name == "mirror" && !b.is_remote)
+        .expect("mirror branch");
+    assert_eq!(made.upstream.as_deref(), Some("origin/main"));
+
+    // ...and it sits at the remote tip the UI is showing, not at local HEAD.
+    let remote_tip = branches
+        .iter()
+        .find(|b| b.name == "origin/main" && b.is_remote)
+        .and_then(|b| b.tip.clone())
+        .expect("origin/main tip");
+    assert_eq!(made.tip.as_deref(), Some(remote_tip.as_str()));
+    assert_eq!(made.behind, 0, "a fresh mirror is not behind its upstream");
+}
+
+/// The same via the fully qualified spelling — `refs/remotes/origin/main` is
+/// what a ref picker hands over, and it must not read as "not a branch".
+#[test]
+fn create_branch_from_a_fully_qualified_remote_ref_also_tracks() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .create_branch(&handle.id, "mirror", Some("refs/remotes/origin/main"))
+        .expect("create branch");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let made = branches
+        .iter()
+        .find(|b| b.name == "mirror" && !b.is_remote)
+        .expect("mirror branch");
+    assert_eq!(made.upstream.as_deref(), Some("origin/main"));
+}
+
+/// Branching off a COMMIT tracks nothing — the same rule git applies. Only a
+/// remote-tracking start point sets up tracking, or every "branch from here"
+/// on a commit would silently adopt an upstream.
+#[test]
+fn create_branch_from_a_commit_sets_no_upstream() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+    let head_oid = tr.repo.head().unwrap().target().unwrap().to_string();
+
+    backend
+        .create_branch(&handle.id, "pinned", Some(&head_oid))
+        .expect("create branch");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let made = branches
+        .iter()
+        .find(|b| b.name == "pinned" && !b.is_remote)
+        .expect("pinned branch");
+    assert!(made.upstream.is_none(), "a commit is not an upstream");
+}
+
+/// A local branch is not an upstream either — `create_branch("x", "main")`
+/// branches off `main` and tracks nothing, as `git branch x main` does.
+#[test]
+fn create_branch_from_a_local_branch_sets_no_upstream() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .create_branch(&handle.id, "side", Some("main"))
+        .expect("create branch");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let made = branches
+        .iter()
+        .find(|b| b.name == "side" && !b.is_remote)
+        .expect("side branch");
+    assert!(made.upstream.is_none());
+}
+
+/// `origin/HEAD` is a SYMBOLIC ref, and the upstream written is the branch it
+/// RESOLVES to — `origin/main`, never a literal `origin/HEAD` whose
+/// `branch.<name>.merge = refs/heads/HEAD` no fetch refspec would ever match.
+/// Measured against git: `git branch foo origin/HEAD` prints "set up to track
+/// 'origin/main'".
+#[test]
+fn create_branch_from_origin_head_tracks_what_it_resolves_to() {
+    let (tr, _up) = with_origin();
+    tr.repo
+        .reference_symbolic(
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+            true,
+            "test fixture",
+        )
+        .unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .create_branch(&handle.id, "fromhead", Some("origin/HEAD"))
+        .expect("create branch");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let made = branches
+        .iter()
+        .find(|b| b.name == "fromhead" && !b.is_remote)
+        .expect("fromhead branch");
+    assert_eq!(made.upstream.as_deref(), Some("origin/main"));
+}
+
 /// `tip` is the FULL oid. It used to be truncated to 7 chars, which made every
 /// frontend comparison against `CommitInfo.oid` fail silently — History's HEAD
 /// marker never drew, and the HEAD-ancestry filter that rebase plans are built

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -36,6 +36,10 @@ import {
   hasCopyableDiffText,
   selectedLinesToText,
 } from "@/lib/diffCopy";
+import {
+  checkoutRemoteAsLocalBranch,
+  withoutRemotePrefix,
+} from "@/features/branches/checkoutRemote";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { branchFolderPaths } from "@/features/branches/branchTree";
 // The MODULE, not the `features/dnd` barrel: the barrel re-exports
@@ -1815,35 +1819,6 @@ export function branchMenuItems(
       },
     },
   ];
-}
-
-/** `origin/feat/x` → `feat/x`. The remote prefix is the FIRST segment only. */
-function withoutRemotePrefix(name: string): string {
-  const i = name.indexOf("/");
-  return i >= 0 ? name.slice(i + 1) : name;
-}
-
-/**
- * Check a remote-tracking ref out by creating a local branch that tracks it.
- *
- * ONE definition, shared by the remote-branch menu and the commit menu's remote
- * entry (#179): a bare `checkoutRef("origin/foo")` would silently DETACH, which
- * is the whole reason this flow exists, so a second copy is how one of the two
- * call sites would come to detach.
- */
-async function checkoutRemoteAsLocalBranch(name: string) {
-  if (!name) return;
-  const localName = await pgPrompt({
-    title: "Check out as new local branch",
-    body: `Tracking ${name}.`,
-    initialValue: withoutRemotePrefix(name),
-    confirmLabel: "Check out",
-    requireValue: true,
-    mono: true,
-  });
-  if (!localName) return;
-  await useRepoStore.getState().createBranch(localName, name);
-  await useRepoStore.getState().checkoutBranch(localName);
 }
 
 export function remoteBranchMenuItems(branch: { name?: string } | null): ContextMenuItem[] {

--- a/src/features/branches/checkoutRemote.flow.test.tsx
+++ b/src/features/branches/checkoutRemote.flow.test.tsx
@@ -273,6 +273,38 @@ describe("the name is already taken — the silent-fallback regression", () => {
     );
   });
 
+  it("spends no stash cycle when the collision is the branch under HEAD", async () => {
+    // You are on `feature`, someone pushes, you right-click `origin/feature`.
+    // checkoutBranch there is a no-op that still stashes and pops the user's
+    // working tree.
+    setBranches([
+      branch({ name: "feature", isHead: true }),
+      branch({ name: "origin/feature", isRemote: true }),
+    ]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    expect(await screen.findByTestId("dialog-title")).toHaveTextContent(
+      "Stay on feature?",
+    );
+    await choose("checkout");
+    await done;
+
+    // The tracking it was missing is still set — that IS the ask.
+    expect(callsTo("set_upstream")[0].args).toMatchObject({
+      branch: "feature",
+      upstream: "origin/feature",
+    });
+    expect(cmds()).not.toContain("checkout_branch");
+    expect(cmds()).not.toContain("stash_save");
+  });
+
   it("'use a different name' re-opens the prompt and takes the new name", async () => {
     takenByStale();
     render(

--- a/src/features/branches/checkoutRemote.flow.test.tsx
+++ b/src/features/branches/checkoutRemote.flow.test.tsx
@@ -1,0 +1,300 @@
+// "Check out origin/x as a new local branch", end to end through the store.
+//
+// The reported bug, in order: the new branch tracked NOTHING, so it showed no
+// ahead/behind and had nothing to pull; and when the name was already taken the
+// flow called `createBranch` (which reports failure by setting the banner, then
+// returns) and checked out anyway — landing the user on a stale same-named
+// branch that had never seen the remote, with the banner cleared by the
+// checkout's own refresh. Both halves are pinned here.
+//
+// Tracking itself is the BACKEND's job (`create_branch` off a remote-tracking
+// start point) — see `src-tauri/tests/branches_tags.rs`. What this file pins is
+// that the frontend asks for it: `from` must be the REMOTE ref, not the commit.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+
+import { checkoutRemoteAsLocalBranch } from "./checkoutRemote";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { WithDialogs, acceptDialog, resetDialogs, dismissDialog } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { BranchInfo } from "@/lib/types";
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: null,
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const cmds = () => getInvokeCalls().map((c) => c.cmd);
+const callsTo = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+/** Pick an answer from the open pgChoose dialog. */
+async function choose(id: string) {
+  await screen.findByTestId(`dialog-choice-${id}`);
+  await act(async () => {
+    fireEvent.click(screen.getByTestId(`dialog-choice-${id}`));
+  });
+}
+
+function setBranches(branches: BranchInfo[]) {
+  useRepoStore.setState({ branches } as never);
+}
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: [],
+    status: [],
+    branches: [],
+    remotes: [{ name: "origin", url: "git@example.com:o/r.git" }],
+    loading: false,
+    error: null,
+  } as never);
+  // checkoutBranch is stash → checkout → pop → refreshAll, so the whole refresh
+  // fan-out has to answer or the action throws before checking out.
+  mockInvoke("stash_save", () => null);
+  mockInvoke("checkout_branch", () => undefined);
+  mockInvoke("create_branch", () => undefined);
+  mockInvoke("set_upstream", () => undefined);
+  mockInvoke("fast_forward_branch", () => ({
+    branch: "feature",
+    upstream: "origin/feature",
+    from: "a".repeat(40),
+    to: "b".repeat(40),
+    moved: true,
+  }));
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 3, mergeBase: "c".repeat(40) }));
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+});
+
+afterEach(() => {
+  resetDialogs();
+  vi.restoreAllMocks();
+});
+
+describe("the name is free", () => {
+  it("branches off the REMOTE ref — which is what makes the backend track it", async () => {
+    setBranches([branch({ name: "main", isHead: true })]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await done;
+
+    expect(callsTo("create_branch")).toHaveLength(1);
+    // `from` is the remote-tracking ref, NOT a commit oid: the backend reads it
+    // to decide the upstream, and an oid tracks nothing.
+    expect(callsTo("create_branch")[0].args).toMatchObject({
+      name: "feature",
+      from: "origin/feature",
+    });
+    expect(callsTo("checkout_branch")[0].args).toMatchObject({ name: "feature" });
+  });
+
+  it("defaults the name to the branch without its remote prefix", async () => {
+    setBranches([]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    void checkoutRemoteAsLocalBranch("origin/feat/nested");
+    const input = await screen.findByTestId<HTMLInputElement>("dialog-input");
+    expect(input.value).toBe("feat/nested");
+    await dismissDialog();
+  });
+
+  it("does nothing at all when the prompt is dismissed", async () => {
+    setBranches([]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await dismissDialog();
+    await done;
+
+    expect(cmds()).not.toContain("create_branch");
+    expect(cmds()).not.toContain("checkout_branch");
+  });
+});
+
+describe("the name is already taken — the silent-fallback regression", () => {
+  const takenByStale = () =>
+    setBranches([
+      branch({ name: "main", isHead: true }),
+      branch({ name: "feature", tip: "a".repeat(40) }),
+      branch({ name: "origin/feature", isRemote: true, tip: "b".repeat(40) }),
+    ]);
+
+  it("asks instead of checking the stale branch out behind the user's back", async () => {
+    takenByStale();
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    void checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+
+    // The old flow reached checkout_branch here with nothing on screen.
+    await screen.findByTestId("dialog-choice-checkout");
+    expect(screen.getByTestId("dialog-title")).toHaveTextContent(
+      "Check out the existing feature?",
+    );
+    expect(cmds()).not.toContain("checkout_branch");
+    // ...and it never asked the backend to create a branch it knew was taken.
+    expect(cmds()).not.toContain("create_branch");
+
+    await dismissDialog();
+  });
+
+  it("dismissing the question checks nothing out", async () => {
+    takenByStale();
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await screen.findByTestId("dialog-choice-checkout");
+    await dismissDialog();
+    await done;
+
+    expect(cmds()).not.toContain("checkout_branch");
+    expect(cmds()).not.toContain("set_upstream");
+  });
+
+  it("'check out as it is' gives the untracked branch the upstream, then switches", async () => {
+    takenByStale();
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await choose("checkout");
+    await done;
+
+    expect(callsTo("set_upstream")[0].args).toMatchObject({
+      branch: "feature",
+      upstream: "origin/feature",
+    });
+    // No ref moved: "as it is" keeps the branch exactly where it was.
+    expect(cmds()).not.toContain("fast_forward_branch");
+    await waitFor(() => expect(callsTo("checkout_branch")).toHaveLength(1));
+    expect(cmds().indexOf("set_upstream")).toBeLessThan(
+      cmds().indexOf("checkout_branch"),
+    );
+  });
+
+  it("leaves an upstream that is already right alone", async () => {
+    setBranches([
+      branch({ name: "main", isHead: true }),
+      branch({ name: "feature", upstream: "origin/feature" }),
+      branch({ name: "origin/feature", isRemote: true }),
+    ]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await choose("checkout");
+    await done;
+
+    expect(cmds()).not.toContain("set_upstream");
+    expect(callsTo("checkout_branch")).toHaveLength(1);
+  });
+
+  it("'update' tracks, fast-forwards and only THEN checks out", async () => {
+    takenByStale();
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await choose("update");
+    await done;
+
+    const order = cmds();
+    // The ref move happens while the branch is NOT HEAD. Checked out first, a
+    // fast-forward would need a working-tree update — `pull`'s job, under the
+    // user's own pull mode — and `fastForwardBranch` reroutes it there.
+    expect(order.indexOf("set_upstream")).toBeLessThan(
+      order.indexOf("fast_forward_branch"),
+    );
+    expect(order.indexOf("fast_forward_branch")).toBeLessThan(
+      order.indexOf("checkout_branch"),
+    );
+  });
+
+  it("'use a different name' re-opens the prompt and takes the new name", async () => {
+    takenByStale();
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+
+    const done = checkoutRemoteAsLocalBranch("origin/feature");
+    await screen.findByTestId("dialog-input");
+    await acceptDialog("feature");
+    await choose("rename");
+
+    const input = await screen.findByTestId<HTMLInputElement>("dialog-input");
+    // Re-opened on what they typed, not on the original suggestion.
+    expect(input.value).toBe("feature");
+    await acceptDialog("feature-2");
+    await done;
+
+    expect(callsTo("create_branch")[0].args).toMatchObject({
+      name: "feature-2",
+      from: "origin/feature",
+    });
+  });
+});

--- a/src/features/branches/checkoutRemote.test.ts
+++ b/src/features/branches/checkoutRemote.test.ts
@@ -18,12 +18,17 @@ import { describe, it, expect } from "vitest";
 import { existingBranchPrompt, withoutRemotePrefix } from "./checkoutRemote";
 
 const ids = (p: { choices: { id: string }[] }) => p.choices.map((c) => c.id);
+const labels = (p: { choices: { label: string }[] }) => p.choices.map((c) => c.label);
 const rel = (over: Partial<{ ahead: number; behind: number; unrelated: boolean }> = {}) => ({
   ahead: 0,
   behind: 0,
   unrelated: false,
   ...over,
 });
+/** An existing branch the user is NOT standing on, tracking `upstream`. */
+const on = (upstream: string | null) => ({ upstream, isHead: false });
+/** ...and one they ARE standing on. */
+const here = (upstream: string | null) => ({ upstream, isHead: true });
 
 describe("withoutRemotePrefix", () => {
   it("strips only the FIRST segment, so a slashed branch name survives", () => {
@@ -38,7 +43,7 @@ describe("withoutRemotePrefix", () => {
 
 describe("existingBranchPrompt", () => {
   it("offers the update when the branch is strictly behind and tracks nothing", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 3 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel({ behind: 3 }));
     expect(ids(p)).toEqual(["update", "checkout", "rename"]);
     expect(p.choices[0].label).toBe("Check out and update to origin/feat");
     expect(p.choices[0].primary).toBe(true);
@@ -47,7 +52,7 @@ describe("existingBranchPrompt", () => {
   });
 
   it("offers the update when it already tracks the very ref asked for", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", "origin/feat", rel({ behind: 1 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on("origin/feat"), rel({ behind: 1 }));
     expect(ids(p)).toContain("update");
     expect(p.body).toContain("It already tracks origin/feat.");
     // Singular, because "1 commits behind" is how a dialog loses trust.
@@ -57,26 +62,26 @@ describe("existingBranchPrompt", () => {
   it("withholds the update from a branch tracking a DIFFERENT ref", () => {
     // Fast-forwarding follows `branch.<name>.merge`, so this would advance the
     // branch along `upstream/feat` — a ref the dialog never mentioned.
-    const p = existingBranchPrompt("feat", "origin/feat", "upstream/feat", rel({ behind: 3 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on("upstream/feat"), rel({ behind: 3 }));
     expect(ids(p)).toEqual(["checkout", "rename"]);
     expect(p.choices[0].primary).toBe(true);
     expect(p.body).toContain("It tracks upstream/feat.");
   });
 
   it("withholds the update from a branch with commits of its own", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ ahead: 2, behind: 3 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel({ ahead: 2, behind: 3 }));
     expect(ids(p)).toEqual(["checkout", "rename"]);
     expect(p.body).toContain("feat has 2 commits origin/feat does not, and is 3 behind it.");
   });
 
   it("withholds the update from a branch that is only ahead", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ ahead: 2 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel({ ahead: 2 }));
     expect(ids(p)).toEqual(["checkout", "rename"]);
     expect(p.body).toContain("feat is 2 commits ahead of origin/feat.");
   });
 
   it("withholds the update when there is nothing to update to", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel());
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel());
     expect(ids(p)).toEqual(["checkout", "rename"]);
     expect(p.body).toContain("feat is already at origin/feat.");
   });
@@ -84,21 +89,52 @@ describe("existingBranchPrompt", () => {
   it("withholds the update for unrelated histories", () => {
     // `behind` is meaningless across unrelated histories — a ref move there is
     // not a fast-forward by any definition.
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 9, unrelated: true }));
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel({ behind: 9, unrelated: true }));
     expect(ids(p)).toEqual(["checkout", "rename"]);
     expect(p.body).toContain("feat shares no history with origin/feat.");
   });
 
   it("always offers a way out that is neither branch", () => {
     for (const r of [rel({ behind: 3 }), rel({ ahead: 1 }), rel({ unrelated: true })]) {
-      const p = existingBranchPrompt("feat", "origin/feat", null, r);
+      const p = existingBranchPrompt("feat", "origin/feat", on(null), r);
       expect(ids(p)).toContain("rename");
     }
   });
 
   it("names the collision in the body — the sentence the flow used to not say", () => {
-    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 3 }));
+    const p = existingBranchPrompt("feat", "origin/feat", on(null), rel({ behind: 3 }));
     expect(p.body).toContain("A local branch named feat already exists.");
     expect(p.title).toBe("Check out the existing feat?");
+  });
+});
+
+// You are on `feat`, someone pushes, you right-click `origin/feat`. Offering to
+// "check out feat" there says nothing true — the useful action on a branch you
+// are already standing on is to make it track the remote, or to catch it up.
+describe("the collision is the branch you are standing on", () => {
+  it("never says 'check out' about the branch already under HEAD", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", here(null), rel({ behind: 3 }));
+    expect(p.title).toBe("Stay on feat?");
+    expect(p.body).toContain("You are on it.");
+    expect(labels(p).some((l) => l.startsWith("Check out"))).toBe(false);
+  });
+
+  it("offers the tracking it is missing, which is what was asked for", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", here(null), rel());
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(labels(p)[0]).toBe("Track origin/feat");
+  });
+
+  it("offers to catch it up rather than to check it out", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", here("origin/feat"), rel({ behind: 2 }));
+    expect(ids(p)).toEqual(["update", "checkout", "rename"]);
+    expect(labels(p)[0]).toBe("Update feat to origin/feat");
+    // Nothing to change about a branch already tracking the right ref.
+    expect(labels(p)[1]).toBe("Stay on feat");
+  });
+
+  it("still withholds the update from a branch with commits of its own", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", here(null), rel({ ahead: 1, behind: 2 }));
+    expect(ids(p)).toEqual(["checkout", "rename"]);
   });
 });

--- a/src/features/branches/checkoutRemote.test.ts
+++ b/src/features/branches/checkoutRemote.test.ts
@@ -1,0 +1,104 @@
+// What "check out origin/x as a local branch" SAYS when the name is taken.
+//
+// The flow's pure half. The bug this exists for was silence: the create failed
+// with "branch already exists", the checkout that unconditionally followed it
+// succeeded on the stale same-named branch, and its refresh wiped the banner on
+// the way past — so the user landed on a branch that had never seen the remote
+// with nothing on screen to say so.
+//
+// The traps pinned here:
+//   - the update offer must NOT appear for a branch with commits of its own
+//     (it cannot be fast-forwarded) or one tracking a DIFFERENT remote ref
+//     (it would be advanced along a ref this dialog never named);
+//   - `ahead`/`behind` read FROM the remote ref TOWARD the local branch, and
+//     reversing that pair inverts every sentence silently.
+
+import { describe, it, expect } from "vitest";
+
+import { existingBranchPrompt, withoutRemotePrefix } from "./checkoutRemote";
+
+const ids = (p: { choices: { id: string }[] }) => p.choices.map((c) => c.id);
+const rel = (over: Partial<{ ahead: number; behind: number; unrelated: boolean }> = {}) => ({
+  ahead: 0,
+  behind: 0,
+  unrelated: false,
+  ...over,
+});
+
+describe("withoutRemotePrefix", () => {
+  it("strips only the FIRST segment, so a slashed branch name survives", () => {
+    expect(withoutRemotePrefix("origin/feat/x")).toBe("feat/x");
+    expect(withoutRemotePrefix("origin/main")).toBe("main");
+  });
+
+  it("leaves a name with no prefix alone", () => {
+    expect(withoutRemotePrefix("main")).toBe("main");
+  });
+});
+
+describe("existingBranchPrompt", () => {
+  it("offers the update when the branch is strictly behind and tracks nothing", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 3 }));
+    expect(ids(p)).toEqual(["update", "checkout", "rename"]);
+    expect(p.choices[0].label).toBe("Check out and update to origin/feat");
+    expect(p.choices[0].primary).toBe(true);
+    expect(p.body).toContain("feat is 3 commits behind origin/feat.");
+    expect(p.body).toContain("It tracks nothing.");
+  });
+
+  it("offers the update when it already tracks the very ref asked for", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", "origin/feat", rel({ behind: 1 }));
+    expect(ids(p)).toContain("update");
+    expect(p.body).toContain("It already tracks origin/feat.");
+    // Singular, because "1 commits behind" is how a dialog loses trust.
+    expect(p.body).toContain("is 1 commit behind");
+  });
+
+  it("withholds the update from a branch tracking a DIFFERENT ref", () => {
+    // Fast-forwarding follows `branch.<name>.merge`, so this would advance the
+    // branch along `upstream/feat` — a ref the dialog never mentioned.
+    const p = existingBranchPrompt("feat", "origin/feat", "upstream/feat", rel({ behind: 3 }));
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(p.choices[0].primary).toBe(true);
+    expect(p.body).toContain("It tracks upstream/feat.");
+  });
+
+  it("withholds the update from a branch with commits of its own", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ ahead: 2, behind: 3 }));
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(p.body).toContain("feat has 2 commits origin/feat does not, and is 3 behind it.");
+  });
+
+  it("withholds the update from a branch that is only ahead", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ ahead: 2 }));
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(p.body).toContain("feat is 2 commits ahead of origin/feat.");
+  });
+
+  it("withholds the update when there is nothing to update to", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel());
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(p.body).toContain("feat is already at origin/feat.");
+  });
+
+  it("withholds the update for unrelated histories", () => {
+    // `behind` is meaningless across unrelated histories — a ref move there is
+    // not a fast-forward by any definition.
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 9, unrelated: true }));
+    expect(ids(p)).toEqual(["checkout", "rename"]);
+    expect(p.body).toContain("feat shares no history with origin/feat.");
+  });
+
+  it("always offers a way out that is neither branch", () => {
+    for (const r of [rel({ behind: 3 }), rel({ ahead: 1 }), rel({ unrelated: true })]) {
+      const p = existingBranchPrompt("feat", "origin/feat", null, r);
+      expect(ids(p)).toContain("rename");
+    }
+  });
+
+  it("names the collision in the body — the sentence the flow used to not say", () => {
+    const p = existingBranchPrompt("feat", "origin/feat", null, rel({ behind: 3 }));
+    expect(p.body).toContain("A local branch named feat already exists.");
+    expect(p.title).toBe("Check out the existing feat?");
+  });
+});

--- a/src/features/branches/checkoutRemote.ts
+++ b/src/features/branches/checkoutRemote.ts
@@ -164,10 +164,11 @@ async function useExistingBranch(
     await useRepoStore.getState().setUpstream(local, remote);
     if (useRepoStore.getState().error) return;
   }
-  // Advance the ref BEFORE it becomes HEAD. A fast-forward of the checked-out
-  // branch needs a working-tree update, which is `pull`'s job and the user's
-  // own pull mode — `fastForwardBranch` reroutes it there, which is not what
-  // was offered here.
+  // Advance the ref BEFORE anything stands on it — for a branch that is not
+  // HEAD this is a pure ref move. For the one you ARE on, `fastForwardBranch`
+  // reroutes to `pull` under the user's own pull mode, which is the only
+  // correct way to advance a checked-out branch: its index and worktree have
+  // to move too.
   if (update) {
     await useRepoStore.getState().fastForwardBranch(local);
     if (useRepoStore.getState().error) return;

--- a/src/features/branches/checkoutRemote.ts
+++ b/src/features/branches/checkoutRemote.ts
@@ -1,0 +1,216 @@
+import { pgChoose, pgPrompt, type PGChooseOption } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { aheadBehind } from "@/lib/tauri";
+import type { BranchInfo } from "@/lib/types";
+
+/** `origin/feat/x` → `feat/x`. The remote prefix is the FIRST segment only. */
+export function withoutRemotePrefix(name: string): string {
+  const i = name.indexOf("/");
+  return i >= 0 ? name.slice(i + 1) : name;
+}
+
+/**
+ * How an existing local branch stands against the remote ref that was asked
+ * for — NOT against its own upstream, which in the case this exists for is
+ * typically nothing at all.
+ */
+export interface RemoteRelation {
+  /** Commits the local branch has that the remote ref does not. */
+  ahead: number;
+  /** The mirror: commits on the remote ref that the local branch lacks. */
+  behind: number;
+  /** Unrelated histories — or the comparison could not be made at all. */
+  unrelated: boolean;
+}
+
+/** What `pgChoose` is asked when the name is already taken. */
+export interface ExistingBranchPrompt {
+  title: string;
+  body: string;
+  choices: PGChooseOption[];
+}
+
+const plural = (n: number) => (n === 1 ? "commit" : "commits");
+
+/** One sentence for where the local branch sits relative to the remote ref. */
+function relationSentence(
+  local: string,
+  remote: string,
+  rel: RemoteRelation,
+): string {
+  if (rel.unrelated) return `${local} shares no history with ${remote}.`;
+  if (rel.ahead === 0 && rel.behind === 0)
+    return `${local} is already at ${remote}.`;
+  if (rel.ahead === 0)
+    return `${local} is ${rel.behind} ${plural(rel.behind)} behind ${remote}.`;
+  if (rel.behind === 0)
+    return `${local} is ${rel.ahead} ${plural(rel.ahead)} ahead of ${remote}.`;
+  return `${local} has ${rel.ahead} ${plural(rel.ahead)} ${remote} does not, and is ${rel.behind} behind it.`;
+}
+
+/** One sentence for what the local branch currently tracks. */
+function trackingSentence(remote: string, upstream: string | null): string {
+  if (upstream === remote) return `It already tracks ${remote}.`;
+  if (upstream) return `It tracks ${upstream}.`;
+  return "It tracks nothing.";
+}
+
+/**
+ * The dialog for "you asked for `origin/x`, but a local `x` already exists".
+ *
+ * PURE, so what the user is told — and which answers they are offered — is
+ * testable without a repository. The flow below only renders it.
+ *
+ * The update offer is deliberately narrow. It appears only when the existing
+ * branch is STRICTLY behind and the ref it would be advanced along is the one
+ * the user named: fast-forwarding a branch that tracks something ELSE would
+ * move it along a ref this dialog never mentioned, and a branch with commits
+ * of its own cannot be fast-forwarded at all. Everything else gets the plain
+ * checkout and keeps its commits.
+ */
+export function existingBranchPrompt(
+  local: string,
+  remote: string,
+  upstream: string | null,
+  rel: RemoteRelation,
+): ExistingBranchPrompt {
+  const canUpdate =
+    !rel.unrelated &&
+    rel.behind > 0 &&
+    rel.ahead === 0 &&
+    (upstream === null || upstream === remote);
+
+  const choices: PGChooseOption[] = [];
+  if (canUpdate)
+    choices.push({
+      id: "update",
+      label: `Check out and update to ${remote}`,
+      primary: true,
+    });
+  choices.push({
+    id: "checkout",
+    label: canUpdate ? `Check out ${local} as it is` : `Check out ${local}`,
+    primary: !canUpdate,
+  });
+  choices.push({ id: "rename", label: "Use a different name…" });
+
+  return {
+    title: `Check out the existing ${local}?`,
+    body: `A local branch named ${local} already exists. ${relationSentence(
+      local,
+      remote,
+      rel,
+    )} ${trackingSentence(remote, upstream)}`,
+    choices,
+  };
+}
+
+/**
+ * Where the local branch sits relative to the remote ref.
+ *
+ * Advisory: a failure degrades to "we cannot say" rather than blocking the
+ * checkout the user asked for. `unrelated` then drops the update offer, which
+ * is the conservative half of the dialog anyway.
+ */
+async function relationTo(
+  repoId: string,
+  remote: string,
+  local: string,
+): Promise<RemoteRelation> {
+  try {
+    // `aheadBehind(a, b)` reads FROM a TOWARD b, so with the remote ref as `a`
+    // `ahead` is what the LOCAL branch has on its own. Reversing this pair
+    // inverts the whole dialog silently.
+    const ab = await aheadBehind(repoId, remote, local);
+    return { ahead: ab.ahead, behind: ab.behind, unrelated: ab.mergeBase === null };
+  } catch {
+    return { ahead: 0, behind: 0, unrelated: true };
+  }
+}
+
+/** Act on the existing branch the user chose to keep. */
+async function useExistingBranch(
+  local: string,
+  remote: string,
+  existing: BranchInfo,
+  update: boolean,
+): Promise<void> {
+  // The missing upstream IS what the user came here for: they asked for
+  // `remote`, and a branch tracking nothing shows no ahead/behind and has
+  // nothing to pull. One that already tracks something else is left alone —
+  // re-pointing it is a different decision, and not the one this dialog asked.
+  if (!existing.upstream) {
+    await useRepoStore.getState().setUpstream(local, remote);
+    if (useRepoStore.getState().error) return;
+  }
+  // Advance the ref BEFORE it becomes HEAD. A fast-forward of the checked-out
+  // branch needs a working-tree update, which is `pull`'s job and the user's
+  // own pull mode — `fastForwardBranch` reroutes it there, which is not what
+  // was offered here.
+  if (update) {
+    await useRepoStore.getState().fastForwardBranch(local);
+    if (useRepoStore.getState().error) return;
+  }
+  await useRepoStore.getState().checkoutBranch(local);
+}
+
+/**
+ * Check a remote-tracking ref out as a local branch that TRACKS it.
+ *
+ * ONE definition, shared by the remote-branch menu, the commit menu's remote
+ * entry (#179) and the Branches detail pane: a bare `checkoutRef("origin/foo")`
+ * would silently DETACH, which is the whole reason this flow exists, so a
+ * second copy is how one of those call sites would come to detach.
+ *
+ * The create and the checkout are ONE store action (`createAndSwitchBranch`),
+ * because as two they were not atomic in the way that matters. The store's
+ * `createBranch` reports failure by setting the banner, and the checkout that
+ * used to follow it unconditionally then SUCCEEDED — on whatever unrelated
+ * local branch already had that name — and cleared the banner on its way past.
+ * The user asked for `origin/x` and silently landed on a stale `x` that had
+ * never seen the remote, with nothing on screen to say so. That collision is
+ * now the question below rather than an accident.
+ *
+ * Tracking itself is set by the BACKEND (`create_branch` off a remote-tracking
+ * start point), so every other way of branching off `origin/x` gets it too.
+ */
+export async function checkoutRemoteAsLocalBranch(remote: string): Promise<void> {
+  if (!remote) return;
+  let suggested = withoutRemotePrefix(remote);
+  // Loops only on "use a different name"; every other answer returns.
+  for (;;) {
+    const local = await pgPrompt({
+      title: "Check out as new local branch",
+      body: `Tracking ${remote}.`,
+      initialValue: suggested,
+      confirmLabel: "Check out",
+      requireValue: true,
+      mono: true,
+    });
+    if (!local) return;
+
+    const store = useRepoStore.getState();
+    const existing = store.branches.find((b) => !b.isRemote && b.name === local);
+    if (!existing) {
+      await store.createAndSwitchBranch(local, { from: remote });
+      return;
+    }
+
+    const repoId = store.current?.id;
+    const rel = repoId
+      ? await relationTo(repoId, remote, local)
+      : { ahead: 0, behind: 0, unrelated: true };
+    const answer = await pgChoose(
+      existingBranchPrompt(local, remote, existing.upstream, rel),
+    );
+    if (answer === "rename") {
+      // Re-open on what they typed, not on the original suggestion — the name
+      // they chose is usually a prefix of the one they want.
+      suggested = local;
+      continue;
+    }
+    if (answer === null) return;
+    await useExistingBranch(local, remote, existing, answer === "update");
+    return;
+  }
+}

--- a/src/features/branches/checkoutRemote.ts
+++ b/src/features/branches/checkoutRemote.ts
@@ -55,6 +55,12 @@ function trackingSentence(remote: string, upstream: string | null): string {
   return "It tracks nothing.";
 }
 
+/** The half of the existing branch this dialog reads. */
+export interface ExistingBranch {
+  upstream: string | null;
+  isHead: boolean;
+}
+
 /**
  * The dialog for "you asked for `origin/x`, but a local `x` already exists".
  *
@@ -67,13 +73,19 @@ function trackingSentence(remote: string, upstream: string | null): string {
  * move it along a ref this dialog never mentioned, and a branch with commits
  * of its own cannot be fast-forwarded at all. Everything else gets the plain
  * checkout and keeps its commits.
+ *
+ * The collision can be the branch you are STANDING ON — you are on `feat`,
+ * someone pushes, you right-click `origin/feat`. Offering to "check out feat"
+ * there says nothing true, so the wording changes: the useful action on a
+ * branch you are already on is to make it track the remote, or to catch it up.
  */
 export function existingBranchPrompt(
   local: string,
   remote: string,
-  upstream: string | null,
+  existing: ExistingBranch,
   rel: RemoteRelation,
 ): ExistingBranchPrompt {
+  const { upstream, isHead } = existing;
   const canUpdate =
     !rel.unrelated &&
     rel.behind > 0 &&
@@ -84,19 +96,28 @@ export function existingBranchPrompt(
   if (canUpdate)
     choices.push({
       id: "update",
-      label: `Check out and update to ${remote}`,
+      label: isHead
+        ? `Update ${local} to ${remote}`
+        : `Check out and update to ${remote}`,
       primary: true,
     });
   choices.push({
     id: "checkout",
-    label: canUpdate ? `Check out ${local} as it is` : `Check out ${local}`,
+    label: isHead
+      ? upstream === null
+        ? `Track ${remote}`
+        : `Stay on ${local}`
+      : canUpdate
+        ? `Check out ${local} as it is`
+        : `Check out ${local}`,
     primary: !canUpdate,
   });
   choices.push({ id: "rename", label: "Use a different name…" });
 
+  const where = isHead ? " You are on it." : "";
   return {
-    title: `Check out the existing ${local}?`,
-    body: `A local branch named ${local} already exists. ${relationSentence(
+    title: isHead ? `Stay on ${local}?` : `Check out the existing ${local}?`,
+    body: `A local branch named ${local} already exists.${where} ${relationSentence(
       local,
       remote,
       rel,
@@ -151,6 +172,9 @@ async function useExistingBranch(
     await useRepoStore.getState().fastForwardBranch(local);
     if (useRepoStore.getState().error) return;
   }
+  // Already standing on it: `checkoutBranch` would be a no-op that still spends
+  // a stash → checkout → pop cycle on the user's working tree.
+  if (existing.isHead) return;
   await useRepoStore.getState().checkoutBranch(local);
 }
 
@@ -201,7 +225,7 @@ export async function checkoutRemoteAsLocalBranch(remote: string): Promise<void>
       ? await relationTo(repoId, remote, local)
       : { ahead: 0, behind: 0, unrelated: true };
     const answer = await pgChoose(
-      existingBranchPrompt(local, remote, existing.upstream, rel),
+      existingBranchPrompt(local, remote, existing, rel),
     );
     if (answer === "rename") {
       // Re-open on what they typed, not on the original suggestion — the name

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -1706,9 +1706,13 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await createBranch(repo.id, name, opts?.from);
     } catch (e) {
-      setErrorFor(repo.id, e);
       setActivity(repo.id, "branch", null);
+      // Refresh first, error last — refreshAll clears `error` as its first act,
+      // so the other order loses the banner (see mergeBranch). This arm is the
+      // ONLY thing a caller can see when a name is already taken, and it used
+      // to wipe itself.
       await get().refreshAll();
+      setErrorFor(repo.id, e);
       return false;
     }
     setActivity(repo.id, "branch", null);

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/design";
 import { useElementSize } from "@/lib/useElementSize";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { checkoutRemoteAsLocalBranch } from "@/features/branches/checkoutRemote";
 import { orderBranches } from "@/features/branches/orderBranches";
 import {
   branchFolderPaths,
@@ -482,9 +483,11 @@ export function BranchesScreen() {
       }
       if (r?.kind !== "branch") return;
       const b = branches.find((x) => x.name === r.name);
-      if (b && !b.isHead && !b.isRemote) {
-        void useRepoStore.getState().checkoutBranch(b.name);
-      }
+      if (!b || b.isHead) return;
+      // Enter on a remote row used to do NOTHING — the row the user most often
+      // wants to act on was the one row with no keyboard answer.
+      if (b.isRemote) void checkoutRemoteAsLocalBranch(b.name);
+      else void useRepoStore.getState().checkoutBranch(b.name);
     },
     onExpand: (i) => {
       const r = flatRefs[i];
@@ -1373,9 +1376,17 @@ function BranchActions({ branch }: { branch: BranchInfo }) {
         variant="primary"
         icon="check"
         disabled={branch.isHead}
-        onClick={() => useRepoStore.getState().checkoutBranch(branch.name)}
+        // A remote-tracking ref is not a local branch: `checkoutBranch` looks
+        // under `refs/heads/`, so this button used to answer `origin/x` with
+        // InvalidRef. It goes through the same create-a-tracking-branch flow
+        // the context menu uses — the one checkout path for a remote ref.
+        onClick={() =>
+          branch.isRemote
+            ? void checkoutRemoteAsLocalBranch(branch.name)
+            : void useRepoStore.getState().checkoutBranch(branch.name)
+        }
       >
-        Check out
+        {branch.isRemote ? "Check out as local branch…" : "Check out"}
       </PGButton>
       <PGButton
         variant="outline"


### PR DESCRIPTION
Checking out `origin/x` as a new local branch produced a branch that tracked **nothing**, and when the name was already taken it silently checked out the stale same-named branch instead. Reported from use: *"i had no commits from the origin and were unable to check out the origin one since i had one with the same name which did not track that branch."*

## The two root causes

**1. `create_branch` set up no tracking at all.** It called `repo.branch(…)` and stopped, so the prompt that says *Tracking origin/x* was making a promise nothing kept. The branch had no upstream: no ahead/behind, no pull, no fast-forward, and nothing to say it had fallen behind.

**2. A taken name fell through silently.** `checkoutRemoteAsLocalBranch` called the store's `createBranch` (which reports failure by setting the banner and *returning*) and then called `checkoutBranch` unconditionally. That second call **succeeded** — on whatever unrelated local branch already held the name — and its own `refreshAll()` cleared the banner on the way past. The user asked for `origin/x` and landed on a stale `x` with nothing on screen to say so.

Two adjacent surfaces in the same story were broken too: the Branches detail pane's **Check out** button answered a remote ref with `InvalidRef` (`checkoutBranch` looks under `refs/heads/`), and <kbd>Enter</kbd> on a remote row did nothing at all.

## What changed

**Backend** — `create_branch` sets the upstream when the start point resolves to a remote-tracking branch, and only then. This is git's `branch.autoSetupMerge` default, measured against real git rather than assumed: `git branch x origin/main` prints *"set up to track 'origin/main'"*, while `git branch x main` and `git branch x <oid>` set up nothing. Doing it in the backend means every path that branches off `origin/x` gets tracking, not just this one flow.

- The question is whether the revspec **resolves** to a ref under `refs/remotes/` — answered by resolving it, not by looking for a slash. A local branch may itself be called `origin/main`, and `refs/remotes/origin/main` is the spelling a ref picker hands over.
- `origin/HEAD` is symbolic and yields what it points at (`origin/main`), again matching git. The literal name is never written — `branch.<name>.merge = refs/heads/HEAD` matches no fetch refspec that has ever existed.
- A failed `set_upstream` un-creates the branch rather than shipping the half, the same rule as the signing chain.

**Frontend** — the flow moves to `features/branches/checkoutRemote.ts`, because two of its four surfaces could not reach it inside `design/context-menu.tsx`. The create and the checkout are now one store action (`createAndSwitchBranch`), so a failed create aborts instead of falling through. A taken name is now a question:

> **Check out the existing feat?**
> A local branch named feat already exists. feat is 3 commits behind origin/feat. It tracks nothing.
> `Check out and update to origin/feat` · `Check out feat as it is` · `Use a different name…`

- The **update** offer is deliberately narrow: only when the branch is strictly behind *and* the ref it would advance along is the one the user named. A branch tracking something else would move along a ref the dialog never mentioned; a branch with commits of its own cannot be fast-forwarded at all.
- The ref moves **before** the branch becomes HEAD — a fast-forward of the checked-out branch needs a working-tree update, which is `pull`'s job under the user's own pull mode.
- A branch tracking **nothing** is given the upstream (that is what the user came for); one tracking something else is left alone, because re-pointing it is a different decision.
- `createAndSwitchBranch`'s catch arm now refreshes first and sets the error last — the house order. It had them reversed, so the one thing a caller could see when a name was taken wiped itself.

## Verification

Both halves were proved by planting the old behaviour and watching the new tests go red, then restoring:

- backend plant (drop the `set_upstream` call) → **3 of the 5 new Rust tests fail**, the negative ones still passing;
- frontend plant (restore the two-call sequence) → **6 of the 9 new flow tests fail**, including *"asks instead of checking the stale branch out behind the user's back"*.

Green after restore: `cargo test` all suites, `vitest` 401 files / 4068 tests, `tsc --noEmit` for `src/` and `e2e/`. Docs updated in `docs/dev/backend.md`, `docs/dev/frontend.md` and the `architecture.md` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
