### PR TITLE
fix(settings): stop the theme editor's colour section sidescrolling

### DIFF
--- a/src/features/settings/theme/ColorEditor.tsx
+++ b/src/features/settings/theme/ColorEditor.tsx
@@ -36,7 +36,10 @@ export function ColorEditor({
   ];
 
   return (
-    <div style={{ padding: "14px 16px 18px" }}>
+    // No horizontal padding: this sits directly in the editor's scrolling
+    // column, so side padding here would inset the rows from the Palette card
+    // above them — and it was what the caller's `0 -16px` bleed was cancelling.
+    <div style={{ padding: "14px 0 18px" }}>
       {groups.map((g) => (
         <div key={g.group} style={{ marginTop: g.group === "background" ? 0 : 16 }}>
           <div
@@ -58,7 +61,12 @@ export function ColorEditor({
               // 190px, not 240: the editor's left column is ~410px, so a 240px
               // minimum fitted exactly ONE field per row and made the list
               // twice as long to scroll as it needs to be.
-              gridTemplateColumns: "repeat(auto-fill, minmax(190px, 1fr))",
+              //
+              // `min(190px, 100%)`, not a bare `190px`: an auto-fill track keeps
+              // its floor even when the container is narrower than it, so the
+              // bare version sidescrolls the whole section once the column
+              // drops under 190px (measured: 38px of overflow at 180px).
+              gridTemplateColumns: "repeat(auto-fill, minmax(min(190px, 100%), 1fr))",
               gap: 8,
             }}
           >

--- a/src/features/settings/theme/ThemeEditorDialog.test.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.test.tsx
@@ -164,6 +164,46 @@ describe("ThemeEditorDialog", () => {
     expect(screen.getByLabelText(/^logo · bill$/i)).toBeInTheDocument();
   });
 
+  it("lets nothing bleed sideways out of the scrolling controls column", () => {
+    ed().openNew(dark);
+    const { container } = mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+
+    // The controls column is `overflow: auto`, so a negative horizontal margin
+    // on an in-flow child makes the block wider than its own scroll port and
+    // the colour section grows a horizontal scrollbar — which is exactly what
+    // `margin: 0 -16px` around the ColorEditor did. jsdom has no layout, so the
+    // mechanism is what gets pinned, not the measurement.
+    //
+    // Positioned elements are exempt: the Tint slider centres its thumb on the
+    // track with `marginLeft: -6` under a `position: relative` parent, which
+    // widens nothing.
+    const bleeding = [...container.querySelectorAll<HTMLElement>("*")]
+      .filter((el) => !["absolute", "fixed"].includes(el.style.position))
+      .filter(
+        (el) =>
+          parseFloat(el.style.marginLeft || "0") < 0 ||
+          parseFloat(el.style.marginRight || "0") < 0,
+      )
+      .map((el) => `${el.tagName}: ${el.style.marginLeft} / ${el.style.marginRight}`);
+    expect(bleeding).toEqual([]);
+  });
+
+  it("never floors a colour column wider than the column holding it", () => {
+    ed().openNew(dark);
+    mount();
+    fireEvent.click(screen.getByRole("button", { name: /all colours/i }));
+
+    // An auto-fill track keeps its floor even when the container is narrower
+    // than it, so a bare `minmax(190px, 1fr)` sidescrolls the section once the
+    // editor's column drops under 190px. `min(190px, 100%)` is what stops it.
+    const grid = screen
+      .getByLabelText(/^background · base$/i)
+      .closest("div[style*='grid-template-columns']") as HTMLElement | null;
+    expect(grid).not.toBeNull();
+    expect(grid!.style.gridTemplateColumns).toContain("min(190px, 100%)");
+  });
+
   it("applies the guided start from a base theme", () => {
     ed().openNew(dark);
     mount();

--- a/src/features/settings/theme/ThemeEditorDialog.tsx
+++ b/src/features/settings/theme/ThemeEditorDialog.tsx
@@ -348,18 +348,22 @@ export function ThemeEditorDialog() {
             </button>
 
             {showAll && (
-              <div style={{ margin: "0 -16px" }}>
-                <ColorEditor
-                  colors={ed.colors}
-                  onPatch={ed.patchColors}
-                  badgeFor={(key) => {
-                    const pair = CONTRAST_PAIRS.find((p) => p.a === key);
-                    return pair ? (
-                      <RatioBadge a={pair.a} b={pair.b} colors={ed.colors} />
-                    ) : null;
-                  }}
-                />
-              </div>
+              // No negative margin here. A bleed out to the modal's own padding
+              // reads as full-width, but this is not a child of the modal — it
+              // is a child of a scrolling COLUMN, so `0 -16px` made the block
+              // 32px wider than its scroll port and the colour section grew a
+              // horizontal scrollbar (measured: scrollWidth 440 / clientWidth
+              // 424). The rows line up with the Palette card instead.
+              <ColorEditor
+                colors={ed.colors}
+                onPatch={ed.patchColors}
+                badgeFor={(key) => {
+                  const pair = CONTRAST_PAIRS.find((p) => p.a === key);
+                  return pair ? (
+                    <RatioBadge a={pair.a} b={pair.b} colors={ed.colors} />
+                  ) : null;
+                }}
+              />
             )}
           </div>
 


### PR DESCRIPTION
The theme editor's colour section had a horizontal scrollbar. Two causes, both fixed.

**The bleed margin.** The "All colours (18)" block was wrapped in `margin: 0 -16px`, a bleed out to the modal's own padding. But it is not a child of the modal — it is a child of the controls *column*, which is `overflow: auto`. A stretched flex child with -16px on each side is 32px wider than its scroll port, so the section scrolled sideways. The bleed is gone, and `ColorEditor`'s horizontal padding with it, so the colour rows now line up with the Palette card above them instead of sitting inset from it.

**The grid floor.** `minmax(190px, 1fr)` under `auto-fill` keeps its floor even when the container is narrower than the track, which sidescrolls the section once the column drops under 190px. Now `minmax(min(190px, 100%), 1fr)`.

### Measured

jsdom has no layout, so this was verified in a real browser — a scratch page rendering the real `ColorEditor` inside a replica of the controls column, reading `scrollWidth - clientWidth`:

| column width | before | after |
| --- | --- | --- |
| 436px (wide window) | **16px** | 0px |
| 346px (at the 800px `minWidth`) | — | 0px |
| 180px | **38px** | 0px |

### Guards

Two tests in `ThemeEditorDialog.test.tsx`, pinning the mechanisms rather than the measurement:

- nothing in the dialog carries a negative horizontal margin in normal flow (positioned elements are exempt — the Tint slider centres its thumb with `marginLeft: -6` under a `position: relative` parent and widens nothing);
- the colour grid's track floor stays `min(190px, 100%)`.

Both were confirmed to go **red** against the planted original bug, then green once reverted.

Full suite green: 4115 tests, 402 files. `tsc --noEmit` clean. No e2e run — `settings.e2e.ts` reaches the theme editor only through `data-testid` attributes that are untouched, and never opens the "All colours" disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
