### PR TITLE
feat(settings): global Text size and Spacing presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,10 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   obvious version ships. (`docs/dev/frontend.md`)
 - **Design system lives in `src/design/`**, imported from `@/design`. Do NOT
   add `src/components/ui/`. Never hardcode the accent hue — CSS vars/theme
-  tokens only. New list-row surfaces opt into UI density (`var(--row-step)`).
-  (`docs/dev/frontend.md`)
+  tokens only. New list-row surfaces opt into BOTH UI scales —
+  `calc(<base>px * var(--row-scale) + var(--row-step))`, base multiplied and
+  step added — or `test/uiScale.test.ts` fails the build; JS geometry uses
+  `useRowH()`. (`docs/dev/frontend.md`)
 - **Icons are `lucide-react` behind `PGIcon`** — `src/design/icons.tsx` is the
   ONLY file that may import it, and `PGIcon`'s `strokeWidth` is on a 16-unit
   grid (scaled to lucide's 24), so changing that scale re-weights every icon at

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1529,12 +1529,13 @@ a result is the actual control, never a copy of it that could drift — see
   takes `gates: Record<SettingRowGate, boolean>` for this reason: widening
   `SettingRowGate` is a compile error until `useSettingsIndex` answers the new
   member, where a per-gate equality test would have made it silently "always".
-- **Both settings row helpers read `--row-step`, and they move together.**
-  `SettingsRow` and `ForgeSettings`' local `ForgeRow` are separate components
-  by design (one is a fixed setting with a `data-setting-id`, the other a row
-  over account data), but they sit in the same panel, so density has to reach
-  both or neither: giving it to one leaves a forge account row a different
-  height from the setting directly above it. They share ONE value —
+- **Both settings row helpers read `--row-step` AND `--row-scale`, and they
+  move together.** `SettingsRow` and `ForgeSettings`' local `ForgeRow` are
+  separate components by design (one is a fixed setting with a
+  `data-setting-id`, the other a row over account data), but they sit in the
+  same panel, so both UI scales have to reach both or neither: giving it to
+  one leaves a forge account row a different height from the setting directly
+  above it. They share ONE value —
   `SETTINGS_ROW_PADDING`, built by `densityPadding(12)` — because being equal
   is the requirement, and two copied literals cannot fail a test when only one
   is edited. Anything else in a card BODY takes the same step from
@@ -2192,15 +2193,32 @@ update checks back on for someone who turned them off.
   string inside a click-outside-to-close popover is gone by the second drag.
   The update panel's package-manager command shipped as a bare `<code>`: the
   notify path's only actionable content, unselectable and uncopyable.
-- **New list-row surfaces must opt into UI density** (issue #70):
-  `height: "calc(<base>px + var(--row-step))"` (or `/ 2` for padding-sized
-  rows); `--row-h` for plain 24px rows. `--row-step` is 0 in compact, so each
-  surface keeps its base. Chrome and code-line geometry (`--lh-code`) stay
-  fixed. `grep -rn 'var(--row-step)' src/` lists participants — but NOT the
-  Settings panel, whose surfaces take the step from one shared helper rather
-  than a literal, so add `-e densityPadding -e SETTINGS_ROW_PADDING` or they
-  read as non-participants. `PGGraphRow` draws in SVG units — `PGCommitRow`
-  feeds it `useDensityStep()`.
+- **New list-row surfaces must opt into BOTH UI scales — Spacing and Text
+  size** (issue #70; the row-geometry tables both live in
+  `features/settings/useSettingsStore.ts`):
+  `SPACING_STEP_PX` (compact 0 / cozy 2 / comfortable 4 / spacious 8,
+  default cozy) is written to `--row-step` by `applySpacing`; `TEXT_SCALE`
+  (small 0.92 / default 1 / large 1.15 / larger 1.3, default `"default"`) is
+  written to `--row-scale`, plus all ten `--fs-*` tokens as resolved px, by
+  `applyTextScale`. A row's call-site form is
+  `height: "calc(<base>px * var(--row-scale) + var(--row-step))"` (`/ 2` for
+  padding-sized rows, since top and bottom each take half); `--row-h` for
+  plain 24px rows. The base is MULTIPLIED and the step is ADDED — the step is
+  already the user's own number of pixels, while the base has to HOLD the
+  text, since every row surface sets `height`, not `min-height`, and a base
+  that does not grow with the type clips it. Compact + default renders
+  pixel-identically to the pre-scale layout. Chrome stays fixed regardless of
+  either scale — neither reaches the app frame. `--lh-code` itself (the code
+  line-height RATIO) is likewise unchanged by either; what does move is the
+  diff row pitch built from it, since that pitch multiplies the ratio by
+  `--fs-12` — see Diff row pitch below.
+  `grep -rn 'var(--row-step)' src/` (or `-e 'var(--row-scale)'`) lists
+  participants — but NOT the Settings panel, whose surfaces take both from
+  one shared helper rather than a literal, so add
+  `-e densityPadding -e SETTINGS_ROW_PADDING` or they read as
+  non-participants. `test/uiScale.test.ts` is the guard: a surface that takes
+  one var without the other, or that multiplies `--row-scale` more than once
+  (a doubled call site from sweeping an already-scaled line), fails the build.
   **"Chrome" means the app frame** — the tab strip, the operation bar — and a
   settings card's HEADER, which is the one named exemption inside a content
   pane. It does NOT mean "anything that is not a row": a band sitting between
@@ -2208,6 +2226,40 @@ update checks back on for someone who turned them off.
   content, and a fixed height there gives one card two row pitches. Settings
   surfaces take the step through `densityPadding()` / `SETTINGS_ROW_PADDING`
   rather than their own literal — see the Settings section.
+  **`useRowH(basePx)` is the JS twin of that `calc()`** — one owner for "a
+  row's height in px" rather than the expression re-derived at every windowed
+  list, because six copies is six chances for one to disagree (#70). It reads
+  `useSpacingStep()` (the active step as a number) and `useTextScale()` (the
+  active factor), multiplies the base by the factor and adds the step,
+  rounded to one decimal to match `applyTextScale`'s own ramp precision.
+  Three JS geometries build on it because CSS alone can't reach them:
+  - **Diff row pitch** — `useDiffRowHeight()` (`lib/useDiffRowHeight.ts`)
+    re-reads the CSS-computed `--diff-row-h` (`calc(var(--fs-12) *
+    var(--lh-code))`) whenever `useSpacingStep()`/`useTextScale()` change;
+    those two are only a re-read TRIGGER here, since the value itself is
+    computed in CSS, with `DIFF_ROW_H_FALLBACK` standing in wherever jsdom
+    (or any non-resolving engine) hands back garbage. Fold/gap rows in the
+    same views use `useRowH(22)` directly instead.
+  - **Commit-row columns** (`design/graph-geometry.ts`) — `shaColW`,
+    `colPad`, `subjectMinW`, `authorColW`, `authorMinW`, `dateColW` and
+    `commitListMinW` all take the TEXT scale only, never the spacing step:
+    they are column widths sized to hold text, not row heights. Each
+    defaults `scale = 1`, so a caller with no notion of the setting — tests
+    included — gets the pre-scale numbers unchanged; `commitRowGrid` threads
+    the same `scale` through to build the shared grid template.
+  - **The SVG graph gutter** (`PGGraphRow`, fed by `PGCommitRow`) — its
+    `height` prop must be `useRowH(COMMIT_ROW_BASE_H)` (both axes: it draws
+    lanes in SVG user units and cannot read a CSS var), but its `width`
+    (`graphWidth(maxCol)`) is NOT part of either scale — lane spacing
+    (`GRAPH_PAD`, `LANE_W`) is fixed regardless of text size, so the gutter
+    only widens when a repo's graph needs more lanes, never when type grows.
+  **The boundary against Zoom**: Text size moves TYPE — the `--fs-*` ramp,
+  the row bases that hold it, and the text-sized columns above. Zoom (the
+  existing "Zoom" row, same Appearance card) moves everything else, through
+  the webview's own zoom factor — icons, borders, gaps, the titlebar — and
+  answers "the whole app is too small on my display", not "the type is too
+  small". The two compose; a new setting that scales pixels picks one side
+  rather than reopening both.
 
 ## Design system
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -424,6 +424,14 @@ change here is not proven by `pnpm test`. It needs a real Docker e2e run.
 - **`test/nativeSelect.test.ts`** is a SOURCE invariant: no `<select>`/`<option>`
   in shipped `src/` (issue 146) — the failure is invisible on macOS/Windows.
   Comments stripped first; test files out of scope.
+- **`test/uiScale.test.ts`** copies that shape (source invariant, comments
+  stripped first, test files out of scope) for the OTHER row-geometry trap: a
+  row that opts into Spacing (`var(--row-step)`) without Text size
+  (`var(--row-scale)`), or the reverse, either way a row that grows roomier
+  under one preset but keeps clipping — or ignoring — the other. It is not
+  exhaustive: `densityPadding()` builds its calc from a template literal, so
+  its only safety net is the `-e densityPadding -e SETTINGS_ROW_PADDING` grep
+  addendum named in `index.css`'s row-geometry comment.
 - **`test/depOverrides.test.ts`** guards the `pnpm.overrides` security block
   (#346) against the one thing that routinely kills it: a Dependabot npm PR
   regenerates the lockfile, drops the whole block, and 20 advisories come back

--- a/docs/superpowers/plans/2026-09-11-ui-spacing-and-text-size.md
+++ b/docs/superpowers/plans/2026-09-11-ui-spacing-and-text-size.md
@@ -1299,7 +1299,7 @@ Expected: FAIL — `appearance.textSize` is not in the index.
 
 - [ ] **Step 3: Replace the meta row**
 
-`src/features/settings/pages/appearance.tsx:43` — replace the single `appearance.density` entry with two. Keep them adjacent and directly before `appearance.dateFormat` so the three size controls read as a group with `appearance.zoom`:
+`src/features/settings/pages/appearance.tsx:43` — replace the single `appearance.density` entry with two. Keep them adjacent and directly above `appearance.zoom` so the three size controls read as a group:
 
 ```ts
         { id: "appearance.textSize", label: "Text size", keywords: "font size text type bigger smaller larger readable accessibility scale" },

--- a/docs/superpowers/plans/2026-09-11-ui-spacing-and-text-size.md
+++ b/docs/superpowers/plans/2026-09-11-ui-spacing-and-text-size.md
@@ -1,0 +1,1508 @@
+# Global spacing + text size Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the binary `uiDensity` setting with two independent presets — **Spacing** (four row-step values) and **Text size** (four type-ramp scales) — so a user can loosen the layout, enlarge the type, or both, without touching the whole-UI Zoom.
+
+**Architecture:** Two persisted enums in `useSettingsStore`, each with a `TABLE → normalize → apply` trio that writes CSS custom properties on `:root`, exactly mirroring the existing `DENSITY_STEP_PX → normalizeDensity → applyDensity`. Spacing keeps writing `--row-step`; text writes the resolved `--fs-*` ramp plus a unitless `--row-scale` that the 26 existing row call sites multiply their base by. Three places restate this geometry in TypeScript (diff row pitch, commit-row column widths, SVG graph gutter) and are taught to read the scale.
+
+**Tech Stack:** React 19 + TypeScript, Zustand, vitest (projects `unit` jsdom / `docs` node), WebdriverIO e2e, Tauri 2 webview.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md`
+
+## Global Constraints
+
+- **Toolchain.** `~/Library/pnpm/pnpm` and `~/.cargo/bin/cargo` by absolute path — the Bash tool does not inherit the interactive shell rc, and in a worktree-isolated session the `export PATH=…` line from `CLAUDE.md` is refused.
+- **Work only in this worktree**, `.claude/worktrees/ui-scale`, branch `feat/ui-scale`. Never commit to `main`.
+- **No native `<select>`/`<option>`** in shipped `src/` — a guard test fails the build. Appearance uses `PGButtonGroup` for every small enum; both new controls follow it.
+- **Settings is a registry.** A new setting MUST join its page's `meta.cards[].rows` or `settings.index.test.tsx` fails the build. A word that lives only in a `hint` is NOT indexed — it goes in `keywords`.
+- **Never hardcode a pixel the tables own.** `SPACING_STEP_PX` and `TEXT_SCALE` are the source of truth; CSS declares only pre-hydration defaults, and hints read the tables rather than spelling numbers.
+- **Commit style:** `feat(scope): …` / `fix(scope): …` / `test: …` / `docs: …`, imperative subject under 72 chars, `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` as the last line. Write every message as public prose — the squash quotes all of them into the body.
+- **Backticks in a `git commit -m` body hang the Bash tool** (the command is eval'd, so `` `x` `` runs `x` and blocks on stdin). Use `-m` with no backticks, or `-F <file>`.
+- **Run the unit suite with** `~/Library/pnpm/pnpm vitest run --project unit <path>` and the guard suite with `--project docs`. Type-check with `~/Library/pnpm/pnpm tsc --noEmit`.
+- **E2E only at the end, only in Docker**, and only the one spec this change touches.
+
+### The two tables, verbatim — every task refers to these
+
+```ts
+export const SPACING_STEP_PX = {
+  compact: 0,
+  cozy: 2,
+  comfortable: 4,
+  spacious: 8,
+} as const;
+
+export const TEXT_SCALE = {
+  small: 0.92,
+  default: 1,
+  large: 1.15,
+  larger: 1.3,
+} as const;
+```
+
+Defaults: `uiSpacing: "cozy"`, `uiTextScale: "default"`.
+
+---
+
+## File Structure
+
+**Modified — the store (the owner of both settings):**
+- `src/features/settings/useSettingsStore.ts` — both tables, both normalizers, both appliers, the persisted keys, the `coerceSettings` migration, and the `useSpacingStep` / `useTextScale` / `useRowH` hooks.
+
+**Modified — CSS contract:**
+- `src/index.css` — `--row-scale: 1` beside `--row-step: 0px`, and the `===== DENSITY =====` comment block becomes the contract for both.
+
+**Modified — the 26 row call sites** (mechanical, one regex): `src/design/primitives.tsx`, `src/design/chrome.tsx`, `src/design/git-components.tsx`, `src/features/settings/layout/SettingsCard.tsx`, `src/features/diff/CommitDiffPanel.tsx`, `src/features/forge/PullRequestRow.tsx`, `src/features/compare/CompareSidePicker.tsx`, `src/features/branches/BranchPicker.tsx`, `src/features/rebase/RebaseBasePicker.tsx`, `src/features/palette/CommandPalette.tsx`, `src/screens/History.tsx`, `src/screens/FileHistory.tsx`, `src/screens/DiffViewer.tsx`, `src/screens/Compare.tsx`, `src/screens/Welcome.tsx`, `src/screens/Branches.tsx`.
+
+**Modified — the JS geometry that CSS cannot reach:**
+- `src/lib/useDiffRowHeight.ts` — re-read dependency.
+- `src/design/graph-geometry.ts` — column widths become functions of the scale.
+- `src/design/git-components.tsx` — `PGCommitRow` / `PGGraphRow`, `commitRowGrid` caller.
+- `src/screens/History.tsx` — header grid + `siblingMin`.
+- `src/screens/RepoBrowser.tsx`, `src/screens/CommitPanel.tsx`, `src/screens/DiffViewer.tsx` — windowed row pitches.
+
+**Modified — UI:**
+- `src/features/settings/pages/appearance.tsx` — `meta` rows and the two controls.
+
+**Created:**
+- `test/uiScale.test.ts` — guard (project `docs`): no row surface may opt into `--row-step` without `--row-scale`.
+
+**Modified — tests:** `src/design/git-components.density.test.tsx` (renamed), `src/design/git-components.narrow.test.tsx`, `src/features/settings/useSettingsStore.test.ts`, `src/features/settings/useSettingsStore.export.test.ts`, `src/features/settings/themeFiles.test.ts`, `src/features/settings/layout/SettingsCard.test.tsx`, `src/screens/Settings.appearance.test.tsx`, `e2e/specs/settings.e2e.ts`.
+
+**Modified — docs:** `src/index.css` comment, `docs/dev/frontend.md`, `CLAUDE.md`.
+
+### Trap: two existing tests use `"cozy"` as their example of an INVALID value
+
+`"cozy"` becomes a real spacing value in Task 1, so these two stop testing what they say:
+
+- `src/features/settings/useSettingsStore.test.ts:427` — stores `{ uiDensity: "cozy" }` and expects the fallback.
+- `src/features/settings/useSettingsStore.export.test.ts:492` — imports `uiDensity: "cozy"` and expects `"compact"`.
+
+Both must switch to a value that is genuinely not in the table. Use `"roomy"`. Task 1 does this; do not skip it, and do not "fix" the resulting failure by re-adding `cozy` as invalid.
+
+---
+
+### Task 1: Spacing — widen the step table, rename the axis, migrate
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts` (lines ~666–730, 835, 1094, ~1455, ~1507, 2003, 2031, 2047, 2058, 2089)
+- Modify: `src/design/git-components.tsx:18,1630`, `src/screens/RepoBrowser.tsx:35,366,718`, `src/screens/CommitPanel.tsx:42,643`, `src/screens/DiffViewer.tsx:63,239`, `src/screens/History.tsx:51,318`, `src/lib/useDiffRowHeight.ts:2,30`
+- Test: `src/features/settings/useSettingsStore.test.ts`, `src/features/settings/useSettingsStore.export.test.ts`, `src/features/settings/themeFiles.test.ts`, `src/design/git-components.density.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces:
+  - `export const SPACING_STEP_PX: { compact: 0; cozy: 2; comfortable: 4; spacious: 8 }`
+  - `export type UiSpacing = keyof typeof SPACING_STEP_PX`
+  - `export function applySpacing(spacing: UiSpacing): void`
+  - `export function useSpacingStep(): number`
+  - `PersistedState.uiSpacing: UiSpacing`
+  - `DENSITY_STEP_PX`, `UiDensity`, `applyDensity`, `useDensityStep` no longer exist.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/features/settings/useSettingsStore.test.ts`, replace the whole `describe("uiDensity CSS hook", …)` block (lines ~387–430) with:
+
+```ts
+describe("uiSpacing CSS hook", () => {
+  it("applies --row-step from the persisted spacing at load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "spacious" }));
+    await freshStore();
+    expect(rowStep()).toBe("8px");
+  });
+
+  it("re-applies --row-step when the spacing setting changes", async () => {
+    await freshStore();
+    useSettingsStore.getState().set("uiSpacing", "comfortable");
+    expect(rowStep()).toBe("4px");
+    useSettingsStore.getState().set("uiSpacing", "compact");
+    expect(rowStep()).toBe("0px");
+  });
+
+  // Compact must stay exactly 0: it is the value that reproduces the
+  // pre-density layout, so every `calc(Npx + var(--row-step))` collapses to Npx.
+  it("keeps compact at zero and orders the four steps", async () => {
+    const { SPACING_STEP_PX } = await freshStore();
+    expect(SPACING_STEP_PX.compact).toBe(0);
+    expect(Object.values(SPACING_STEP_PX)).toEqual([0, 2, 4, 8]);
+  });
+
+  // An unrecognized value would emit `--row-step: undefinedpx`, and one
+  // invalid substitution makes every `calc(Npx + var(--row-step))` compute to
+  // `auto` — collapsing the height of every row in the app at once.
+  it("falls back to the default for an unknown stored spacing", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "roomy" }));
+    await freshStore();
+    expect(rowStep()).toBe("2px");
+  });
+
+  // `in` walks the prototype chain, so a hand-edited "toString" would pass a
+  // membership check and index the table to a FUNCTION — the same undefinedpx
+  // collapse, reached by a value that looks like it was validated.
+  it("rejects an inherited Object property as a spacing value", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "toString" }));
+    await freshStore();
+    expect(rowStep()).toBe("2px");
+  });
+});
+
+describe("uiDensity migration", () => {
+  it("carries a stored comfortable density over to comfortable spacing", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
+    await freshStore();
+    expect(useSettingsStore.getState().uiSpacing).toBe("comfortable");
+    expect(rowStep()).toBe("4px");
+  });
+
+  // Deliberate: a stored "compact" cannot be told apart from "never touched
+  // it", and the whole point of the change is that the old default was too
+  // dense. Landing an upgraded install on cozy is the same call the
+  // headIndicator -> headMarks migration made one setting over.
+  it("lands an upgraded compact install on cozy", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "compact" }));
+    await freshStore();
+    expect(useSettingsStore.getState().uiSpacing).toBe("cozy");
+  });
+
+  it("lets a stored uiSpacing win over a stale uiDensity", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ uiDensity: "comfortable", uiSpacing: "compact" }),
+    );
+    await freshStore();
+    expect(useSettingsStore.getState().uiSpacing).toBe("compact");
+  });
+
+  it("drops the retired key from state", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
+    await freshStore();
+    expect("uiDensity" in useSettingsStore.getState()).toBe(false);
+  });
+});
+```
+
+Add the `rowStep()` helper next to the existing one at line ~330 if it is not already a named function:
+
+```ts
+const rowStep = () =>
+  document.documentElement.style.getPropertyValue("--row-step");
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/features/settings/useSettingsStore.test.ts`
+Expected: FAIL — `SPACING_STEP_PX` is not exported, and `uiSpacing` is not a key.
+
+- [ ] **Step 3: Replace the table, the normalizer and the applier**
+
+In `src/features/settings/useSettingsStore.ts`, replace `DENSITY_STEP_PX` / `UiDensity` / `normalizeDensity` / `applyDensity` (lines ~666–727) with:
+
+```ts
+/**
+ * Extra vertical pixels each row-ish surface adds, per spacing preset.
+ *
+ * THE source of truth for the number. `index.css` declares `--row-step: 0px`
+ * as a pre-hydration default and derives every row token from it
+ * (`--row-h: calc(24px * var(--row-scale) + var(--row-step))`, …);
+ * `applySpacing` overwrites the var from this table, so CSS never hardcodes a
+ * step and cannot drift from the JS one. Compact is 0 by definition — it is
+ * the value that reproduces the pre-density layout exactly.
+ */
+export const SPACING_STEP_PX = {
+  compact: 0,
+  cozy: 2,
+  comfortable: 4,
+  spacious: 8,
+} as const;
+
+export type UiSpacing = keyof typeof SPACING_STEP_PX;
+
+/**
+ * Coerce a persisted spacing into a known one.
+ *
+ * `coerceSettings` copies any JSON value for a known key and only type-guards
+ * it against the TYPE of its default, so state can hold a string this build
+ * has never heard of — a hand-edited `pg-settings-v2`, or a value written by a
+ * newer build the user downgraded from. That must degrade to the default: an
+ * unknown key would emit `--row-step: undefinedpx`, and one invalid
+ * substitution makes every `calc(Npx + var(--row-step))` compute to `auto`,
+ * collapsing the height of every row in the app at once.
+ *
+ * `Object.hasOwn`, not `in`: `in` walks the prototype chain, so "toString"
+ * would pass the check and then index the table to a FUNCTION — the same
+ * collapse, reached by a value that looked validated.
+ */
+function normalizeSpacing(spacing: unknown): UiSpacing {
+  return typeof spacing === "string" && Object.hasOwn(SPACING_STEP_PX, spacing)
+    ? (spacing as UiSpacing)
+    : DEFAULTS.uiSpacing;
+}
+
+/**
+ * Apply the spacing preset by writing the row-step slot to CSS vars on :root.
+ *
+ * `data-spacing` is also set — a reserved hook for any future rule that isn't
+ * a simple pixel delta. Nothing reads it today (it's asserted only in
+ * useSettingsStore.test.ts); drop it if that stays true.
+ */
+export function applySpacing(spacing: UiSpacing) {
+  const root = document.documentElement;
+  const s = normalizeSpacing(spacing);
+  root.style.setProperty("--row-step", `${SPACING_STEP_PX[s]}px`);
+  root.dataset.spacing = s;
+}
+```
+
+`normalizeSpacing` reads `DEFAULTS`, which is declared later in the file. That is fine — it is only ever *called* after module evaluation, the same way the existing normalizers reference `DEFAULTS.dateFormat`.
+
+- [ ] **Step 4: Swap the persisted key**
+
+`src/features/settings/useSettingsStore.ts:835` — replace `uiDensity: "compact" | "comfortable";` with:
+
+```ts
+  /**
+   * How much breathing room every list row gets (`--row-step`). Replaces the
+   * binary `uiDensity`; `coerceSettings` migrates the old key.
+   */
+  uiSpacing: UiSpacing;
+```
+
+`:1094` — replace `uiDensity: "compact",` with `uiSpacing: "cozy",`.
+
+- [ ] **Step 5: Migrate in `coerceSettings`, the ONE place both paths pass through**
+
+`load()` calls `coerceSettings(parsed, DEFAULTS).state` and `importSettings` calls it too, so the migration written here covers storage AND an imported settings file. Nothing extra is needed in either caller.
+
+At `:1455`, extend the `ignored` exemption so the retired key is honoured rather than reported:
+
+```ts
+  const ignored = Object.keys(parsed).filter(
+    // `headIndicator` and `uiDensity` left the schema but the migrations below
+    // still read them, so they are honoured rather than ignored.
+    (k) => !known.has(k) && k !== "headIndicator" && k !== "uiDensity",
+  );
+```
+
+At `:1507`, replace the `out.uiDensity = normalizeDensity(out.uiDensity);` line with:
+
+```ts
+  // Spacing (#457-era rename). A stored `uiSpacing` wins; otherwise the
+  // pre-rename `uiDensity` is carried over, reading `parsed` rather than `out`
+  // because the old key is gone from the schema and the copy loop above never
+  // picked it up.
+  //
+  // `compact` deliberately lands on `cozy` rather than on `compact`: a stored
+  // "compact" cannot be distinguished from "never touched it" — `load()` fills
+  // missing keys from DEFAULTS and writes the result back — so preserving it
+  // would ship the roomier default to new installs only. Two pixels per row is
+  // mild and one click reversible, and it is the same call the headIndicator
+  // migration below makes one setting over.
+  if (!("uiSpacing" in parsed)) {
+    out.uiSpacing =
+      parsed.uiDensity === "comfortable"
+        ? "comfortable"
+        : parsed.uiDensity === "compact"
+          ? "cozy"
+          : DEFAULTS.uiSpacing;
+  }
+  out.uiSpacing = normalizeSpacing(out.uiSpacing);
+```
+
+- [ ] **Step 6: Repoint the four appliers and the hook**
+
+In the same file:
+- `:2003` (inside `importSettings`) — `applyDensity(state.uiDensity);` → `applySpacing(state.uiSpacing);`
+- `:2031` — `if (key === "uiDensity") { applyDensity(get().uiDensity); }` → `if (key === "uiSpacing") { applySpacing(get().uiSpacing); }`
+- `:2047` (inside `reset`) — `applyDensity(DEFAULTS.uiDensity);` → `applySpacing(DEFAULTS.uiSpacing);`
+- `:2058` (module load) — `applyDensity(s.uiDensity);` → `applySpacing(s.uiSpacing);`
+- `:2089` — replace `useDensityStep` with:
+
+```ts
+/**
+ * The active spacing preset's pixel step, for surfaces that need the NUMBER
+ * rather than the `--row-step` CSS var — i.e. anything doing geometry math in
+ * JS. Prefer the CSS token everywhere it works; this exists for SVG user-unit
+ * drawing (see `PGGraphRow`) and for windowed lists, neither of which a
+ * `calc()` can reach.
+ */
+export function useSpacingStep(): number {
+  return SPACING_STEP_PX[normalizeSpacing(useSettingsStore((s) => s.uiSpacing))];
+}
+```
+
+- [ ] **Step 7: Rename the six consumers**
+
+Mechanical — each is an import plus a call:
+
+```bash
+cd /Users/jonas/dev/fun/platypusgit/.claude/worktrees/ui-scale
+grep -rl "useDensityStep" src/ | xargs sed -i '' 's/useDensityStep/useSpacingStep/g'
+grep -rn "useDensityStep\|applyDensity\|DENSITY_STEP_PX\|uiDensity" src/ | grep -v "\.test\."
+```
+
+The second command must print NOTHING except the migration comment in `useSettingsStore.ts`. Fix anything else it finds.
+
+- [ ] **Step 8: Update the tests that used the old key**
+
+- `src/design/git-components.density.test.tsx` — `set("uiDensity", "compact")` → `set("uiSpacing", "compact")` at lines 39, and `set("uiDensity", "comfortable")` → `set("uiSpacing", "comfortable")` at 53 and 68. The asserted heights (26 and 30) are unchanged, because compact is still 0 and comfortable still 4.
+- `src/features/settings/themeFiles.test.ts:103,110` — the fixture `'{"settings":{"uiDensity":"comfortable"}}'` now MIGRATES rather than being ignored. Change the fixture to `'{"settings":{"uiSpacing":"comfortable"}}'` and line 110 to `expect(useSettingsStore.getState().uiSpacing).toBe("compact")` if the test asserts a denied import, or `toBe("comfortable")` if it asserts an accepted one — read the surrounding `it(…)` title and keep its meaning.
+- `src/features/settings/useSettingsStore.export.test.ts:97` — `"uiDensity"` → `"uiSpacing"` in the portable-key list.
+- `…export.test.ts:273` — `set("uiDensity", "comfortable")` → `set("uiSpacing", "comfortable")`.
+- `…export.test.ts:492,499` — **the "cozy" trap.** `uiDensity: "cozy"` was this test's example of an invalid value and `cozy` is now valid. Change the payload to `{ uiSpacing: "roomy" }` and the expectation to `expect(s.uiSpacing).toBe("cozy")` — the default.
+- `src/features/settings/useSettingsStore.test.ts:16` — the `--row-step` cleanup stays as is.
+
+- [ ] **Step 9: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/features/settings src/design/git-components.density.test.tsx`
+Expected: PASS. Then `~/Library/pnpm/pnpm tsc --noEmit` — expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/jonas/dev/fun/platypusgit/.claude/worktrees/ui-scale
+git add -A
+git commit -m "feat(settings): four spacing presets in place of binary density" -m "Widens DENSITY_STEP_PX into SPACING_STEP_PX (0/2/4/8px) and renames the
+axis to uiSpacing, migrating the retired uiDensity key in coerceSettings --
+the one function both localStorage load and settings import pass through.
+
+An upgraded install on compact deliberately lands on cozy: a stored
+compact cannot be distinguished from never having touched the setting,
+so preserving it would ship the roomier default to new installs only.
+
+Also hardens the membership check to Object.hasOwn. The old 'in' walked
+the prototype chain, so a hand-edited value of toString passed validation
+and then indexed the table to a function -- emitting undefinedpx, which
+collapses the height of every row in the app at once.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Text scale — the ramp and `--row-scale`, written from JS
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts`
+- Test: `src/features/settings/useSettingsStore.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeSpacing`, `applySpacing`, `DEFAULTS` (Task 1).
+- Produces:
+  - `export const FS_TOKENS: readonly [10,11,12,13,14,15,17,20,28,40]`
+  - `export const TEXT_SCALE: { small: 0.92; default: 1; large: 1.15; larger: 1.3 }`
+  - `export type UiTextScale = keyof typeof TEXT_SCALE`
+  - `export function applyTextScale(scale: UiTextScale): void`
+  - `export function useTextScale(): number` — the raw factor (0.92 … 1.3), not the key
+  - `PersistedState.uiTextScale: UiTextScale`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/features/settings/useSettingsStore.test.ts`:
+
+```ts
+const fsVar = (n: number) =>
+  document.documentElement.style.getPropertyValue(`--fs-${n}`);
+const rowScale = () =>
+  document.documentElement.style.getPropertyValue("--row-scale");
+
+describe("uiTextScale CSS hook", () => {
+  it("applies the resolved ramp from the persisted scale at load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "larger" }));
+    await freshStore();
+    expect(fsVar(13)).toBe("16.9px");
+    expect(fsVar(40)).toBe("52px");
+    expect(rowScale()).toBe("1.3");
+  });
+
+  it("re-applies the ramp when the setting changes", async () => {
+    await freshStore();
+    expect(fsVar(13)).toBe("13px");
+    useSettingsStore.getState().set("uiTextScale", "large");
+    expect(fsVar(13)).toBe("15px");
+    expect(rowScale()).toBe("1.15");
+  });
+
+  // Rounding is what could break this, and a collapsed or reordered pair would
+  // render two different type roles identically with nothing on screen saying
+  // why. Four presets is a finite set, so assert it rather than sample it.
+  it("keeps the ramp strictly ascending at every preset", async () => {
+    const { TEXT_SCALE, FS_TOKENS, applyTextScale } = await freshStore();
+    for (const key of Object.keys(TEXT_SCALE) as (keyof typeof TEXT_SCALE)[]) {
+      applyTextScale(key);
+      const sizes = FS_TOKENS.map((n) => Number.parseFloat(fsVar(n)));
+      for (let i = 1; i < sizes.length; i++) {
+        expect(sizes[i], `${key}: --fs-${FS_TOKENS[i]}`).toBeGreaterThan(sizes[i - 1]);
+      }
+    }
+  });
+
+  // The clipping guard. Rows set `height`, not `min-height`, so a base that
+  // does not grow with the type clips it -- and no test that only reads the
+  // ramp can see that. --fs-13 x --lh-body must fit the SMALLEST row base in
+  // use (22px, PGBranchRow and the Compare header).
+  it("keeps the smallest row base clear of its own line box at every preset", async () => {
+    const { TEXT_SCALE, applyTextScale } = await freshStore();
+    const SMALLEST_ROW_BASE = 22;
+    const LH_BODY = 1.45;
+    for (const key of Object.keys(TEXT_SCALE) as (keyof typeof TEXT_SCALE)[]) {
+      applyTextScale(key);
+      const lineBox = Number.parseFloat(fsVar(13)) * LH_BODY;
+      const rowH = SMALLEST_ROW_BASE * Number.parseFloat(rowScale());
+      expect(rowH, `${key}`).toBeGreaterThanOrEqual(lineBox);
+    }
+  });
+
+  it("falls back to the default for an unknown stored text scale", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "huge" }));
+    await freshStore();
+    expect(fsVar(13)).toBe("13px");
+    expect(rowScale()).toBe("1");
+  });
+
+  it("rejects an inherited Object property as a text scale", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "toString" }));
+    await freshStore();
+    expect(rowScale()).toBe("1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/features/settings/useSettingsStore.test.ts`
+Expected: FAIL — `TEXT_SCALE` is not exported.
+
+- [ ] **Step 3: Add the table, the normalizer and the applier**
+
+In `src/features/settings/useSettingsStore.ts`, immediately after `applySpacing`:
+
+```ts
+/**
+ * Every step of the type ramp, as the NUMBER in its token name.
+ *
+ * `index.css` declares `--fs-10` … `--fs-40` at these exact px values as the
+ * pre-hydration default; `applyTextScale` overwrites all ten from this list,
+ * so the two cannot drift and a new step is added in one place.
+ */
+export const FS_TOKENS = [10, 11, 12, 13, 14, 15, 17, 20, 28, 40] as const;
+
+/**
+ * How far the type ramp moves, per text-size preset.
+ *
+ * Text size is NOT zoom. Zoom scales the whole UI through the webview —
+ * borders, icons, the titlebar, whitespace — and is the answer to "this app is
+ * too small on my display". This scales type, the row bases that have to hold
+ * it, and the column widths that are sized to text; icons and gaps stay put.
+ * The two compose, which is why both exist.
+ */
+export const TEXT_SCALE = {
+  small: 0.92,
+  default: 1,
+  large: 1.15,
+  larger: 1.3,
+} as const;
+
+export type UiTextScale = keyof typeof TEXT_SCALE;
+
+/** Same contract as `normalizeSpacing`, one setting over — see its comment. */
+function normalizeTextScale(scale: unknown): UiTextScale {
+  return typeof scale === "string" && Object.hasOwn(TEXT_SCALE, scale)
+    ? (scale as UiTextScale)
+    : DEFAULTS.uiTextScale;
+}
+
+/**
+ * Apply the text-size preset by writing the RESOLVED ramp to :root.
+ *
+ * Resolved px rather than `--fs-13: calc(13px * var(--ui-text-scale))`, which
+ * reads better but would make `--diff-row-h: calc(var(--fs-12) *
+ * var(--lh-code))` a nested calc() inside an unregistered custom property —
+ * and `readDiffRowHeight` already carries a fallback for the case where that
+ * value does not resolve to px. Writing px keeps `--diff-row-h` a one-level
+ * calc, unchanged, and keeps the question from arising in the webview at all.
+ *
+ * One decimal, not whole pixels: two steps of the ramp are 1px apart at the
+ * small end, and integer rounding can collapse or reorder them.
+ *
+ * `--row-scale` is the same factor, unitless, for the row bases — every row
+ * surface sets `height`, not `min-height`, so a base that does not grow with
+ * the type clips it.
+ */
+export function applyTextScale(scale: UiTextScale) {
+  const root = document.documentElement;
+  const key = normalizeTextScale(scale);
+  const f = TEXT_SCALE[key];
+  for (const base of FS_TOKENS) {
+    root.style.setProperty(`--fs-${base}`, `${Math.round(base * f * 10) / 10}px`);
+  }
+  root.style.setProperty("--row-scale", String(f));
+  root.dataset.textScale = key;
+}
+```
+
+- [ ] **Step 4: Add the persisted key and wire the four appliers**
+
+- `PersistedState`, directly under `uiSpacing`:
+
+```ts
+  /**
+   * How large the type is (`--fs-*`) and, with it, the row bases and the
+   * text-sized columns. Independent of `uiZoom`, which scales everything.
+   */
+  uiTextScale: UiTextScale;
+```
+
+- `DEFAULTS`, under `uiSpacing: "cozy",` — add `uiTextScale: "default",`.
+- In `coerceSettings`, directly after the `out.uiSpacing = normalizeSpacing(…)` line — add `out.uiTextScale = normalizeTextScale(out.uiTextScale);`
+- `importSettings` — add `applyTextScale(state.uiTextScale);` beside `applySpacing(state.uiSpacing);`
+- `set()` — add beside the `uiSpacing` arm:
+
+```ts
+    if (key === "uiTextScale") {
+      applyTextScale(get().uiTextScale);
+    }
+```
+
+- `reset()` — add `applyTextScale(DEFAULTS.uiTextScale);`
+- module-load block — add `applyTextScale(s.uiTextScale);`, and update its comment to "Apply active theme, spacing and text scale on module load so there's no flash before first render."
+
+- [ ] **Step 5: Add the hook**
+
+Beside `useSpacingStep`:
+
+```ts
+/**
+ * The active text scale as a FACTOR (0.92 … 1.3), for surfaces that multiply a
+ * JS pixel constant by it — windowed row pitches, the SVG graph gutter, and
+ * the commit row's text-sized columns. Everything a `calc()` can reach should
+ * use `var(--row-scale)` instead.
+ */
+export function useTextScale(): number {
+  return TEXT_SCALE[normalizeTextScale(useSettingsStore((s) => s.uiTextScale))];
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/features/settings/useSettingsStore.test.ts`
+Expected: PASS, including the ascending-ramp and line-box guards.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(settings): a text-size preset that scales the type ramp" -m "applyTextScale writes all ten --fs-* tokens as resolved px from one JS
+table, plus a unitless --row-scale for the row bases. Resolved px rather
+than calc(13px * var(--scale)) because the latter would turn --diff-row-h
+into a nested calc inside an unregistered custom property, which is
+exactly the case readDiffRowHeight already carries a fallback for.
+
+Two guards land with it: the ramp stays strictly ascending at every
+preset (rounding is what could break it), and the smallest row base
+clears its own line box at every preset -- the assertion that catches
+scaling type without scaling the rows that must hold it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: The 26 row call sites multiply their base by `--row-scale`
+
+**Files:**
+- Modify: `src/index.css:174–195`
+- Modify (sweep): `src/design/primitives.tsx`, `src/design/chrome.tsx`, `src/design/git-components.tsx`, `src/features/diff/CommitDiffPanel.tsx`, `src/features/forge/PullRequestRow.tsx`, `src/features/compare/CompareSidePicker.tsx`, `src/features/branches/BranchPicker.tsx`, `src/features/rebase/RebaseBasePicker.tsx`, `src/features/palette/CommandPalette.tsx`, `src/screens/History.tsx`, `src/screens/FileHistory.tsx`, `src/screens/DiffViewer.tsx`, `src/screens/Compare.tsx`, `src/screens/Welcome.tsx`, `src/screens/Branches.tsx`
+- Modify: `src/features/settings/layout/SettingsCard.tsx:18–20`
+- Create: `test/uiScale.test.ts`
+- Test: `src/features/settings/layout/SettingsCard.test.tsx`, `src/screens/Settings.appearance.test.tsx`
+
+**Interfaces:**
+- Consumes: `--row-scale`, written by `applyTextScale` (Task 2).
+- Produces: `densityPadding(basePx)` returns `` `calc(${basePx}px * var(--row-scale) + var(--row-step) / 2) 16px` ``.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Create `test/uiScale.test.ts` (project `docs`, node env — it reads source files):
+
+```ts
+// A row surface that opts into spacing must opt into text size too.
+//
+// Every one of these sets `height`, not `min-height`, so a base that does not
+// grow with the type CLIPS it: at the largest preset --fs-13's line box is
+// 24.5px, taller than the 22px and 24px bases in use. The two vars are one
+// decision — `--row-step` is the user's spacing preset, `--row-scale` the
+// text one — and a surface that takes the first without the second is a row
+// that gets roomier but still cuts its own text in half.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+
+function sourceFiles(): string[] {
+  return globSync("src/**/*.{ts,tsx,css}", { cwd: ROOT })
+    .filter((f) => !f.includes(".test."))
+    .map((f) => join(ROOT, f));
+}
+
+describe("--row-step and --row-scale travel together", () => {
+  it("has no row surface that scales with spacing but not with text", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        // `calc(<n>px + var(--row-step)` — a base that never grows with type.
+        if (/calc\(\s*\d+px\s*\+\s*var\(--row-step\)/.test(line)) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // The other half: a base multiplied by --row-scale but never given the
+  // user's spacing step is a row that ignores the Spacing setting entirely.
+  it("has no row surface that scales with text but not with spacing", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        if (
+          /var\(--row-scale\)/.test(line) &&
+          !/var\(--row-step\)/.test(line) &&
+          !/--row-scale:/.test(line)
+        ) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+```
+
+If `globSync` is not available from `node:fs` on this Node version, use the same glob helper the neighbouring guard tests use — read `test/fileSave.test.ts` and copy its file-walking approach rather than adding a dependency.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run --project docs test/uiScale.test.ts`
+Expected: FAIL — the first test lists ~25 offenders.
+
+- [ ] **Step 3: Sweep the call sites**
+
+One regex covers every inline style and the CSS token. It matches only a literal-px base followed by `+ var(--row-step)`, which is exactly the shape being replaced:
+
+```bash
+cd /Users/jonas/dev/fun/platypusgit/.claude/worktrees/ui-scale
+grep -rl -- "--row-step" src/ --include="*.tsx" --include="*.css" \
+  | grep -v "\.test\." \
+  | xargs sed -i '' -E 's/calc\(([0-9]+)px \+ var\(--row-step\)/calc(\1px * var(--row-scale) + var(--row-step)/g'
+```
+
+Then the one template literal the regex cannot reach — `src/features/settings/layout/SettingsCard.tsx:18-20`:
+
+```ts
+export function densityPadding(basePx: number): string {
+  return `calc(${basePx}px * var(--row-scale) + var(--row-step) / 2) 16px`;
+}
+```
+
+Update that function's doc comment: after the existing `--row-step` paragraph, add
+
+```
+ * `--row-scale` multiplies the BASE and not the step: the step is already the
+ * user's own number in pixels, while the base is what has to hold the text.
+```
+
+- [ ] **Step 4: Verify the sweep is complete**
+
+```bash
+grep -rn -- "var(--row-step)" src/ --include="*.tsx" --include="*.css" | grep -v "\.test\." | grep -v "row-scale"
+```
+
+Expected: only comment lines (`src/index.css`'s token block, `SettingsCard.tsx`'s doc comment, `skeleton.tsx`'s note that it uses `--row-h` directly). No `height:` or `padding:` line may appear. `skeleton.tsx` needs NO edit — it consumes `--row-h`, which is fixed in Step 5.
+
+- [ ] **Step 5: Update the CSS contract**
+
+`src/index.css` — replace the `/* ===== DENSITY ===== */` comment block and its two declarations (lines ~174–195) with:
+
+```css
+  /* ===== ROW GEOMETRY: SPACING + TEXT SIZE =====
+   * Two knobs, written from JS (features/settings/useSettingsStore.ts), which
+   * is THE source of truth for both numbers — these declarations are only the
+   * pre-hydration defaults.
+   *
+   *   --row-step   the user's Spacing preset, in whole extra pixels per row
+   *                (applySpacing, from SPACING_STEP_PX)
+   *   --row-scale  the user's Text size preset, unitless (applyTextScale,
+   *                from TEXT_SCALE) — the same factor the --fs-* ramp took
+   *
+   * Row surfaces opt into BOTH:
+   *
+   *   calc(<base>px * var(--row-scale) + var(--row-step))
+   *   calc(<base>px * var(--row-scale) + var(--row-step) / 2)   for padding,
+   *                                    since top and bottom each take half
+   *
+   * The base is multiplied and the step is added, because the step is already
+   * the user's own number of pixels while the base is what has to HOLD the
+   * text — every row surface sets `height`, not `min-height`, so a base that
+   * did not grow with the type would clip it.
+   *
+   * Keeping each surface's own base inline means compact at x1 renders
+   * pixel-identically to the pre-density layout, and
+   * `grep -rn 'var(--row-step)' src/` lists every participating surface —
+   * EXCEPT the Settings panel, which takes both from one shared helper
+   * (`densityPadding()` / `SETTINGS_ROW_PADDING` in features/settings/layout/
+   * SettingsCard.tsx) so its row helpers cannot drift apart on height. Add
+   * `-e densityPadding -e SETTINGS_ROW_PADDING` to that grep to see them, or
+   * the Settings rows, the forge account rows and the Appearance page's theme
+   * action strip all read as non-participants.
+   *
+   * `test/uiScale.test.ts` fails the build for a surface that takes one var
+   * without the other.
+   *
+   * One surface can't use either token: PGGraphRow draws in SVG user units, so
+   * PGCommitRow feeds it the numbers via useSpacingStep() + useTextScale(). */
+  --row-step: 0px;
+  --row-scale: 1;
+  --row-h: calc(24px * var(--row-scale) + var(--row-step));
+```
+
+- [ ] **Step 6: Update the two tests that assert the exact padding string**
+
+- `src/features/settings/layout/SettingsCard.test.tsx:61-63`:
+
+```ts
+    expect(densityPadding(12)).toBe(
+      "calc(12px * var(--row-scale) + var(--row-step) / 2) 16px",
+    );
+    expect(densityPadding(10)).toBe(
+      "calc(10px * var(--row-scale) + var(--row-step) / 2) 16px",
+    );
+    expect(SETTINGS_ROW_PADDING).toBe(densityPadding(12));
+```
+
+- `src/screens/Settings.appearance.test.tsx:55,58` assert `densityPadding(10)` and `toContain("var(--row-step) / 2")` — both still hold unchanged, since the first compares against the helper and the second is a substring that survives. Run them; edit only if they fail.
+- `src/design/primitives.select.test.tsx:110` asserts `row.style.height` **contains** `var(--row-step)` — still true. No edit.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run:
+```
+~/Library/pnpm/pnpm vitest run --project docs test/uiScale.test.ts
+~/Library/pnpm/pnpm vitest run --project unit src/design src/features/settings src/screens
+~/Library/pnpm/pnpm tsc --noEmit
+```
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(design): row bases grow with the text-size preset" -m "Every row surface sets height, not min-height, so scaling the type ramp
+without scaling the bases clips it: at the largest preset --fs-13's line
+box is 24.5px against 22px and 24px bases. All 26 call sites now read
+calc(<base>px * var(--row-scale) + var(--row-step)).
+
+min-height would have been self-correcting and arithmetic-free, but
+History, DiffViewer, Branches and RepoBrowser are windowed -- a row whose
+height the window cannot predict desyncs the window from the rows it is
+measuring, which is the #70 lesson.
+
+test/uiScale.test.ts fails the build for a surface that takes one var
+without the other, in either direction.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The JS row pitches get one owner
+
+Six surfaces compute a windowed row pitch as `BASE + useSpacingStep()`. Each now also needs `* useTextScale()`, and six copies of that arithmetic is six chances to write it differently. One hook owns it.
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts` (add `useRowH`)
+- Modify: `src/lib/useDiffRowHeight.ts:2,30`
+- Modify: `src/design/git-components.tsx:268-273,1630,1635`
+- Modify: `src/screens/RepoBrowser.tsx:366,718`, `src/screens/CommitPanel.tsx:643`, `src/screens/DiffViewer.tsx:239`, `src/screens/History.tsx:318`
+- Test: `src/design/git-components.density.test.tsx` → renamed `git-components.scale.test.tsx`
+
+**Interfaces:**
+- Consumes: `useSpacingStep()` (Task 1), `useTextScale()` (Task 2).
+- Produces: `export function useRowH(basePx: number): number` — `basePx * textScale + spacingStep`, the JS twin of `calc(<base>px * var(--row-scale) + var(--row-step))`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Rename the file and update it:
+
+```bash
+git mv src/design/git-components.density.test.tsx src/design/git-components.scale.test.tsx
+```
+
+In `src/design/git-components.scale.test.tsx`, change the `beforeEach` to reset both axes and add two cases to the `describe`:
+
+```ts
+beforeEach(() => {
+  useSettingsStore.getState().set("uiSpacing", "compact");
+  useSettingsStore.getState().set("uiTextScale", "default");
+});
+```
+
+```ts
+  // The graph gutter is drawn in SVG user units, so it cannot read
+  // --row-scale. If PGCommitRow does not hand it the same number the row box
+  // used, the lane curves stop meeting the dots -- in the most visible list in
+  // the app. Literals, not the expression: if either input moves this fails
+  // rather than following along silently.
+  it("grows row and graph gutter together when the text scale changes", () => {
+    useSettingsStore.getState().set("uiTextScale", "larger");
+    const { row, svg } = renderCommitRow();
+    // COMMIT_ROW_BASE_H 26 x 1.3 = 33.8, + compact step 0
+    expect(row.style.height).toBe("33.8px");
+    expect(svg.getAttribute("height")).toBe("33.8");
+  });
+
+  it("adds the spacing step on top of the scaled base", () => {
+    useSettingsStore.getState().set("uiTextScale", "large");
+    useSettingsStore.getState().set("uiSpacing", "spacious");
+    const { row, svg } = renderCommitRow();
+    // 26 x 1.15 = 29.9, + spacious step 8
+    expect(row.style.height).toBe("37.9px");
+    expect(svg.getAttribute("height")).toBe("37.9");
+  });
+```
+
+Also rename the outer `describe("PGCommitRow density", …)` to `describe("PGCommitRow row scale", …)` and update the file's header comment to name both axes.
+
+Append to `src/features/settings/useSettingsStore.test.ts`:
+
+```ts
+describe("useRowH", () => {
+  it("multiplies the base by the text scale and adds the spacing step", async () => {
+    const { useRowH, useSettingsStore: store } = await freshStore();
+    store.getState().set("uiTextScale", "larger");
+    store.getState().set("uiSpacing", "comfortable");
+    const { result } = renderHook(() => useRowH(24));
+    // 24 x 1.3 = 31.2, + comfortable step 4
+    expect(result.current).toBeCloseTo(35.2, 5);
+  });
+});
+```
+
+Import `renderHook` from `@testing-library/react` at the top of that test file if it is not already imported.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/design/git-components.scale.test.tsx src/features/settings/useSettingsStore.test.ts`
+Expected: FAIL — `useRowH` is not exported, and the row height is still `26px`.
+
+- [ ] **Step 3: Add the hook**
+
+In `src/features/settings/useSettingsStore.ts`, directly after `useTextScale`:
+
+```ts
+/**
+ * A row's height in px — the JS twin of
+ * `calc(<base>px * var(--row-scale) + var(--row-step))`.
+ *
+ * One owner rather than the expression repeated at each windowed list, because
+ * a window that computes its pitch differently from the rows it measures is
+ * the #70 desync, and six copies is six chances to write it differently. The
+ * base is MULTIPLIED and the step ADDED, for the reason `index.css` gives:
+ * the step is already the user's own number of pixels, the base is what has to
+ * hold the text.
+ */
+export function useRowH(basePx: number): number {
+  return basePx * useTextScale() + useSpacingStep();
+}
+```
+
+- [ ] **Step 4: Repoint the six call sites**
+
+Each is a one-line change; keep the surrounding comments and update the ones that name the old expression.
+
+- `src/screens/RepoBrowser.tsx:366` — `const treeRowH = FILE_TREE_ROW_BASE_H + useSpacingStep();` → `const treeRowH = useRowH(FILE_TREE_ROW_BASE_H);`
+- `src/screens/RepoBrowser.tsx:718` — `const diffFoldH = 22 + useSpacingStep();` → `const diffFoldH = useRowH(22);`
+- `src/screens/CommitPanel.tsx:643` — `const foldH = 22 + useSpacingStep();` → `const foldH = useRowH(22);`
+- `src/screens/DiffViewer.tsx:239` — `const foldH = 22 + useSpacingStep();` → `const foldH = useRowH(22);`
+- `src/screens/History.tsx:318` — `const rowH = COMMIT_ROW_BASE_H + useSpacingStep();` → `const rowH = useRowH(COMMIT_ROW_BASE_H);`
+- `src/design/git-components.tsx:1630,1635` — replace
+
+```ts
+  const step = useSpacingStep();
+  …
+  const h = rowHeight ?? COMMIT_ROW_BASE_H + step;
+```
+
+with
+
+```ts
+  const derivedH = useRowH(COMMIT_ROW_BASE_H);
+  …
+  const h = rowHeight ?? derivedH;
+```
+
+`useRowH` must be called unconditionally — it is a hook. Keep it at the top of the component beside the other hook calls, and use `??` afterwards.
+
+Fix every import: remove `useSpacingStep` where it is no longer referenced, add `useRowH`. Then:
+
+```bash
+grep -rn "useSpacingStep" src/ | grep -v "\.test\." | grep -v useSettingsStore.ts
+```
+Expected: NOTHING. `useSpacingStep` survives only as `useRowH`'s own input and for `PGGraphRow`'s SVG feed if that reads it separately — if the grep prints a line, read it and confirm it genuinely needs the raw step rather than a row height.
+
+- [ ] **Step 5: Update the two comments that describe the old arithmetic**
+
+- `src/design/git-components.tsx:268-273` — the `FILE_TREE_ROW_BASE_H` doc comment says a caller "must add `useSpacingStep()`". Replace that sentence with: "A windowing caller needs the pitch as a NUMBER and must get it from `useRowH()`; a literal would desync the window from the rows at any preset but the default (#70)."
+- `src/lib/useWindowedList.ts:7` — the comment naming `COMMIT_ROW_BASE_H + useSpacingStep()` becomes `useRowH(COMMIT_ROW_BASE_H)`.
+
+- [ ] **Step 6: Fix `useDiffRowHeight`'s dependency**
+
+`src/lib/useDiffRowHeight.ts` — `--diff-row-h` is `calc(var(--fs-12) * var(--lh-code))`, so it moves with TEXT, not with spacing. Today's dependency is the one axis that cannot change it.
+
+```ts
+import React from "react";
+import { useSpacingStep, useTextScale } from "@/features/settings/useSettingsStore";
+```
+
+```ts
+/**
+ * Code-row pitch in px, read from CSS rather than restated here.
+ *
+ * --lh-code stays the owner of code geometry, and 1.55 × 12px is 18.6px — any
+ * literal in TypeScript would already be wrong and would desync the window from
+ * the rows it is measuring (the #70 lesson).
+ *
+ * Re-read when either UI scale changes. The TEXT scale is the one that
+ * actually moves this value — `--diff-row-h` is derived from `--fs-12` — and
+ * spacing is kept as a dependency because that is when the theme layer
+ * rewrites geometry-adjacent tokens.
+ */
+export function useDiffRowHeight(): number {
+  const step = useSpacingStep();
+  const scale = useTextScale();
+  const [h, setH] = React.useState(() => readDiffRowHeight());
+  React.useEffect(() => {
+    setH(readDiffRowHeight());
+  }, [step, scale]);
+  return h;
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run:
+```
+~/Library/pnpm/pnpm vitest run --project unit src/design src/screens src/lib src/features/settings
+~/Library/pnpm/pnpm tsc --noEmit
+```
+Expected: PASS. `History.virtual.test.tsx` and `RepoBrowser.virtual.test.tsx` exercise the windowed pitches — if either fails, the row height and the window disagree; fix the call site rather than the assertion.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(design): one owner for a row's pitch in JS" -m "Six windowed surfaces computed BASE + useSpacingStep() by hand and each
+now needs the text scale too. useRowH(base) owns the arithmetic instead,
+as the JS twin of calc(<base>px * var(--row-scale) + var(--row-step)) --
+a window that computes its pitch differently from the rows it measures is
+the #70 desync, and six copies is six chances to diverge.
+
+Also fixes useDiffRowHeight, which re-read --diff-row-h when the SPACING
+changed. That value is derived from --fs-12, so text size is the one axis
+that can move it and the only one it was not watching.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: The commit row's text-sized columns follow the text scale
+
+`SHA_COL_W = 70` is documented as "seven hex digits of monospace, plus the gap"; `DATE_COL_W` is sized to a rendered date string. At the largest preset both are narrower than the text they exist to hold, and truncating a sha or a timestamp destroys its meaning.
+
+**Files:**
+- Modify: `src/design/graph-geometry.ts:42-46,49,61,81-94,117-123`
+- Modify: `src/design/git-components.tsx:1671`
+- Modify: `src/screens/History.tsx:130,205,867`
+- Modify: `src/features/settings/useSettingsStore.ts` (`useDateColumnWidth`)
+- Test: `src/design/git-components.narrow.test.tsx`
+
+**Interfaces:**
+- Consumes: `useTextScale()` (Task 2).
+- Produces:
+  - `export const shaColW = (scale?: number): number`
+  - `export const colPad = (scale?: number): number`
+  - `export const subjectMinW = (scale?: number): number`
+  - `export const authorMinW = (scale?: number): number`
+  - `export const authorColW = (scale?: number): number`
+  - `export const dateColW = (fmt: DateFormat, scale?: number): number`
+  - `export const commitListMinW = (scale?: number): number`
+  - `commitRowGrid(graphW: number, dateW?: number, scale?: number): string`
+  - Every one defaults `scale` to `1`, so a caller with no notion of the setting (tests, any surface that never scales) gets exactly the old numbers.
+  - The bare constants `SHA_COL_W`, `COL_PAD`, `SUBJECT_MIN_W`, `AUTHOR_MIN_W`, `AUTHOR_COL_W`, `COMMIT_LIST_MIN_W` stay exported as the ×1 values, because that is what the functions are built from and what the tests pin.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/design/git-components.narrow.test.tsx`, replace the `it("fits every minimum inside the narrowest commit list", …)` case with:
+
+```ts
+  // The floors are only worth anything if they FIT. Past the sum of the
+  // minimum tracks the grid overflows its pane and the date falls off the
+  // right edge, so the narrowest pane the app can produce has to hold them.
+  //
+  // Asserted at EVERY text preset, not only at x1: the columns are sized to
+  // text, so they all move together and a floor that stayed at 420 would push
+  // the Date column off the edge the moment someone picked Large. The sum is
+  // re-derived from commitRowGrid's own template rather than from the same
+  // expression commitListMinW uses -- otherwise this asserts nothing, and what
+  // it is here to catch is a NEW fixed column added to the grid and not to the
+  // formula.
+  it("fits every minimum inside the narrowest commit list, at every text preset", () => {
+    for (const scale of Object.values(TEXT_SCALE)) {
+      const template = commitRowGrid(graphWidth(4), dateColW("relative", scale), scale);
+      const tracks = template.split(" ");
+      const sum = tracks.reduce((acc, t) => {
+        const px = /^(\d+(?:\.\d+)?)px$/.exec(t);
+        if (px) return acc + Number.parseFloat(px[1]);
+        const mm = /^minmax\((\d+(?:\.\d+)?)px,/.exec(t);
+        if (mm) return acc + Number.parseFloat(mm[1]);
+        return acc;
+      }, 0);
+      expect(sum, `scale ${scale}`).toBeLessThanOrEqual(commitListMinW(scale));
+    }
+  });
+
+  // The avatar and the flex gap after it are not type, so they do not scale --
+  // but COL_PAD does, because it exists to make the NAME truncate before it
+  // touches the date. Below this the "who" goes as well as the name.
+  it("keeps the author's avatar inside the author minimum at every preset", () => {
+    for (const scale of Object.values(TEXT_SCALE)) {
+      expect(authorMinW(scale), `scale ${scale}`).toBeGreaterThanOrEqual(
+        16 + 6 + colPad(scale),
+      );
+    }
+  });
+
+  // A sha is seven hex digits of monospace: the column is sized to text, so it
+  // has to move with text or it truncates the one value truncation destroys.
+  it("grows the sha and date columns with the text scale", () => {
+    expect(shaColW(1)).toBe(SHA_COL_W);
+    expect(shaColW(1.3)).toBeGreaterThan(SHA_COL_W);
+    expect(dateColW("relative", 1)).toBe(DATE_COL_W.relative);
+    expect(dateColW("relative", 1.3)).toBeGreaterThan(DATE_COL_W.relative);
+  });
+```
+
+Update that file's imports:
+
+```ts
+import {
+  AUTHOR_COL_W,
+  AUTHOR_MIN_W,
+  COL_PAD,
+  COMMIT_LIST_MIN_W,
+  DATE_COL_W,
+  SHA_COL_W,
+  SUBJECT_MIN_W,
+  authorMinW,
+  colPad,
+  commitListMinW,
+  commitRowGrid,
+  dateColW,
+  graphWidth,
+  shaColW,
+} from "./graph-geometry";
+import { TEXT_SCALE } from "@/features/settings/useSettingsStore";
+```
+
+The two existing `commitRowGrid(…)` template assertions keep working unchanged, because `scale` defaults to 1.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/design/git-components.narrow.test.tsx`
+Expected: FAIL — `shaColW` is not exported.
+
+- [ ] **Step 3: Make the widths functions of the scale**
+
+In `src/design/graph-geometry.ts`, keep every existing constant and its comment, and add beneath them:
+
+```ts
+// ─── Text-scaled widths ──────────────────────────────────────────────────────
+//
+// Every constant above is sized to TEXT: a sha is seven hex digits of
+// monospace, the Date column is the widest string its format can produce, the
+// subject floor is a readable number of characters. So they all move with the
+// user's Text size preset, or the column truncates the very thing it was sized
+// to hold — and for a sha or a timestamp, truncation destroys the meaning.
+//
+// `scale` defaults to 1 so a caller with no notion of the setting — tests, any
+// surface that never scales — gets exactly the pre-scale numbers. The avatar
+// (16px) and the flex gap after it are NOT type and do not scale; see
+// `authorMinW`.
+//
+// Rounded to a tenth, the same precision applyTextScale writes the ramp at, so
+// a template string never carries a 17-digit float.
+
+const px = (n: number): number => Math.round(n * 10) / 10;
+
+export const shaColW = (scale = 1): number => px(SHA_COL_W * scale);
+export const colPad = (scale = 1): number => px(COL_PAD * scale);
+export const subjectMinW = (scale = 1): number => px(SUBJECT_MIN_W * scale);
+export const authorColW = (scale = 1): number => px(AUTHOR_COL_W * scale);
+/** Avatar and gap are fixed; only the truncation gutter is type-sized. */
+export const authorMinW = (scale = 1): number => px(16 + 6 + COL_PAD * scale);
+export const dateColW = (fmt: DateFormat, scale = 1): number =>
+  px(DATE_COL_W[fmt] * scale);
+
+/**
+ * The narrowest the commit list may be dragged to, at a given text scale.
+ *
+ * Scaled with the columns it is the sum of — a floor that stayed at 420 while
+ * the columns grew would push the Date column off the right edge the moment
+ * someone picked Large, which is exactly the overflow
+ * `git-components.narrow.test.tsx` exists to prevent. `graphWidth` is not in
+ * the scale: lanes are dots and strokes in SVG user units, and they follow row
+ * HEIGHT, not type.
+ */
+export const commitListMinW = (scale = 1): number =>
+  Math.ceil(
+    graphWidth(4) +
+      shaColW(scale) +
+      subjectMinW(scale) +
+      authorMinW(scale) +
+      dateColW("relative", scale),
+  );
+```
+
+Then widen `commitRowGrid`:
+
+```ts
+export const commitRowGrid = (
+  graphW: number,
+  dateW: number = DATE_COL_W.relative,
+  scale = 1,
+): string => {
+  const cols =
+    `${shaColW(scale)}px minmax(${subjectMinW(scale)}px, 1fr) ` +
+    `minmax(${authorMinW(scale)}px, ${authorColW(scale)}px) ${dateW}px`;
+  return graphW > 0 ? `${graphW}px ${cols}` : cols;
+};
+```
+
+Extend its doc comment with: "`scale` is the user's Text size preset. It defaults to 1 for the same reason `dateW` defaults to the relative width — a caller that knows nothing about the setting gets exactly the old template."
+
+- [ ] **Step 4: Pass the scale from the two callers, and scale the date width**
+
+- `src/features/settings/useSettingsStore.ts` — `useDateColumnWidth`:
+
+```ts
+export function useDateColumnWidth(): number {
+  return dateColW(useDateFormat(), useTextScale());
+}
+```
+
+Change its import at the top of the file from `import { DATE_COL_W } from "@/design/graph-geometry";` to `import { dateColW } from "@/design/graph-geometry";`, and check whether `DATE_COL_W` is still referenced anywhere else in that file — if not, drop it from the import. Extend the function's doc comment: "…then hand the SAME number to `commitRowGrid`, which is what keeps the header aligned with the rows under it when the format OR the text size changes."
+
+- `src/design/git-components.tsx:1671` — `gridTemplateColumns: commitRowGrid(graphW, dateW),` → `gridTemplateColumns: commitRowGrid(graphW, dateW, textScale),`, where `textScale` is `useTextScale()` called at the top of the component beside `useRowH`.
+- `src/design/git-components.tsx:1729,1794` — `paddingRight: COL_PAD` → `paddingRight: colPad(textScale)`. Update the import on line 25 to bring in `colPad` and drop `COL_PAD` if it is no longer used there.
+- `src/screens/History.tsx:867` — `commitRowGrid(graphW, dateW)` → `commitRowGrid(graphW, dateW, textScale)`, with `const textScale = useTextScale();` beside the existing hooks in that component.
+- `src/screens/History.tsx:130` — `HEADER_LABEL`'s `paddingRight: COL_PAD` is a module-level constant, so it cannot call a hook. Leave the constant at `COL_PAD` and instead override it at the header's usage site with `paddingRight: colPad(textScale)` in the inline style, keeping the constant as the ×1 default. If `HEADER_LABEL` is spread into several header cells, add the override to each spread: `style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}`.
+- `src/screens/History.tsx:205` — `siblingMin: COMMIT_LIST_MIN_W,` → `siblingMin: commitListMinW(textScale),`. Confirm the enclosing function is a component or hook body so `useTextScale()` is legal there; if it is not, thread the value in from the caller rather than calling the hook.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```
+~/Library/pnpm/pnpm vitest run --project unit src/design src/screens/History.virtual.test.tsx src/features/settings
+~/Library/pnpm/pnpm tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(history): commit-row columns follow the text-size preset" -m "SHA_COL_W is seven hex digits of monospace and DATE_COL_W is the widest
+string its format can produce, so both are narrower than their own
+content at the larger presets -- and truncating a sha or a timestamp
+destroys the value rather than shortening it.
+
+COMMIT_LIST_MIN_W scales with the columns it is the sum of, because a
+floor left at 420 while the columns grew would push the Date column off
+the right edge the moment someone picked Large. The narrow-pane guard now
+runs at every preset and re-derives the sum from commitRowGrid's own
+template, so it still catches a new fixed column added to the grid and
+not to the formula.
+
+The avatar and its gap do not scale -- they are not type. Only the
+truncation gutter beside them does.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: The Appearance page
+
+**Files:**
+- Modify: `src/features/settings/pages/appearance.tsx:43` (meta) and `:181-196` (the control)
+- Test: `src/screens/Settings.appearance.test.tsx`
+
+**Interfaces:**
+- Consumes: `SPACING_STEP_PX`, `TEXT_SCALE`, `UiSpacing`, `UiTextScale` (Tasks 1–2).
+- Produces: settings-index row ids `appearance.textSize` and `appearance.spacing`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/screens/Settings.appearance.test.tsx`:
+
+```ts
+// Settings is a registry: a row absent from `meta` is a setting the search
+// cannot find, and hints are ReactNode and are NOT indexed -- which is why the
+// words a user would actually type live in `keywords`.
+describe("Appearance size controls", () => {
+  it("indexes both new size rows, and no longer the retired density row", () => {
+    const rows = meta.cards.flatMap((c) => c.rows);
+    const ids = rows.map((r) => r.id);
+    expect(ids).toContain("appearance.textSize");
+    expect(ids).toContain("appearance.spacing");
+    expect(ids).not.toContain("appearance.density");
+  });
+
+  // The vocabulary this build no longer displays still has to find its
+  // replacement: someone who learned the word "density" must land on Spacing.
+  it("keeps the retired vocabulary searchable on the spacing row", () => {
+    const row = meta.cards.flatMap((c) => c.rows).find((r) => r.id === "appearance.spacing")!;
+    for (const word of ["density", "compact", "comfortable"]) {
+      expect(row.keywords).toContain(word);
+    }
+  });
+
+  it("keeps font-size vocabulary searchable on the text row", () => {
+    const row = meta.cards.flatMap((c) => c.rows).find((r) => r.id === "appearance.textSize")!;
+    for (const word of ["font", "text", "larger"]) {
+      expect(row.keywords).toContain(word);
+    }
+  });
+});
+```
+
+Import `meta` from `@/features/settings/pages/appearance` at the top of that file if it is not already imported.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `~/Library/pnpm/pnpm vitest run --project unit src/screens/Settings.appearance.test.tsx`
+Expected: FAIL — `appearance.textSize` is not in the index.
+
+- [ ] **Step 3: Replace the meta row**
+
+`src/features/settings/pages/appearance.tsx:43` — replace the single `appearance.density` entry with two. Keep them adjacent and directly before `appearance.dateFormat` so the three size controls read as a group with `appearance.zoom`:
+
+```ts
+        { id: "appearance.textSize", label: "Text size", keywords: "font size text type bigger smaller larger readable accessibility scale" },
+        { id: "appearance.spacing", label: "Spacing", keywords: "density compact cozy comfortable spacious row height breathing room padding" },
+```
+
+- [ ] **Step 4: Replace the control**
+
+Replace the whole `<SettingsRow id="appearance.density" …/>` block (lines ~181–196) with:
+
+```tsx
+      <SettingsRow
+        id="appearance.textSize"
+        label="Text size"
+        hint={`Scales the type everywhere, code and diffs included — ${Math.round(
+          TEXT_SCALE.larger * 100,
+        )}% at the largest. Rows grow to fit it; icons and borders don’t — use Zoom below for those.`}
+        control={
+          <PGButtonGroup
+            size="sm"
+            value={s.uiTextScale}
+            onChange={(v) => s.set("uiTextScale", v as UiTextScale)}
+            options={[
+              { value: "small", label: "Small" },
+              { value: "default", label: "Default" },
+              { value: "large", label: "Large" },
+              { value: "larger", label: "Larger" },
+            ]}
+          />
+        }
+      />
+
+      <SettingsRow
+        id="appearance.spacing"
+        label="Spacing"
+        hint={`How much breathing room every list row gets — compact is the dense IDE feel, spacious adds ${SPACING_STEP_PX.spacious}px to each row.`}
+        control={
+          <PGButtonGroup
+            size="sm"
+            value={s.uiSpacing}
+            onChange={(v) => s.set("uiSpacing", v as UiSpacing)}
+            options={[
+              { value: "compact", label: "Compact" },
+              { value: "cozy", label: "Cozy" },
+              { value: "comfortable", label: "Comfortable" },
+              { value: "spacious", label: "Spacious" },
+            ]}
+          />
+        }
+      />
+```
+
+Update the imports at the top of the file: replace `DENSITY_STEP_PX` with `SPACING_STEP_PX, TEXT_SCALE`, and add the `UiSpacing` and `UiTextScale` types.
+
+- [ ] **Step 5: Check the button group fits**
+
+Four options with "Comfortable" in them is wider than the three-option Date format row beside it. Run the app or the component test and look at the control column. If it overflows, add `stacked` to the `SettingsRow` — the same escape hatch `appearance.headMarks` already uses — rather than shortening a label. Do NOT switch to a native `<select>`; a guard test fails the build.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run:
+```
+~/Library/pnpm/pnpm vitest run --project unit src/screens/Settings.appearance.test.tsx src/features/settings
+~/Library/pnpm/pnpm tsc --noEmit
+```
+Expected: PASS, including `settings.index.test.tsx`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(settings): Text size and Spacing controls in Appearance" -m "Two PGButtonGroups replace the binary UI density row, placed together
+above Zoom so the three size controls read as one group. Text size's hint
+names what it does NOT scale, so the difference from Zoom is on screen
+rather than inferred.
+
+The spacing row keeps density, compact and comfortable in its keywords:
+hints are ReactNode and are not indexed, so the vocabulary this build no
+longer displays would otherwise stop finding its own replacement.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: E2E, docs, and the full-suite gate
+
+**Files:**
+- Modify: `e2e/specs/settings.e2e.ts:50,248-330`
+- Modify: `docs/dev/frontend.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing new.
+
+- [ ] **Step 1: Read the e2e skill before touching the spec**
+
+Read `.claude/skills/e2e-testing/SKILL.md` in full. It is a hard requirement in `CLAUDE.md` before writing or debugging any e2e spec.
+
+- [ ] **Step 2: Update the e2e spec**
+
+`e2e/specs/settings.e2e.ts:248` — the case is titled "UI density scales every row surface, and compact restores them" and hardcodes `const STEP = 4; // DENSITY_STEP_PX.comfortable` at line 300.
+
+Retitle it "Spacing scales every row surface, and compact restores them", drive the new **Spacing** control instead of **UI density**, and keep `STEP = 4` by selecting **Comfortable** — the value and the label are both unchanged, so the assertions below it hold as written. Update the comment at line 300 to `// SPACING_STEP_PX.comfortable` and the one at line 50 to spell the new call-site form, `calc(Npx * var(--row-scale) + var(--row-step))`.
+
+Add one case beside it, since this is the axis no unit test can measure — jsdom does not resolve `calc()`, so a real webview is the only place the scaled ramp and the scaled row are observable together:
+
+```ts
+  it("Text size scales the type and the rows that hold it", async () => {
+    await openSettingsPage("appearance");
+    const before = await browser.execute(() => {
+      const el = document.querySelector('[data-testid="commit-row"]');
+      return {
+        fs: getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+        rowH: el ? Math.round(el.getBoundingClientRect().height) : 0,
+      };
+    });
+
+    await clickButtonGroupOption("appearance.textSize", "Larger");
+
+    const after = await browser.execute(() => {
+      const el = document.querySelector('[data-testid="commit-row"]');
+      return {
+        fs: getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+        rowH: el ? Math.round(el.getBoundingClientRect().height) : 0,
+      };
+    });
+
+    expect(after.fs).toBe("16.9px");
+    // The row has to grow with the type or it clips it — this is the whole
+    // point of --row-scale, and jsdom cannot see it.
+    expect(after.rowH).toBeGreaterThan(before.rowH);
+
+    await clickButtonGroupOption("appearance.textSize", "Default");
+    const restored = await browser.execute(
+      () => getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+    );
+    expect(restored).toBe("13px");
+  });
+```
+
+`openSettingsPage` and `clickButtonGroupOption` are illustrative names — use whatever helpers this spec file already defines for navigating Settings and clicking a `PGButtonGroup` option, reading them from the existing density case directly above. Do not invent a new helper if one is already there.
+
+- [ ] **Step 3: Type-check the e2e spec**
+
+Run: `~/Library/pnpm/pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean. The root `tsc` excludes `e2e/`, so this is a separate gate.
+
+- [ ] **Step 4: Update the docs**
+
+- `docs/dev/frontend.md` — find the density section. Rewrite it to cover both axes: the two tables and where they live, the `calc(<base>px * var(--row-scale) + var(--row-step))` call-site form, `useRowH` as the JS twin, the three JS geometries (diff pitch, commit-row columns, SVG graph gutter), and the §4 boundary — text size moves type, row bases and text-sized columns; Zoom is what moves icons, borders and gaps. Name `test/uiScale.test.ts` as the guard.
+- `CLAUDE.md` — in the design-system bullet, replace "New list-row surfaces opt into UI density (`var(--row-step)`)." with:
+
+```
+  New list-row surfaces opt into BOTH UI scales —
+  `calc(<base>px * var(--row-scale) + var(--row-step))`, base multiplied and
+  step added — or `test/uiScale.test.ts` fails the build; JS geometry uses
+  `useRowH()`.
+```
+
+Keep the edit to one bullet: `CLAUDE.md` is deliberately short and a new section needs a reason a pointer cannot serve.
+
+- [ ] **Step 5: Run the whole unit + docs suite**
+
+Run: `~/Library/pnpm/pnpm test`
+Expected: PASS. `test/docs.test.ts` reads `CLAUDE.md` and `docs/dev/` — if it fails, the doc set has fallen behind the tree; fix the doc, not the test.
+
+Note: `ImageDiffView` has a known ~1-in-111 flake. A red `unit` on a diff that never touched `features/diff` is that — re-run once before investigating.
+
+- [ ] **Step 6: Build the e2e snapshot and run the one spec**
+
+```bash
+cd /Users/jonas/dev/fun/platypusgit/.claude/worktrees/ui-scale
+~/Library/pnpm/pnpm test:e2e:docker build
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/settings.e2e.ts
+```
+
+Never rely on a stale snapshot after a `src/` change. Only one cold container build at a time across ALL worktrees.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add -A
+git commit -m "docs: the two UI scales, and an e2e case for the text one" -m "jsdom does not resolve calc(), so a real webview is the only place the
+scaled ramp and the scaled row can be observed together -- which is
+exactly the pair that breaks if the type grows and the base does not.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+
+git push -u origin feat/ui-scale
+```
+
+Then open the PR with `gh pr create --body-file <file>` (a `--body` with prose is refused in a worktree-isolated session). Verify the ruleset's `allowed_merge_methods` before merging — `gh api repos/:owner/:repo/rulesets/18319179` — and believe the ruleset over `CLAUDE.md` if they disagree.
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 settings + labels → Tasks 1, 2, 6. §1 defaults and upgrade → Task 1 Step 5. §1 migration incl. export/import → Task 1 Step 5 (`coerceSettings` is the single point both paths use — verified, `load()` calls it and so does `importSettings`). §2 spacing mechanism → Task 1. §2 ramp from JS → Task 2. §2 row bases → Task 3. §3 the three JS geometries → Task 4 (diff pitch, graph gutter) and Task 5 (columns). §4 scope boundary → stated in Task 2's `TEXT_SCALE` comment and Task 6's hint; the dead `--s-*` tokens are untouched by every task, as intended. §5 Appearance page → Task 6. §6 invariants 1–6 → ramp ascending (T2), line box (T2), narrow-pane at every preset (T5), migration (T1), `useDiffRowHeight` dependency (T4 Step 6 — covered by the changed deps; the assertion is the e2e case in T7, since jsdom cannot resolve the calc that produces the value). §7 documentation → Task 7.
+
+**Deviation from the spec, deliberate:** the spec named `PGSelect` for both controls. The plan uses `PGButtonGroup`, which is what every other small enum in the Appearance card uses (follow-mode, the retired density row, Date format) — a lone dropdown among button groups would be the inconsistent choice. `stacked` is the documented fallback if four options overflow.
+
+**Placeholder scan.** No TBD/TODO. Two steps are deliberately conditional rather than prescriptive and say exactly how to resolve themselves: Task 3 Step 1's `globSync` fallback (read `test/fileSave.test.ts` and copy its walker) and Task 7 Step 2's e2e helper names (read the density case directly above). Task 1 Step 8's `themeFiles.test.ts` edit depends on what the enclosing `it(…)` asserts, and says to read the title and keep its meaning.
+
+**Type consistency.** `useSpacingStep` (not `useDensityStep`) throughout Tasks 1, 4. `useTextScale()` returns the FACTOR, not the key — used that way in `useRowH`, `commitRowGrid`, `dateColW`, `commitListMinW`, and asserted as a number in the narrow test. `normalizeSpacing`/`normalizeTextScale` both take `unknown` and both read `DEFAULTS`. `applyTextScale` writes `--fs-*` AND `--row-scale`; `applySpacing` writes only `--row-step`. The graph-geometry functions all take `scale` last with a default of 1, and the bare ×1 constants stay exported because the tests and the functions both build on them.

--- a/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
+++ b/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
@@ -222,11 +222,17 @@ scale:
 shaColW(s)          = 70 * s
 dateColW(fmt, s)    = DATE_COL_W[fmt] * s
 subjectMinW(s)      = 140 * s
+authorColW(s)       = 150 * s                   // the author TRACK's width, sized to hold a name
 authorMinW(s)       = 16 + 6 + COL_PAD * s      // avatar and gap are not type
 colPad(s)           = 10 * s
 commitListMinW(s)   = ceil(graphWidth(4) + shaColW(s) + subjectMinW(s)
                            + authorMinW(s) + dateColW("relative", s))
 ```
+
+`authorColW` follows the same principle as `shaColW`/`dateColW`/`subjectMinW`: it
+is a width sized to hold TEXT — the author name, at its non-yielded track
+width — so it scales too. `authorMinW`, just below it, is the separate and
+smaller floor the author track yields DOWN to when the pane narrows.
 
 `graphWidth` is not scaled: lanes are dots and strokes in SVG user units, and
 under §4 they belong to row height, not to type. The avatar's 16px and the 6px

--- a/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
+++ b/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
@@ -262,10 +262,14 @@ spec does not start it.
 and immediately above `appearance.zoom` so the three size controls read as a
 group:
 
-- **Text size** — `PGSelect`, four options. Hint names what it does *not* do,
+- **Text size** — `PGButtonGroup`, four options — the control every other small
+  enum in this card uses (follow-mode, the retired density row, Date format);
+  `stacked` is the fallback if four options overflow, never a native select.
+  Hint names what it does *not* do,
   so the difference from Zoom is on screen rather than inferred: text only,
   chrome unchanged.
-- **Spacing** — `PGSelect`, four options. Hint states the per-row pixel delta,
+- **Spacing** — `PGButtonGroup`, four options. Hint states the per-row pixel
+  delta,
   read from `SPACING_STEP_PX` rather than written as a literal, the way the
   current hint reads `DENSITY_STEP_PX.comfortable`.
 

--- a/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
+++ b/docs/superpowers/specs/2026-09-11-ui-spacing-and-text-size-design.md
@@ -1,0 +1,323 @@
+# Global spacing + text size — spec
+
+No issue: requested directly — "lets add some settings for global spacing and
+font size, the app can feel a bit dense some times and for some users it might
+be better to have a bit larger font and more spacing. replace the 'comfortable'
+'dense' ui settings."
+
+## What exists today, and why it is not enough
+
+Appearance has one row-geometry control: **UI density**, a two-value select
+(`compact` | `comfortable`) backed by `DENSITY_STEP_PX = { compact: 0,
+comfortable: 4 }`. `applyDensity` writes the chosen number to `--row-step` on
+`:root`, and 26 style call sites opt in with `calc(<their base>px + var(--row-step))`
+— or `calc(<base>px + var(--row-step) / 2)` for vertical padding, since top and
+bottom each take half. Compact is 0 by definition, so the shipped default is
+pixel-identical to the pre-density layout.
+
+Two things are missing from that.
+
+**It is binary.** The whole range on offer is four pixels. "Feels dense" is not
+a yes/no question, and a user who wants a genuinely roomy list has nothing to
+pick.
+
+**It does not touch type at all.** Density moves rows apart; it does not make
+a single character larger. A user who finds 13px body text hard to read gets no
+help from it. The type ramp — `--fs-10` through `--fs-40`, used at 380 sites
+across 85 files — is fixed at build time.
+
+There is a third control that *does* move type: **Zoom** (`--fs`-agnostic,
+60–240%, `Mod+=` / `Mod+-` / `Mod+0`), which scales the entire UI through the
+webview's own zoom factor. It is not a substitute for a text-size setting,
+because it is deliberately uniform: it grows borders, icons, the titlebar and
+whitespace along with the text. Someone who wants *readable text in the same
+amount of screen* cannot express that with zoom, and someone who wants *roomier
+rows at the same text size* cannot either.
+
+## The decision: three knobs, each doing one thing
+
+Zoom stays exactly as it is. Density is replaced by two independent settings.
+The three compose, and each answers a question the other two cannot:
+
+| Control | Scales | Answers |
+|---|---|---|
+| **Zoom** (unchanged) | everything — type, chrome, icons, borders | "this whole app is too small on my display" |
+| **Text size** (new) | the type ramp, row bases, text-derived column widths | "I want to read the text without giving up rows" |
+| **Spacing** (new, replaces density) | row heights and row padding | "the lists feel cramped" |
+
+Keeping all three is a deliberate cost: the Appearance page grows to three size
+controls. The alternative — folding text size into zoom — was rejected because
+whole-UI zoom is the only one of the three that cannot answer either half of the
+request without also answering the other.
+
+## §1 — The settings
+
+`uiDensity` is retired. Two persisted keys replace it.
+
+```ts
+export const SPACING_STEP_PX = {
+  compact: 0,
+  cozy: 2,
+  comfortable: 4,
+  spacious: 8,
+} as const;
+export type UiSpacing = keyof typeof SPACING_STEP_PX;
+
+export const TEXT_SCALE = {
+  small: 0.92,
+  default: 1,
+  large: 1.15,
+  larger: 1.3,
+} as const;
+export type UiTextScale = keyof typeof TEXT_SCALE;
+```
+
+Labels in the picker are **Compact · Cozy · Comfortable · Spacious** and
+**Small · Default · Large · Larger**. Every spacing label describes what it
+looks like rather than which one ships, so the default stays findable by
+appearance and the vocabulary does not go stale if the default ever moves.
+`Compact` and `Comfortable` keep their current meanings and their current pixel
+values, so an upgrading user recognises both.
+
+### Defaults, and what happens on upgrade
+
+**The shipped default becomes `cozy` (+2px), and an existing install on
+`compact` is migrated to `cozy`.** `comfortable` stays `comfortable`.
+
+This moves pixels under existing users, which is the kind of thing this codebase
+normally refuses to do, so the reasoning is worth stating plainly. The premise
+of the request is that *today's shipped default is too dense*. A persisted
+`uiDensity: "compact"` cannot be distinguished from "never touched it" —
+`load()` fills missing keys from `DEFAULTS` and the result is written back — so
+grandfathering `compact` means the fix reaches new installs only, which is
+nobody who has already formed the opinion that prompted it. Two pixels per row
+is a mild change, it is one click reversible, and there is direct precedent in
+this same function: the `headIndicator` → `headMarks` migration deliberately
+lands an upgraded install on a *more* visible value, with the reasoning written
+at the call site.
+
+`uiTextScale` defaults to `default` (×1) on every install, new or upgraded.
+Nobody's type changes size without asking.
+
+### Migration
+
+In `load()`, mirroring the `headIndicator` → `headMarks` shape — reading
+`parsed`, not `out`, because the old key is gone from the schema and the copy
+loop never picks it up:
+
+```
+parsed.uiDensity === "comfortable"  → uiSpacing: "comfortable"
+parsed.uiDensity === "compact"      → uiSpacing: "cozy"       (see above)
+parsed.uiSpacing present and known  → itself (wins over uiDensity)
+anything else                       → DEFAULTS.uiSpacing
+```
+
+Both keys are normalized on the way in, for the reason the current
+`normalizeDensity` documents: an unrecognized key emits `--row-step:
+undefinedpx`, and one invalid substitution makes every `calc(Npx +
+var(--row-step))` compute to `auto`, collapsing the height of every row in the
+app at once. A text scale has the same failure mode one step worse, since it
+writes ten tokens rather than one.
+
+Settings **export/import** carries `uiSpacing` and `uiTextScale` in place of
+`uiDensity`, and an imported payload from an older build migrates through the
+same path — an exported file is the same shape as stored state, so the migration
+cannot live only in `load()`'s storage branch.
+
+## §2 — Mechanism
+
+### Spacing: almost nothing to build
+
+`DENSITY_STEP_PX` → `SPACING_STEP_PX` with four entries; `applyDensity` →
+`applySpacing`; `useDensityStep` → `useSpacingStep`. Every one of the 26
+existing `var(--row-step)` style call sites responds with no edit, because they were
+written against a variable rather than against the two values it used to hold.
+This is the part of the feature that the existing design already paid for.
+
+### Text: the ramp, written from JS
+
+A new `applyTextScale(scale)` writes **the whole resolved `--fs-*` ramp** onto
+`:root` as px values, computed from one JS table. It deliberately mirrors
+`applySpacing`: JS owns the numbers, and `index.css` declares the ×1 ramp only
+as a pre-hydration default so there is no flash of unscaled type before the
+store applies.
+
+The rejected alternative was declaring the ramp in CSS as
+`--fs-13: calc(13px * var(--ui-text-scale))`. It reads better, but it turns
+`--diff-row-h: calc(var(--fs-12) * var(--lh-code))` into a nested `calc()`
+inside an *unregistered* custom property, and `readDiffRowHeight` already
+carries a fallback for exactly the case where that value does not resolve to px
+("notably jsdom, which does not evaluate calc()"). Writing resolved px keeps
+`--diff-row-h` a one-level calc, unchanged, and keeps the resolution question
+from ever arising in the webview.
+
+Values are rounded to one decimal (`Math.round(px * 10) / 10`). Not to whole
+pixels: two adjacent steps of the ramp are 1px apart at the small end, and
+rounding ×0.92 or ×1.15 to integers can collapse or reorder them.
+
+| token | ×0.92 | ×1 | ×1.15 | ×1.3 |
+|---|---|---|---|---|
+| `--fs-10` | 9.2 | 10 | 11.5 | 13 |
+| `--fs-11` | 10.1 | 11 | 12.7 | 14.3 |
+| `--fs-12` | 11 | 12 | 13.8 | 15.6 |
+| `--fs-13` | 12 | 13 | 15 | 16.9 |
+| `--fs-14` | 12.9 | 14 | 16.1 | 18.2 |
+| `--fs-15` | 13.8 | 15 | 17.3 | 19.5 |
+| `--fs-17` | 15.6 | 17 | 19.6 | 22.1 |
+| `--fs-20` | 18.4 | 20 | 23 | 26 |
+| `--fs-28` | 25.8 | 28 | 32.2 | 36.4 |
+| `--fs-40` | 36.8 | 40 | 46 | 52 |
+
+### Text: the row bases
+
+The 26 row surfaces set `height:`, not `min-height:`. At ×1.3 a 13px label
+becomes 16.9px, whose line box at `--lh-body` is 24.5px — taller than the 22px
+and 24px row bases in use. Text clips unless the bases scale too.
+
+`applyTextScale` therefore also writes `--row-scale` (the raw factor), and those
+call sites become:
+
+```
+calc(<base>px * var(--row-scale) + var(--row-step))
+calc(<base>px * var(--row-scale) + var(--row-step) / 2)   /* padding */
+```
+
+`grep -rn 'var(--row-step)' src/` still enumerates every participant, so the
+discovery mechanism `index.css` documents survives unchanged — as does the note
+that Settings' rows take the step from `densityPadding()` / `SETTINGS_ROW_PADDING`
+in `SettingsCard.tsx` rather than inline, and must be included in that grep.
+
+Two alternatives were rejected:
+
+- **Folding text scale into `--row-step`** (one additive number for both). A
+  48px pull-request row and a 22px chip need different *absolute* growth for
+  the same proportional change; a single additive step over-grows the short row
+  and under-grows the tall one. It also destroys the meaning of
+  `useSpacingStep`, which several surfaces read as a number.
+- **Switching the rows to `min-height`**, letting them grow on their own. Self
+  correcting and arithmetic-free, but History, DiffViewer, Branches and
+  RepoBrowser are windowed: a row whose height the window cannot predict
+  desyncs the window from the rows it is measuring. That is the #70 lesson, and
+  applying `min-height` only to the unwindowed surfaces would leave two rules
+  where there is currently one.
+
+## §3 — The JS geometry that must follow the text scale
+
+Three places restate geometry in TypeScript and will not move on their own.
+
+**1. `lib/useDiffRowHeight.ts`.** It re-reads `--diff-row-h` when
+`useDensityStep()` changes. But `--diff-row-h` is derived from `--fs-12`, so it
+moves with *text*, not with spacing — today's dependency is the one axis that
+cannot change it. It takes the text scale as a dependency; keeping the spacing
+dep as well is harmless and cheap.
+
+**2. `design/graph-geometry.ts`.** `SHA_COL_W = 70` is documented as "seven hex
+digits of monospace, plus the gap"; `DATE_COL_W` is sized to a rendered date
+string. At ×1.3 both columns are narrower than the text they exist to hold, and
+a fixed column that cannot fit its content truncates a sha or a timestamp —
+values where truncation destroys the meaning. They become functions of the
+scale:
+
+```
+shaColW(s)          = 70 * s
+dateColW(fmt, s)    = DATE_COL_W[fmt] * s
+subjectMinW(s)      = 140 * s
+authorMinW(s)       = 16 + 6 + COL_PAD * s      // avatar and gap are not type
+colPad(s)           = 10 * s
+commitListMinW(s)   = ceil(graphWidth(4) + shaColW(s) + subjectMinW(s)
+                           + authorMinW(s) + dateColW("relative", s))
+```
+
+`graphWidth` is not scaled: lanes are dots and strokes in SVG user units, and
+under §4 they belong to row height, not to type. The avatar's 16px and the 6px
+flex gap after it are likewise not type.
+
+Scaling `COMMIT_LIST_MIN_W` with the columns it is the sum of is what keeps the
+yield order intact at every preset: a floor that stayed at 420 while the columns
+grew would push the Date column off the right edge at Large, which is precisely
+the failure `git-components.narrow.test.tsx` exists to prevent.
+
+**3. `design/git-components.tsx`.** `ROW_H` (the JS twin of `--row-h`) and the
+number `PGCommitRow` feeds `PGGraphRow`, which draws in SVG user units and
+cannot read the CSS token. Both take the scale.
+
+## §4 — Scope boundary
+
+Text size moves **type, row bases, and text-derived column widths**. It does
+**not** scale icons, borders, strokes, shadows, gaps or graph lanes. Zoom is the
+control that scales those, and the two composing is the reason all three knobs
+exist. A user at Larger text with 16px icons has slightly small icons; a user
+who wants everything bigger has Zoom, one row up in the same card.
+
+Also explicitly out of scope: the dead `--s-1` … `--s-8` spacing tokens in
+`index.css`. They are declared and used at **zero** sites — every padding and
+gap in the app is a hardcoded inline literal — so "global spacing" cannot mean
+"scale the spacing tokens". It means the row-step mechanism, widened. Reviving
+the spacing scale across the codebase is a separate, much larger change and this
+spec does not start it.
+
+## §5 — The Appearance page
+
+`appearance.density` is replaced by two rows in the same card, placed together
+and immediately above `appearance.zoom` so the three size controls read as a
+group:
+
+- **Text size** — `PGSelect`, four options. Hint names what it does *not* do,
+  so the difference from Zoom is on screen rather than inferred: text only,
+  chrome unchanged.
+- **Spacing** — `PGSelect`, four options. Hint states the per-row pixel delta,
+  read from `SPACING_STEP_PX` rather than written as a literal, the way the
+  current hint reads `DENSITY_STEP_PX.comfortable`.
+
+`meta.cards[].rows` gains both ids. Settings is a registry: a row absent from
+`meta` fails `settings.index.test.tsx`, and a word that lives only in a `hint`
+is not indexed. Keywords therefore retain **density, compact, cozy, comfortable,
+spacious, row height, spacing** on the spacing row and **font size, text, type,
+bigger, smaller, larger, readable, accessibility** on the text row — so a user
+searching the word this build no longer displays still lands on its replacement.
+
+## §6 — Invariants, each a guard test
+
+The presets are a finite set, which is the point of making them presets: every
+property below can be asserted across all four rather than sampled.
+
+1. **The ramp stays strictly ascending at every text preset.** The rounding
+   step is what could break it, and a collapsed or reordered pair would make two
+   different type roles render identically with nothing on screen saying why.
+2. **Every row base clears its own line box at every text preset** — for the
+   smallest base in use (22px) against `--fs-13 × --lh-body`. This is the
+   clipping guard, and it is the assertion that would have failed had we scaled
+   the ramp without scaling the bases.
+3. **Sum of column minimums ≤ `commitListMinW(s)` at every text preset**,
+   extending `git-components.narrow.test.tsx`. Since `commitListMinW` is defined
+   as that sum, the test must re-derive the sum from `commitRowGrid`'s own
+   template rather than from the same expression, or it asserts nothing — what
+   it is there to catch is a *new* fixed column added to the grid and not to the
+   formula.
+4. **Migration:** `uiDensity: "comfortable"` → `uiSpacing: "comfortable"`;
+   `uiDensity: "compact"` → `uiSpacing: "cozy"`; a stored `uiSpacing` wins over
+   a stale `uiDensity`; an unknown value in either key falls back to its
+   default rather than emitting `undefinedpx`.
+5. **`useDiffRowHeight` re-reads on a text-scale change** — the dependency that
+   is wrong today.
+6. **Export/import round-trips both keys**, and an exported payload carrying
+   the old `uiDensity` migrates on import.
+
+Existing tests to update: `git-components.density.test.tsx` (renamed to cover
+both axes), `git-components.narrow.test.tsx`, `Settings.appearance.test.tsx`,
+`useSettingsStore.test.ts`, `useSettingsStore.export.test.ts`,
+`SettingsCard.test.tsx`, `skeleton.test.tsx`, and `e2e/specs/settings.e2e.ts`.
+
+## §7 — Documentation
+
+- `index.css` — the `===== DENSITY =====` comment block is the written
+  contract for `--row-step`. It becomes the contract for `--row-step` *and*
+  `--row-scale`, including the `* var(--row-scale)` call-site form and the
+  unchanged grep.
+- `docs/dev/frontend.md` — the density section gains the text scale, the three
+  JS geometries of §3, and the §4 boundary against Zoom.
+- `CLAUDE.md` — the design-system bullet currently says new list-row surfaces
+  opt into UI density (`var(--row-step)`); it must name both vars.
+- Changelog — this is the rare change that moves an existing user's pixels
+  without being asked, so it needs an entry that says so and names the control
+  that reverses it.

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -43,12 +43,13 @@ async function clickSettingsToggleRow(labelText: string, settingId: string): Pro
 }
 
 /**
- * Measure the rendered height of one row per density mechanism.
+ * Measure the rendered height of one row per row-geometry mechanism.
  *
  * There is no repo truth for a layout setting, so rendered geometry IS the
  * acceptance here — and it can only be measured in a real webview: the tokens
- * are `calc(Npx + var(--row-step))`, which jsdom does not resolve (the store
- * side is unit-tested in src/features/settings/useSettingsStore.test.ts).
+ * are `calc(Npx * var(--row-scale) + var(--row-step))`, which jsdom does not
+ * resolve (the store side is unit-tested in
+ * src/features/settings/useSettingsStore.test.ts).
  *
  * Measures via `getSize("height")` on the same elements it waits for, so a
  * selector change surfaces as "row never appeared" rather than as a wrong
@@ -245,13 +246,23 @@ describe("settings", () => {
     );
   });
 
-  it("UI density scales every row surface, and compact restores them", async () => {
+  it("Spacing scales every row surface, and compact restores them", async () => {
     repo = dirtyRepo(); // a.txt unstaged, so CommitPanel has a change row
     await openRepo(repo.path);
 
+    // The app's OWN default is "cozy" (Task 1's compact -> cozy migration),
+    // not "compact" — so the zero-step baseline has to be SELECTED, not read
+    // off a freshly opened repo, or this measures cozy's +2 instead of 0.
+    await openSettings("general.appearance");
+    await $("button*=Compact").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Compact').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Compact never became active" },
+    );
+
     const compact = await measureRows();
-    // Compact is the pre-density baseline — pinned so a future token edit
-    // can't silently reflow the default layout.
+    // Compact is the pre-spacing baseline — pinned so a future token edit
+    // can't silently reflow the zero-step layout.
     expect(compact).toEqual({
       changeRow: 24, branchRow: 28, commitRow: 26, graphSvg: 26,
     });
@@ -280,7 +291,7 @@ describe("settings", () => {
   });
 
   /**
-   * The Settings panel's OWN rows resolve the density calc.
+   * The Settings panel's OWN rows resolve the spacing calc.
    *
    * `measureRows` above covers the four surfaces outside Settings. These two
    * are the ones no unit test can reach: jsdom does not resolve `calc()`, so
@@ -296,13 +307,13 @@ describe("settings", () => {
    * It is here because a fixed height there gives ONE card two row pitches,
    * which is the same bug as a forge row that does not scale.
    */
-  it("Settings rows resolve the density calc, by exactly one step", async () => {
-    const STEP = 4; // DENSITY_STEP_PX.comfortable
+  it("Settings rows resolve the spacing calc, by exactly one step", async () => {
+    const STEP = 4; // SPACING_STEP_PX.comfortable
 
     const measureSettings = async () => {
-      const row = $('[data-setting-id="appearance.density"]');
+      const row = $('[data-setting-id="appearance.spacing"]');
       await row.waitForDisplayed({
-        timeout: 10_000, timeoutMsg: "density row never appeared for measurement",
+        timeout: 10_000, timeoutMsg: "spacing row never appeared for measurement",
       });
       const strip = $('[data-testid="theme-actions"]');
       await strip.waitForDisplayed({
@@ -315,6 +326,14 @@ describe("settings", () => {
     };
 
     await openSettings("general.appearance");
+    // The app's own default is "cozy", not "compact" (Task 1's migration) —
+    // select Compact explicitly so the delta below is measured from a true
+    // zero step, not from cozy's already-nonzero one.
+    await $("button*=Compact").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Compact').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Compact never became active" },
+    );
     const compact = await measureSettings();
 
     await $("button*=Comfortable").click();
@@ -335,6 +354,58 @@ describe("settings", () => {
       { timeout: 10_000, timeoutMsg: "Compact never became active" },
     );
     expect(await measureSettings()).toEqual(compact);
+  });
+
+  /**
+   * Text size is the axis no unit test can measure end to end: jsdom does not
+   * resolve `calc()`, so the store side only proves the token STRING is
+   * written (`useSettingsStore.test.ts`), never that a row grown from it
+   * actually clears the bigger type sitting inside it. A real webview is the
+   * only place the scaled `--fs-13` ramp and the scaled row box are
+   * observable together — reuses `measureRows()` rather than restating its
+   * screen-switching, exactly as the spacing case above does.
+   */
+  it("Text size scales the type and the rows that hold it", async () => {
+    repo = dirtyRepo(); // a.txt unstaged, so CommitPanel has a change row
+    await openRepo(repo.path);
+
+    const before = await measureRows();
+    const fsBefore = await browser.execute(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+    );
+    expect(fsBefore).toBe("13px");
+
+    await openSettings("general.appearance");
+    await $("button*=Larger").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Larger').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Larger never became active" },
+    );
+
+    const fsAfter = await browser.execute(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+    );
+    expect(fsAfter).toBe("16.9px");
+
+    // The row has to grow with the type or it clips it — this is the whole
+    // point of --row-scale, and jsdom cannot see it.
+    const after = await measureRows();
+    expect(after.commitRow).toBeGreaterThan(before.commitRow);
+    expect(after.graphSvg).toBeGreaterThan(before.graphSvg);
+    expect(after.changeRow).toBeGreaterThan(before.changeRow);
+    expect(after.branchRow).toBeGreaterThan(before.branchRow);
+
+    await openSettings("general.appearance");
+    await $("button*=Default").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Default').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Default never became active" },
+    );
+    const fsRestored = await browser.execute(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--fs-13").trim(),
+    );
+    expect(fsRestored).toBe("13px");
+    expect(await measureRows()).toEqual(before);
   });
 
   it("confirmForcePush=off skips the confirm entirely", async () => {

--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -741,7 +741,7 @@ export function PGSidebarRow({
         display: "flex",
         alignItems: "center",
         gap: 6,
-        height: "calc(22px + var(--row-step))",
+        height: "calc(22px * var(--row-scale) + var(--row-step))",
         padding: `0 8px 0 ${8 + indent * 12}px`,
         background: selected
           ? "var(--bg-selection)"

--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -122,10 +122,12 @@ export interface PGTabItem {
  * scrolling strip in there would eat `data-tauri-drag-region` on a narrow
  * window.
  *
- * Chrome, so a FIXED height — the UI-density token deliberately does not apply
- * (see CLAUDE.md's density rule). The strip owns its own `overflow-x`, and each
- * tab is `flexShrink: 0` with a max width, so a long tab list scrolls INSIDE
- * the strip and can never widen the window (the shell is a fixed frame).
+ * Chrome, so a FIXED height — it deliberately opts into neither UI scale (see
+ * CLAUDE.md's rule that list-row surfaces opt into both `--row-scale` and
+ * `--row-step`; this strip is chrome, not a list row, and sits that rule out).
+ * The strip owns its own `overflow-x`, and each tab is `flexShrink: 0` with a
+ * max width, so a long tab list scrolls INSIDE the strip and can never widen
+ * the window (the shell is a fixed frame).
  *
  * The `+` sits INSIDE that scroller, immediately after the last tab (issue 178),
  * where browsers and editors put it — not pinned to the far right, which is the

--- a/src/design/git-components.density.test.tsx
+++ b/src/design/git-components.density.test.tsx
@@ -36,7 +36,7 @@ function renderCommitRow() {
 }
 
 beforeEach(() => {
-  useSettingsStore.getState().set("uiDensity", "compact");
+  useSettingsStore.getState().set("uiSpacing", "compact");
 });
 
 describe("PGCommitRow density", () => {
@@ -50,7 +50,7 @@ describe("PGCommitRow density", () => {
   // Literal 30, not COMMIT_ROW_BASE_H + step: if either the base or the step
   // moves, this fails rather than following along silently.
   it("grows row and graph gutter together when density is comfortable", () => {
-    useSettingsStore.getState().set("uiDensity", "comfortable");
+    useSettingsStore.getState().set("uiSpacing", "comfortable");
     const { row, svg } = renderCommitRow();
     expect(row.style.height).toBe("30px");
     expect(svg.getAttribute("height")).toBe("30");
@@ -65,7 +65,7 @@ describe("PGCommitRow density", () => {
     expect(svg.getAttribute("height")).toBe("26");
 
     act(() => {
-      useSettingsStore.getState().set("uiDensity", "comfortable");
+      useSettingsStore.getState().set("uiSpacing", "comfortable");
     });
 
     expect(row.style.height).toBe("30px");

--- a/src/design/git-components.narrow.test.tsx
+++ b/src/design/git-components.narrow.test.tsx
@@ -23,14 +23,18 @@ import { PGCommitRow } from "./git-components";
 import {
   AUTHOR_COL_W,
   AUTHOR_MIN_W,
-  COL_PAD,
-  COMMIT_LIST_MIN_W,
   DATE_COL_W,
   SHA_COL_W,
   SUBJECT_MIN_W,
+  authorMinW,
+  colPad,
+  commitListMinW,
   commitRowGrid,
+  dateColW,
   graphWidth,
+  shaColW,
 } from "./graph-geometry";
+import { TEXT_SCALE } from "@/features/settings/useSettingsStore";
 
 describe("commitRowGrid yield order", () => {
   it("floors the subject and lets the author name shrink to its avatar", () => {
@@ -52,21 +56,48 @@ describe("commitRowGrid yield order", () => {
 
   // The floors are only worth anything if they FIT. Past the sum of the
   // minimum tracks the grid overflows its pane and the date falls off the
-  // right edge, so the narrowest pane the app can produce has to hold them:
-  // COMMIT_LIST_MIN_W is that pane. Raising a column's minimum — or the Date
-  // column's width — without checking this is how the row starts overflowing
-  // again at the bottom of the drag.
-  it("fits every minimum inside the narrowest commit list", () => {
-    const min =
-      graphWidth(4) + SHA_COL_W + SUBJECT_MIN_W + AUTHOR_MIN_W + DATE_COL_W.relative;
-    expect(min).toBeLessThanOrEqual(COMMIT_LIST_MIN_W);
+  // right edge, so the narrowest pane the app can produce has to hold them.
+  //
+  // Asserted at EVERY text preset, not only at x1: the columns are sized to
+  // text, so they all move together and a floor that stayed at 420 would push
+  // the Date column off the edge the moment someone picked Large. The sum is
+  // re-derived from commitRowGrid's own template rather than from the same
+  // expression commitListMinW uses -- otherwise this asserts nothing, and what
+  // it is here to catch is a NEW fixed column added to the grid and not to the
+  // formula.
+  it("fits every minimum inside the narrowest commit list, at every text preset", () => {
+    for (const scale of Object.values(TEXT_SCALE)) {
+      const template = commitRowGrid(graphWidth(4), dateColW("relative", scale), scale);
+      const tracks = template.split(" ");
+      const sum = tracks.reduce((acc, t) => {
+        const px = /^(\d+(?:\.\d+)?)px$/.exec(t);
+        if (px) return acc + Number.parseFloat(px[1]);
+        const mm = /^minmax\((\d+(?:\.\d+)?)px,/.exec(t);
+        if (mm) return acc + Number.parseFloat(mm[1]);
+        return acc;
+      }, 0);
+      expect(sum, `scale ${scale}`).toBeLessThanOrEqual(commitListMinW(scale));
+    }
   });
 
-  // Avatar 16px, the flex gap after it, and COL_PAD: below that the "who" goes
-  // as well as the name — a column that costs space and says nothing — or the
-  // avatar ends up touching the date.
-  it("keeps the author's avatar inside the author minimum", () => {
-    expect(AUTHOR_MIN_W).toBeGreaterThanOrEqual(16 + 6 + COL_PAD);
+  // The avatar and the flex gap after it are not type, so they do not scale --
+  // but COL_PAD does, because it exists to make the NAME truncate before it
+  // touches the date. Below this the "who" goes as well as the name.
+  it("keeps the author's avatar inside the author minimum at every preset", () => {
+    for (const scale of Object.values(TEXT_SCALE)) {
+      expect(authorMinW(scale), `scale ${scale}`).toBeGreaterThanOrEqual(
+        16 + 6 + colPad(scale),
+      );
+    }
+  });
+
+  // A sha is seven hex digits of monospace: the column is sized to text, so it
+  // has to move with text or it truncates the one value truncation destroys.
+  it("grows the sha and date columns with the text scale", () => {
+    expect(shaColW(1)).toBe(SHA_COL_W);
+    expect(shaColW(1.3)).toBeGreaterThan(SHA_COL_W);
+    expect(dateColW("relative", 1)).toBe(DATE_COL_W.relative);
+    expect(dateColW("relative", 1.3)).toBeGreaterThan(DATE_COL_W.relative);
   });
 });
 

--- a/src/design/git-components.narrow.test.tsx
+++ b/src/design/git-components.narrow.test.tsx
@@ -23,6 +23,8 @@ import { PGCommitRow } from "./git-components";
 import {
   AUTHOR_COL_W,
   AUTHOR_MIN_W,
+  COL_PAD,
+  COMMIT_LIST_MIN_W,
   DATE_COL_W,
   SHA_COL_W,
   SUBJECT_MIN_W,
@@ -70,14 +72,27 @@ describe("commitRowGrid yield order", () => {
       const template = commitRowGrid(graphWidth(4), dateColW("relative", scale), scale);
       const tracks = template.split(" ");
       const sum = tracks.reduce((acc, t) => {
-        const px = /^(\d+(?:\.\d+)?)px$/.exec(t);
-        if (px) return acc + Number.parseFloat(px[1]);
+        const pxMatch = /^(\d+(?:\.\d+)?)px$/.exec(t);
+        if (pxMatch) return acc + Number.parseFloat(pxMatch[1]);
         const mm = /^minmax\((\d+(?:\.\d+)?)px,/.exec(t);
         if (mm) return acc + Number.parseFloat(mm[1]);
         return acc;
       }, 0);
       expect(sum, `scale ${scale}`).toBeLessThanOrEqual(commitListMinW(scale));
     }
+  });
+
+  // COL_PAD and COMMIT_LIST_MIN_W are the only two ×1 constants no production
+  // code calls by their bare name any more (git-components.tsx and
+  // History.tsx now call colPad()/commitListMinW() instead), so without an
+  // explicit pin here nothing in the suite would notice if the functions ever
+  // drifted from the literals: COMMIT_LIST_MIN_W's own doc comment claims it
+  // is EXACTLY graphWidth(4) + SHA + SUBJECT_MIN + AUTHOR_MIN + DATE, and a
+  // silent drift would mean History's pane-drag floor stopped matching the
+  // width the yield order above was tuned against.
+  it("keeps the ×1 scale functions equal to the constants they replaced", () => {
+    expect(colPad(1)).toBe(COL_PAD);
+    expect(commitListMinW(1)).toBe(COMMIT_LIST_MIN_W);
   });
 
   // The avatar and the flex gap after it are not type, so they do not scale --

--- a/src/design/git-components.scale.test.tsx
+++ b/src/design/git-components.scale.test.tsx
@@ -1,8 +1,9 @@
-// PGCommitRow is the one density surface that cannot be pure CSS: PGGraphRow
+// PGCommitRow is the one row-scale surface that cannot be pure CSS: PGGraphRow
 // draws its lanes in SVG user units (`y2={height}`, bezier control points at
 // `height / 2`), so the row box and the graph gutter must agree on the SAME
-// number. A `calc()` on the row alone would desync the curves from the row
-// pitch — the most visible list in the app. These tests pin them together.
+// number for BOTH axes — the spacing step and the text scale. A `calc()` on
+// the row alone would desync the curves from the row pitch — the most visible
+// list in the app. These tests pin them together.
 import { describe, it, expect, beforeEach } from "vitest";
 import { act, render } from "@testing-library/react";
 
@@ -37,9 +38,10 @@ function renderCommitRow() {
 
 beforeEach(() => {
   useSettingsStore.getState().set("uiSpacing", "compact");
+  useSettingsStore.getState().set("uiTextScale", "default");
 });
 
-describe("PGCommitRow density", () => {
+describe("PGCommitRow row scale", () => {
   it("keeps the compact row at its pre-density height", () => {
     const { row, svg } = renderCommitRow();
     expect(COMMIT_ROW_BASE_H).toBe(26); // the pre-density height, pinned
@@ -89,5 +91,27 @@ describe("PGCommitRow density", () => {
       container.querySelector<HTMLElement>('[data-testid="commit-row"]')!.style.height,
     ).toBe("40px");
     expect(container.querySelector("svg")!.getAttribute("height")).toBe("40");
+  });
+
+  // The graph gutter is drawn in SVG user units, so it cannot read
+  // --row-scale. If PGCommitRow does not hand it the same number the row box
+  // used, the lane curves stop meeting the dots -- in the most visible list in
+  // the app. Literals, not the expression: if either input moves this fails
+  // rather than following along silently.
+  it("grows row and graph gutter together when the text scale changes", () => {
+    useSettingsStore.getState().set("uiTextScale", "larger");
+    const { row, svg } = renderCommitRow();
+    // COMMIT_ROW_BASE_H 26 x 1.3 = 33.8, + compact step 0
+    expect(row.style.height).toBe("33.8px");
+    expect(svg.getAttribute("height")).toBe("33.8");
+  });
+
+  it("adds the spacing step on top of the scaled base", () => {
+    useSettingsStore.getState().set("uiTextScale", "large");
+    useSettingsStore.getState().set("uiSpacing", "spacious");
+    const { row, svg } = renderCommitRow();
+    // 26 x 1.15 = 29.9, + spacious step 8
+    expect(row.style.height).toBe("37.9px");
+    expect(svg.getAttribute("height")).toBe("37.9");
   });
 });

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -15,7 +15,7 @@ import {
 } from "./primitives";
 import {
   useDateColumnWidth,
-  useSpacingStep,
+  useRowH,
 } from "@/features/settings/useSettingsStore";
 import {
   NO_HEAD_DECOR,
@@ -266,9 +266,9 @@ export function flattenFileTree(
 
 /**
  * Base row height in px, matching `--row-h: calc(24px * var(--row-scale) + var(--row-step))`
- * (`index.css`). A windowing caller needs the pitch as a NUMBER and must add
- * `useSpacingStep()`; a literal would desync the window from the rows in
- * comfortable density (#70). Keep in sync with the token.
+ * (`index.css`). A windowing caller needs the pitch as a NUMBER and must get
+ * it from `useRowH()`; a literal would desync the window from the rows at
+ * any preset but the default (#70). Keep in sync with the token.
  */
 export const FILE_TREE_ROW_BASE_H = 24;
 
@@ -1338,10 +1338,10 @@ const HEAD_RING_R = 6.5;
  * `height` is REQUIRED and must be the caller's actual row pitch in px.
  *
  * The lane geometry below is in SVG user units (`y2={height}`, bezier control
- * points at `height / 2`), so it cannot read `--row-step` — a default here
- * would silently draw at one pitch while density moved the rows to another,
- * leaving lanes that don't meet between rows. Callers derive the number from
- * `useSpacingStep()`; see `PGCommitRow`.
+ * points at `height / 2`), so it cannot read `--row-step` or `--row-scale` —
+ * a default here would silently draw at one pitch while spacing or text size
+ * moved the rows to another, leaving lanes that don't meet between rows.
+ * Callers derive the number from `useRowH()`; see `PGCommitRow`.
  *
  * `width` is REQUIRED for the same reason of principle: it must come from
  * `graphWidth(maxCol)`. The old `width = 140` default is exactly what let lanes
@@ -1627,12 +1627,12 @@ export const PGCommitRow = React.memo(function PGCommitRow({
   headDecor = NO_HEAD_DECOR,
 }: PGCommitRowProps) {
   const [hover, setHover] = React.useState(false);
-  const step = useSpacingStep();
-  // Read here rather than passed in, for the same reason as the density step:
+  const derivedH = useRowH(COMMIT_ROW_BASE_H);
+  // Read here rather than passed in, for the same reason as the row scale:
   // every commit row in the app must agree with History's column header, and a
   // prop threaded through two screens is a prop one of them forgets.
   const dateW = useDateColumnWidth();
-  const h = rowHeight ?? COMMIT_ROW_BASE_H + step;
+  const h = rowHeight ?? derivedH;
   // One gate for every mark, so "this row is not HEAD" is checked once.
   const d = isHead && !headDecor.bare ? headDecor : NO_HEAD_DECOR;
   // Selection outranks the HEAD wash — the selected row must stay obvious even

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1077,9 +1077,9 @@ export function PGHunkActions({
  * regions, named rather than labelled with a `@@` range (#157).
  *
  * Says how much is hidden, where it resumes, and offers to show it. Chrome, not
- * code, so it is density-aware (`--row-step`) — code geometry stays on
- * `--lh-code`. `onExpand` omitted leaves it informational, which is what happens
- * when the file text is not available to expand from.
+ * code, so it follows both UI scales (`--row-scale` and `--row-step`) — code
+ * geometry stays on `--lh-code`. `onExpand` omitted leaves it informational,
+ * which is what happens when the file text is not available to expand from.
  */
 export function PGFoldSeparator({
   hiddenLines,
@@ -1573,7 +1573,7 @@ export interface PGCommitRowProps {
   onRowContext?: (oid: string, e: MouseEvent) => void;
   tagged?: string;
   /**
-   * Row height in px. Defaults to the density-derived height. Unlike every
+   * Row height in px. Defaults to `useRowH`'s scaled height. Unlike every
    * other row surface this can't be a `--row-h` calc: PGGraphRow draws lanes
    * in SVG user units, so the row box and the gutter must share one NUMBER.
    */
@@ -2338,7 +2338,7 @@ export function PGSubmoduleRow({
       onContextMenu={onContextMenu}
       title={state.hint}
       style={{
-        // Density-aware (issue #70): padding-sized row, so half the step per side.
+        // Follows both UI scales (issue #70): padding-sized row, so half the step per side.
         padding: "calc(10px * var(--row-scale) + var(--row-step) / 2) 10px",
         background: "var(--bg-1)",
         border: "1px solid var(--border-0)",

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -265,7 +265,7 @@ export function flattenFileTree(
 }
 
 /**
- * Base row height in px, matching `--row-h: calc(24px + var(--row-step))`
+ * Base row height in px, matching `--row-h: calc(24px * var(--row-scale) + var(--row-step))`
  * (`index.css`). A windowing caller needs the pitch as a NUMBER and must add
  * `useSpacingStep()`; a literal would desync the window from the rows in
  * comfortable density (#70). Keep in sync with the token.
@@ -1083,7 +1083,7 @@ export function PGHunkActions({
 export function PGFoldSeparator({
   hiddenLines,
   fromR,
-  height = "calc(22px + var(--row-step))",
+  height = "calc(22px * var(--row-scale) + var(--row-step))",
   onExpand,
 }: {
   hiddenLines: number;
@@ -2053,7 +2053,7 @@ export function PGRebaseRow({
         display: "flex",
         alignItems: "center",
         gap: 8,
-        padding: "calc(6px + var(--row-step) / 2) 10px",
+        padding: "calc(6px * var(--row-scale) + var(--row-step) / 2) 10px",
         // Selection comes from the focus-aware [data-pg-row] CSS, so it must not
         // be overpainted here — only the un-selected row states set a background.
         background: selected ? undefined : dragging ? "var(--bg-3)" : "var(--bg-1)",
@@ -2220,7 +2220,7 @@ export function PGRemoteRow({
       onContextMenu={onContextMenu}
       data-remote={dataRemote}
       style={{
-        padding: "calc(10px + var(--row-step) / 2) 10px",
+        padding: "calc(10px * var(--row-scale) + var(--row-step) / 2) 10px",
         background: "var(--bg-1)",
         border: "1px solid var(--border-0)",
         borderRadius: "var(--r-3)",
@@ -2337,7 +2337,7 @@ export function PGSubmoduleRow({
       title={state.hint}
       style={{
         // Density-aware (issue #70): padding-sized row, so half the step per side.
-        padding: "calc(10px + var(--row-step) / 2) 10px",
+        padding: "calc(10px * var(--row-scale) + var(--row-step) / 2) 10px",
         background: "var(--bg-1)",
         border: "1px solid var(--border-0)",
         borderRadius: "var(--r-3)",
@@ -2485,7 +2485,7 @@ export function PGWorktreeRow({
       data-current={worktree.isCurrent ? "1" : undefined}
       onContextMenu={onContextMenu}
       style={{
-        padding: "calc(10px + var(--row-step) / 2) 10px",
+        padding: "calc(10px * var(--row-scale) + var(--row-step) / 2) 10px",
         background: "var(--bg-1)",
         // The worktree you are standing in gets the accent edge — without it the
         // list is several near-identical paths and "which one am I in" is a guess.

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -16,13 +16,14 @@ import {
 import {
   useDateColumnWidth,
   useRowH,
+  useTextScale,
 } from "@/features/settings/useSettingsStore";
 import {
   NO_HEAD_DECOR,
   type HeadDecor,
 } from "@/features/settings/headMarks";
 import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
-import { COL_PAD, GRAPH_PAD, commitRowGrid, laneX } from "./graph-geometry";
+import { GRAPH_PAD, colPad, commitRowGrid, laneX } from "./graph-geometry";
 import type { WindowRange } from "@/lib/useWindowedList";
 import type {
   RebaseAction,
@@ -1632,6 +1633,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
   // every commit row in the app must agree with History's column header, and a
   // prop threaded through two screens is a prop one of them forgets.
   const dateW = useDateColumnWidth();
+  const textScale = useTextScale();
   const h = rowHeight ?? derivedH;
   // One gate for every mark, so "this row is not HEAD" is checked once.
   const d = isHead && !headDecor.bare ? headDecor : NO_HEAD_DECOR;
@@ -1668,7 +1670,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
       onMouseLeave={() => setHover(false)}
       style={{
         display: "grid",
-        gridTemplateColumns: commitRowGrid(graphW, dateW),
+        gridTemplateColumns: commitRowGrid(graphW, dateW, textScale),
         alignItems: "center",
         height: h,
         background,
@@ -1726,7 +1728,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           alignItems: "center",
           gap: 6,
           minWidth: 0,
-          paddingRight: COL_PAD,
+          paddingRight: colPad(textScale),
           // Below SUBJECT_MIN_W the cell is narrower than its contents, and the
           // pills do not shrink (half a pill reads as a different branch), so
           // without this they painted over the author column instead.
@@ -1791,7 +1793,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           // what the name is cut to CLEAR, which is why AUTHOR_MIN_W counts it.
           minWidth: 0,
           overflow: "hidden",
-          paddingRight: COL_PAD,
+          paddingRight: colPad(textScale),
         }}
       >
         <PGAvatar name={author} size={16} />

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -15,7 +15,7 @@ import {
 } from "./primitives";
 import {
   useDateColumnWidth,
-  useDensityStep,
+  useSpacingStep,
 } from "@/features/settings/useSettingsStore";
 import {
   NO_HEAD_DECOR,
@@ -267,7 +267,7 @@ export function flattenFileTree(
 /**
  * Base row height in px, matching `--row-h: calc(24px + var(--row-step))`
  * (`index.css`). A windowing caller needs the pitch as a NUMBER and must add
- * `useDensityStep()`; a literal would desync the window from the rows in
+ * `useSpacingStep()`; a literal would desync the window from the rows in
  * comfortable density (#70). Keep in sync with the token.
  */
 export const FILE_TREE_ROW_BASE_H = 24;
@@ -1341,7 +1341,7 @@ const HEAD_RING_R = 6.5;
  * points at `height / 2`), so it cannot read `--row-step` — a default here
  * would silently draw at one pitch while density moved the rows to another,
  * leaving lanes that don't meet between rows. Callers derive the number from
- * `useDensityStep()`; see `PGCommitRow`.
+ * `useSpacingStep()`; see `PGCommitRow`.
  *
  * `width` is REQUIRED for the same reason of principle: it must come from
  * `graphWidth(maxCol)`. The old `width = 140` default is exactly what let lanes
@@ -1627,7 +1627,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
   headDecor = NO_HEAD_DECOR,
 }: PGCommitRowProps) {
   const [hover, setHover] = React.useState(false);
-  const step = useDensityStep();
+  const step = useSpacingStep();
   // Read here rather than passed in, for the same reason as the density step:
   // every commit row in the app must agree with History's column header, and a
   // prop threaded through two screens is a prop one of them forgets.

--- a/src/design/graph-geometry.ts
+++ b/src/design/graph-geometry.ts
@@ -115,8 +115,15 @@ export const shaColW = (scale = 1): number => px(SHA_COL_W * scale);
 export const colPad = (scale = 1): number => px(COL_PAD * scale);
 export const subjectMinW = (scale = 1): number => px(SUBJECT_MIN_W * scale);
 export const authorColW = (scale = 1): number => px(AUTHOR_COL_W * scale);
-/** Avatar and gap are fixed; only the truncation gutter is type-sized. */
-export const authorMinW = (scale = 1): number => px(16 + 6 + COL_PAD * scale);
+/**
+ * Avatar and gap are fixed; only the truncation gutter is type-sized. Reuses
+ * `colPad(scale)` rather than re-deriving `COL_PAD * scale` inline, so the two
+ * agree BY CONSTRUCTION — two expressions of the same scaled pad were only
+ * numerically equal by coincidence of `COL_PAD`'s current value, not by any
+ * guarantee, and a future change to `colPad` (a different rounding rule, a
+ * different pad) would otherwise have to be remembered in a second place.
+ */
+export const authorMinW = (scale = 1): number => px(16 + 6 + colPad(scale));
 export const dateColW = (fmt: DateFormat, scale = 1): number =>
   px(DATE_COL_W[fmt] * scale);
 

--- a/src/design/graph-geometry.ts
+++ b/src/design/graph-geometry.ts
@@ -93,6 +93,52 @@ export const AUTHOR_MIN_W = 16 + 6 + COL_PAD;
  */
 export const COMMIT_LIST_MIN_W = 420;
 
+// ─── Text-scaled widths ──────────────────────────────────────────────────────
+//
+// Every constant above is sized to TEXT: a sha is seven hex digits of
+// monospace, the Date column is the widest string its format can produce, the
+// subject floor is a readable number of characters. So they all move with the
+// user's Text size preset, or the column truncates the very thing it was sized
+// to hold — and for a sha or a timestamp, truncation destroys the meaning.
+//
+// `scale` defaults to 1 so a caller with no notion of the setting — tests, any
+// surface that never scales — gets exactly the pre-scale numbers. The avatar
+// (16px) and the flex gap after it are NOT type and do not scale; see
+// `authorMinW`.
+//
+// Rounded to a tenth, the same precision applyTextScale writes the ramp at, so
+// a template string never carries a 17-digit float.
+
+const px = (n: number): number => Math.round(n * 10) / 10;
+
+export const shaColW = (scale = 1): number => px(SHA_COL_W * scale);
+export const colPad = (scale = 1): number => px(COL_PAD * scale);
+export const subjectMinW = (scale = 1): number => px(SUBJECT_MIN_W * scale);
+export const authorColW = (scale = 1): number => px(AUTHOR_COL_W * scale);
+/** Avatar and gap are fixed; only the truncation gutter is type-sized. */
+export const authorMinW = (scale = 1): number => px(16 + 6 + COL_PAD * scale);
+export const dateColW = (fmt: DateFormat, scale = 1): number =>
+  px(DATE_COL_W[fmt] * scale);
+
+/**
+ * The narrowest the commit list may be dragged to, at a given text scale.
+ *
+ * Scaled with the columns it is the sum of — a floor that stayed at 420 while
+ * the columns grew would push the Date column off the right edge the moment
+ * someone picked Large, which is exactly the overflow
+ * `git-components.narrow.test.tsx` exists to prevent. `graphWidth` is not in
+ * the scale: lanes are dots and strokes in SVG user units, and they follow row
+ * HEIGHT, not type.
+ */
+export const commitListMinW = (scale = 1): number =>
+  Math.ceil(
+    graphWidth(4) +
+      shaColW(scale) +
+      subjectMinW(scale) +
+      authorMinW(scale) +
+      dateColW("relative", scale),
+  );
+
 /**
  * Grid template shared by PGCommitRow and History's column header, so the two
  * cannot drift. `graphW === 0` drops the graph column entirely — that is
@@ -113,10 +159,18 @@ export const COMMIT_LIST_MIN_W = 420;
  * than a second `fr` — a fractional author track never stops growing, and
  * `fit-content()` sizes each ROW to its own author, which un-aligns the
  * columns from each other and from the header.
+ *
+ * `scale` is the user's Text size preset. It defaults to 1 for the same reason
+ * `dateW` defaults to the relative width — a caller that knows nothing about
+ * the setting gets exactly the old template.
  */
-export const commitRowGrid = (graphW: number, dateW: number = DATE_COL_W.relative): string => {
+export const commitRowGrid = (
+  graphW: number,
+  dateW: number = DATE_COL_W.relative,
+  scale = 1,
+): string => {
   const cols =
-    `${SHA_COL_W}px minmax(${SUBJECT_MIN_W}px, 1fr) ` +
-    `minmax(${AUTHOR_MIN_W}px, ${AUTHOR_COL_W}px) ${dateW}px`;
+    `${shaColW(scale)}px minmax(${subjectMinW(scale)}px, 1fr) ` +
+    `minmax(${authorMinW(scale)}px, ${authorColW(scale)}px) ${dateW}px`;
   return graphW > 0 ? `${graphW}px ${cols}` : cols;
 };

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -988,7 +988,7 @@ export function PGSelect({
                   padding: "0 10px",
                   // A list-row surface opts into UI density or the Settings
                   // toggle silently skips it.
-                  height: "calc(24px + var(--row-step))",
+                  height: "calc(24px * var(--row-scale) + var(--row-step))",
                   cursor: "pointer",
                   background: i === active ? "var(--bg-selection)" : "transparent",
                   whiteSpace: "nowrap",

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -986,8 +986,8 @@ export function PGSelect({
                   alignItems: "center",
                   gap: 8,
                   padding: "0 10px",
-                  // A list-row surface opts into UI density or the Settings
-                  // toggle silently skips it.
+                  // A list-row surface opts into both UI scales or the
+                  // Settings controls silently skip it.
                   height: "calc(24px * var(--row-scale) + var(--row-step))",
                   cursor: "pointer",
                   background: i === active ? "var(--bg-selection)" : "transparent",

--- a/src/design/skeleton.tsx
+++ b/src/design/skeleton.tsx
@@ -15,7 +15,7 @@ export interface PGSkeletonProps {
    * Size each placeholder as a plain list row honouring the UI-density
    * setting. A skeleton row that ignores density is a different height from
    * the real row it stands in for, so the list visibly jumps when data
-   * arrives. `--row-h` is already `calc(24px + var(--row-step))`, so it is
+   * arrives. `--row-h` is already `calc(24px * var(--row-scale) + var(--row-step))`, so it is
    * used directly — adding `var(--row-step)` on top would double-count.
    */
   rowStep?: boolean;

--- a/src/design/skeleton.tsx
+++ b/src/design/skeleton.tsx
@@ -12,11 +12,11 @@ export interface PGSkeletonProps {
   /** Gap between stacked placeholders, px. */
   gap?: number;
   /**
-   * Size each placeholder as a plain list row honouring the UI-density
-   * setting. A skeleton row that ignores density is a different height from
-   * the real row it stands in for, so the list visibly jumps when data
-   * arrives. `--row-h` is already `calc(24px * var(--row-scale) + var(--row-step))`, so it is
-   * used directly — adding `var(--row-step)` on top would double-count.
+   * Size each placeholder as a plain list row honouring both UI scales. A
+   * skeleton row that ignores them is a different height from the real row it
+   * stands in for, so the list visibly jumps when data arrives. `--row-h` is
+   * already `calc(24px * var(--row-scale) + var(--row-step))`, so it is used
+   * directly — adding `var(--row-step)` on top would double-count.
    */
   rowStep?: boolean;
   style?: React.CSSProperties;

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -412,7 +412,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
           display: "flex",
           alignItems: "center",
           gap: 6,
-          height: "calc(26px + var(--row-step))",
+          height: "calc(26px * var(--row-scale) + var(--row-step))",
           padding: "0 10px",
           paddingLeft: 10 + row.depth * INDENT,
           background: active ? "var(--bg-selection)" : "transparent",
@@ -484,7 +484,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
           display: "flex",
           alignItems: "center",
           gap: 6,
-          height: "calc(26px + var(--row-step))",
+          height: "calc(26px * var(--row-scale) + var(--row-step))",
           padding: "0 10px",
           // Indented like the screen's tree, plus the width of the chevron a
           // folder row spends there, so nested names line up under the label.

--- a/src/features/compare/CompareSidePicker.tsx
+++ b/src/features/compare/CompareSidePicker.tsx
@@ -214,7 +214,7 @@ export function CompareSidePicker({
                           alignItems: "center",
                           gap: 8,
                           // Density-aware, like every other list row (#70).
-                          height: "calc(26px + var(--row-step))",
+                          height: "calc(26px * var(--row-scale) + var(--row-step))",
                           padding: "0 10px",
                           cursor: "pointer",
                           fontFamily: "var(--font-mono)",

--- a/src/features/compare/CompareSidePicker.tsx
+++ b/src/features/compare/CompareSidePicker.tsx
@@ -213,7 +213,7 @@ export function CompareSidePicker({
                           display: "flex",
                           alignItems: "center",
                           gap: 8,
-                          // Density-aware, like every other list row (#70).
+                          // Follows both UI scales, like every other list row (#70).
                           height: "calc(26px * var(--row-scale) + var(--row-step))",
                           padding: "0 10px",
                           cursor: "pointer",

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -315,7 +315,8 @@ export function CommitDiffPanel({
       // `isTextualDiff` also excludes an LFS pointer diff (#93).
       flattenDiffRows(isTextualDiff(current) && current ? current.hunks : [], {
         // This panel's rows are tighter than the other surfaces', so its fold
-        // separator is one code row tall rather than density-sized chrome.
+        // separator is one code row tall rather than the scaled chrome height
+        // the other surfaces use.
         foldH: rowH,
         rowH,
         syntax,

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -536,7 +536,7 @@ export function CommitDiffPanel({
                 alignItems: "center",
                 justifyContent: "space-between",
                 gap: 8,
-                padding: "calc(4px + var(--row-step) / 2) 12px",
+                padding: "calc(4px * var(--row-scale) + var(--row-step) / 2) 12px",
                 cursor: "pointer",
               }}
             >

--- a/src/features/diff/DiffMinimap.tsx
+++ b/src/features/diff/DiffMinimap.tsx
@@ -126,7 +126,7 @@ function readPalette(): MinimapPalette {
  * A store subscription rather than an observer, and BOTH fields are needed:
  * `activeThemeId` covers switching theme, `customThemes` covers editing the live
  * theme's colours — which keeps the same id, so the id alone would miss it.
- * Density arrives separately, through the `rowH` prop.
+ * The row-pitch scaling arrives separately, through the `rowH` prop.
  */
 function useMinimapPalette(): MinimapPalette {
   const activeThemeId = useSettingsStore((s) => s.activeThemeId);

--- a/src/features/forge/PullRequestRow.tsx
+++ b/src/features/forge/PullRequestRow.tsx
@@ -1,6 +1,6 @@
 // One row of the pull/merge request list (#92).
 //
-// Row geometry uses `calc(48px + var(--row-step))` so the Settings density
+// Row geometry uses `calc(48px * var(--row-scale) + var(--row-step))` so the Settings density
 // toggle reaches it — a new list surface that hardcodes a height is exactly how
 // density rotted the first time (issue #70).
 
@@ -41,7 +41,7 @@ export function PullRequestRow({
         gap: 10,
         padding: "0 12px",
         // Density: --row-step is 0 in compact, so the default layout is unchanged.
-        height: "calc(48px + var(--row-step))",
+        height: "calc(48px * var(--row-scale) + var(--row-step))",
         cursor: "pointer",
         borderBottom: "1px solid var(--border-0)",
         background: selected ? "var(--bg-selection)" : "transparent",

--- a/src/features/forge/PullRequestRow.tsx
+++ b/src/features/forge/PullRequestRow.tsx
@@ -1,8 +1,9 @@
 // One row of the pull/merge request list (#92).
 //
-// Row geometry uses `calc(48px * var(--row-scale) + var(--row-step))` so the Settings density
-// toggle reaches it — a new list surface that hardcodes a height is exactly how
-// density rotted the first time (issue #70).
+// Row geometry uses `calc(48px * var(--row-scale) + var(--row-step))` so both
+// Settings scale controls — Spacing and Text size — reach it: a new list
+// surface that hardcodes a height is exactly how row geometry rotted the
+// first time (issue #70).
 
 import { PGBadge, PGIcon } from "@/design";
 import type { ChecksSummary, ForgeKind, PullRequest } from "@/lib/types";
@@ -40,7 +41,7 @@ export function PullRequestRow({
         alignItems: "center",
         gap: 10,
         padding: "0 12px",
-        // Density: --row-step is 0 in compact, so the default layout is unchanged.
+        // Spacing: --row-step is 0 at the compact preset, so the default layout is unchanged.
         height: "calc(48px * var(--row-scale) + var(--row-step))",
         cursor: "pointer",
         borderBottom: "1px solid var(--border-0)",

--- a/src/features/merge/FileList.tsx
+++ b/src/features/merge/FileList.tsx
@@ -182,8 +182,9 @@ function FileRow({
         alignItems: "center",
         gap: 6,
         padding: "0 10px",
-        // Density-aware like every other list row (#70): `--row-h` already
-        // folds in `--row-step`, so it must not be added again here.
+        // Follows both UI scales like every other list row (#70): `--row-h`
+        // already folds in `--row-scale` and `--row-step`, so neither is
+        // added again here.
         height: "var(--row-h)",
         cursor: "pointer",
         background: selected ? "var(--bg-selection)" : "transparent",

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -323,7 +323,7 @@ export function CommandPalette() {
         onMouseEnter={() => setActiveIndex(flatIndex)}
         style={{
           display: "flex", alignItems: "center", gap: 8,
-          height: "calc(30px + var(--row-step))", padding: "0 12px",
+          height: "calc(30px * var(--row-scale) + var(--row-step))", padding: "0 12px",
           background: active ? "var(--bg-selection)" : "transparent", cursor: "pointer",
           fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)",
         }}

--- a/src/features/rebase/RebaseBasePicker.tsx
+++ b/src/features/rebase/RebaseBasePicker.tsx
@@ -184,7 +184,7 @@ export function RebaseBasePicker({
           display: "flex",
           alignItems: "center",
           gap: 8,
-          height: "calc(26px + var(--row-step))",
+          height: "calc(26px * var(--row-scale) + var(--row-step))",
           padding: "0 10px",
           background: active ? "var(--bg-selection)" : "transparent",
           cursor: "pointer",

--- a/src/features/settings/layout/SettingsCard.test.tsx
+++ b/src/features/settings/layout/SettingsCard.test.tsx
@@ -58,8 +58,12 @@ describe("SettingsCard / SettingsRow", () => {
   // does not resolve calc() — so the token math is pinned as a string here and
   // as real geometry in e2e/specs/settings.e2e.ts.
   it("takes half a step, so density is not double-counted", () => {
-    expect(densityPadding(12)).toBe("calc(12px + var(--row-step) / 2) 16px");
-    expect(densityPadding(10)).toBe("calc(10px + var(--row-step) / 2) 16px");
+    expect(densityPadding(12)).toBe(
+      "calc(12px * var(--row-scale) + var(--row-step) / 2) 16px",
+    );
+    expect(densityPadding(10)).toBe(
+      "calc(10px * var(--row-scale) + var(--row-step) / 2) 16px",
+    );
     expect(SETTINGS_ROW_PADDING).toBe(densityPadding(12));
   });
 

--- a/src/features/settings/layout/SettingsCard.tsx
+++ b/src/features/settings/layout/SettingsCard.tsx
@@ -4,7 +4,8 @@ import { useSettingsFilter } from "./filterContext";
 import { useSettingsHighlight } from "./highlightContext";
 
 /**
- * The UI-density opt-in for a settings surface, as vertical padding.
+ * The opt-in into both UI scales — Spacing and Text size — for a settings
+ * surface, as vertical padding.
  *
  * `--row-step` is the WHOLE extra height a row spends, so padding — applied
  * top AND bottom — takes half of it. Writing `var(--row-step)` here instead
@@ -137,8 +138,8 @@ export function SettingsRow({
         flexDirection: stacked ? "column" : "row",
         alignItems: stacked ? "stretch" : "flex-start",
         gap: stacked ? 10 : 16,
-        // A list-row surface, so it opts into UI density (#70). The card's
-        // header above stays fixed: that is chrome, not a row.
+        // A list-row surface, so it opts into both UI scales (#70). The
+        // card's header above stays fixed: that is chrome, not a row.
         padding: SETTINGS_ROW_PADDING,
         borderBottom: "1px solid var(--border-0)",
       }}

--- a/src/features/settings/layout/SettingsCard.tsx
+++ b/src/features/settings/layout/SettingsCard.tsx
@@ -14,9 +14,12 @@ import { useSettingsHighlight } from "./highlightContext";
  * 12px, the theme action strip 10px) while the STEP must not: two surfaces in
  * one card that grow by different amounts is the same bug as one that does not
  * grow at all.
+ *
+ * `--row-scale` multiplies the BASE and not the step: the step is already the
+ * user's own number in pixels, while the base is what has to hold the text.
  */
 export function densityPadding(basePx: number): string {
-  return `calc(${basePx}px + var(--row-step) / 2) 16px`;
+  return `calc(${basePx}px * var(--row-scale) + var(--row-step) / 2) 16px`;
 }
 
 /**

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -1,11 +1,13 @@
 import { PGButton, PGButtonGroup, PGIconButton, pgFlash } from "@/design";
 import {
   SPACING_STEP_PX,
+  TEXT_SCALE,
   ZOOM_MAX,
   ZOOM_MIN,
   useSettingsStore,
   type ThemeFollowMode,
   type UiSpacing,
+  type UiTextScale,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import {
@@ -41,9 +43,14 @@ export const meta: SettingsPageMeta = {
         { id: "appearance.light", label: "Light theme", keywords: "gallery preview swatch add new create custom", when: "themeFollowsSystem" },
         { id: "appearance.dark", label: "Dark theme", keywords: "dark mode gallery preview swatch add new create custom", when: "themeFollowsSystem" },
         { id: "appearance.theme", label: "Theme", keywords: "colors palette custom editor export import gallery preview swatch duplicate contrast add new create", when: "themeFixed" },
-        { id: "appearance.density", label: "UI density", keywords: "compact cozy comfortable row height spacing" },
         { id: "appearance.dateFormat", label: "Date format", keywords: "relative absolute iso timestamp" },
         { id: "appearance.headMarks", label: "Current position (HEAD)", keywords: "bar tint ring marker" },
+        // Text size, Spacing and Zoom sit adjacent here (matching their render
+        // order below) because all three are "how big/roomy is the UI"
+        // controls — reading them as one group is the point, not an accident
+        // of where the old density row used to live.
+        { id: "appearance.textSize", label: "Text size", keywords: "font size text type bigger smaller larger readable accessibility scale" },
+        { id: "appearance.spacing", label: "Spacing", keywords: "density compact cozy comfortable spacious row height breathing room padding" },
         { id: "appearance.zoom", label: "Zoom", keywords: "font size scale text bigger smaller" },
       ],
     },
@@ -180,25 +187,6 @@ export function AppearancePage() {
       </div>
 
       <SettingsRow
-        id="appearance.density"
-        label="UI density"
-        hint={`Compact matches the dense IDE feel; spacious gives every list row ${SPACING_STEP_PX.spacious}px more breathing room.`}
-        control={
-          <PGButtonGroup
-            size="sm"
-            value={s.uiSpacing}
-            onChange={(v) => s.set("uiSpacing", v as UiSpacing)}
-            options={[
-              { value: "compact", label: "Compact" },
-              { value: "cozy", label: "Cozy" },
-              { value: "comfortable", label: "Comfortable" },
-              { value: "spacious", label: "Spacious" },
-            ]}
-          />
-        }
-      />
-
-      <SettingsRow
         id="appearance.dateFormat"
         label="Date format"
         hint={
@@ -235,6 +223,46 @@ export function AppearancePage() {
         label="Current position (HEAD)"
         hint="How History marks the commit you are on. Pick any combination of marks, then set how hard they hit — the preview is the real History row."
         control={<HeadMarksControl />}
+      />
+
+      <SettingsRow
+        id="appearance.textSize"
+        label="Text size"
+        hint={`Scales the type everywhere, code and diffs included — ${Math.round(
+          TEXT_SCALE.larger * 100,
+        )}% at the largest. Rows grow to fit it; icons and borders don’t — use Zoom below for those.`}
+        control={
+          <PGButtonGroup
+            size="sm"
+            value={s.uiTextScale}
+            onChange={(v) => s.set("uiTextScale", v as UiTextScale)}
+            options={[
+              { value: "small", label: "Small" },
+              { value: "default", label: "Default" },
+              { value: "large", label: "Large" },
+              { value: "larger", label: "Larger" },
+            ]}
+          />
+        }
+      />
+
+      <SettingsRow
+        id="appearance.spacing"
+        label="Spacing"
+        hint={`How much breathing room every list row gets — compact is the dense IDE feel, spacious adds ${SPACING_STEP_PX.spacious}px to each row.`}
+        control={
+          <PGButtonGroup
+            size="sm"
+            value={s.uiSpacing}
+            onChange={(v) => s.set("uiSpacing", v as UiSpacing)}
+            options={[
+              { value: "compact", label: "Compact" },
+              { value: "cozy", label: "Cozy" },
+              { value: "comfortable", label: "Comfortable" },
+              { value: "spacious", label: "Spacious" },
+            ]}
+          />
+        }
       />
 
       <SettingsRow

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -145,13 +145,14 @@ export function AppearancePage() {
           editor's own "Start from" picker, not a card you had to find first. */}
       <div
         // A geometry hook: only a real webview resolves the calc below, so e2e
-        // measures this strip's height under each density.
+        // measures this strip's height under each Spacing preset.
         data-testid="theme-actions"
         style={{
-          // Density-aware for the same reason its `SettingsRow` neighbours
-          // are: this strip is in the card BODY, between two rows that scale,
-          // so a fixed height here gives one card two row pitches. The chrome
-          // exemption covers a card's HEADER, not a band between its rows.
+          // Follows both UI scales for the same reason its `SettingsRow`
+          // neighbours do: this strip is in the card BODY, between two rows
+          // that scale, so a fixed height here gives one card two row
+          // pitches. The chrome exemption covers a card's HEADER, not a band
+          // between its rows.
           // Its own 10px base is kept — only the step is shared.
           padding: densityPadding(10),
           borderBottom: "1px solid var(--border-0)",
@@ -228,7 +229,7 @@ export function AppearancePage() {
       <SettingsRow
         id="appearance.textSize"
         label="Text size"
-        hint={`Scales the type everywhere, code and diffs included — ${Math.round(
+        hint={`Scales the type across the app, code and diffs included — except the integrated terminal, which keeps its own font. ${Math.round(
           TEXT_SCALE.larger * 100,
         )}% at the largest. Rows grow to fit it; icons and borders don’t — use Zoom below for those.`}
         control={

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -1,10 +1,11 @@
 import { PGButton, PGButtonGroup, PGIconButton, pgFlash } from "@/design";
 import {
-  DENSITY_STEP_PX,
+  SPACING_STEP_PX,
   ZOOM_MAX,
   ZOOM_MIN,
   useSettingsStore,
   type ThemeFollowMode,
+  type UiSpacing,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import {
@@ -181,15 +182,17 @@ export function AppearancePage() {
       <SettingsRow
         id="appearance.density"
         label="UI density"
-        hint={`Compact matches the dense IDE feel; comfortable gives every list row ${DENSITY_STEP_PX.comfortable}px more breathing room.`}
+        hint={`Compact matches the dense IDE feel; Spacious gives every list row ${SPACING_STEP_PX.spacious}px more breathing room.`}
         control={
           <PGButtonGroup
             size="sm"
-            value={s.uiDensity}
-            onChange={(v) => s.set("uiDensity", v as "compact" | "comfortable")}
+            value={s.uiSpacing}
+            onChange={(v) => s.set("uiSpacing", v as UiSpacing)}
             options={[
               { value: "compact", label: "Compact" },
+              { value: "cozy", label: "Cozy" },
               { value: "comfortable", label: "Comfortable" },
+              { value: "spacious", label: "Spacious" },
             ]}
           />
         }

--- a/src/features/settings/pages/appearance.tsx
+++ b/src/features/settings/pages/appearance.tsx
@@ -182,7 +182,7 @@ export function AppearancePage() {
       <SettingsRow
         id="appearance.density"
         label="UI density"
-        hint={`Compact matches the dense IDE feel; Spacious gives every list row ${SPACING_STEP_PX.spacious}px more breathing room.`}
+        hint={`Compact matches the dense IDE feel; spacious gives every list row ${SPACING_STEP_PX.spacious}px more breathing room.`}
         control={
           <PGButtonGroup
             size="sm"

--- a/src/features/settings/themeFiles.test.ts
+++ b/src/features/settings/themeFiles.test.ts
@@ -100,14 +100,16 @@ describe("readSettingsFile", () => {
   it("hands back the path and contents WITHOUT applying them", async () => {
     useSettingsStore.getState().reset();
     mockDialogOpen("/home/you/settings.json");
-    mockInvoke("read_user_file", () => '{"settings":{"uiDensity":"comfortable"}}');
+    mockInvoke("read_user_file", () => '{"settings":{"uiSpacing":"comfortable"}}');
 
     const picked = await readSettingsFile();
 
     expect(picked?.path).toBe("/home/you/settings.json");
     // Read, not applied: the Backup page confirms first, so nothing may change
-    // before the user has answered.
-    expect(useSettingsStore.getState().uiDensity).toBe("compact");
+    // before the user has answered. Still the post-reset DEFAULT ("cozy"), not
+    // the fixture's "comfortable" — proof the file's contents never touched
+    // the store.
+    expect(useSettingsStore.getState().uiSpacing).toBe("cozy");
   });
 
   it("returns null when the user cancels", async () => {

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -95,6 +95,10 @@ const PORTABLE = [
   // "no systemAppearance" assertions below pin that.
   "themePreference",
   "uiSpacing",
+  // The type-ramp preset (`--fs-*`, `--row-scale`). Portable for the same
+  // reason uiSpacing is: it says how large the person likes their text, not
+  // anything about this machine's display.
+  "uiTextScale",
   "uiZoom",
   // The release channel (#237). Portable: "we track the prereleases" is a
   // team decision, not a fact about one machine — the same call

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -94,7 +94,7 @@ const PORTABLE = [
   // not: that is observed state, it is not in PersistedState at all, and the
   // "no systemAppearance" assertions below pin that.
   "themePreference",
-  "uiDensity",
+  "uiSpacing",
   "uiZoom",
   // The release channel (#237). Portable: "we track the prereleases" is a
   // team decision, not a fact about one machine — the same call
@@ -270,7 +270,7 @@ describe("an export carries no secrets", () => {
 function moveEverything(store: Store) {
   store.useSettingsStore.getState().saveAsNewTheme("House style");
   const set = store.useSettingsStore.getState().set;
-  set("uiDensity", "comfortable");
+  set("uiSpacing", "comfortable");
   set("uiZoom", 1.2);
   set("headMarks", ["badge"]);
   set("headWeight", "subtle");
@@ -483,20 +483,22 @@ describe("import validates like load() does", () => {
     }
   });
 
-  it("degrades unknown diff modes, density and pull mode", async () => {
+  it("degrades unknown diff modes, spacing and pull mode", async () => {
     const store = await freshStore();
     store.useSettingsStore.getState().importSettings(
       payloadOf({
         diffViewMode: "sideways",
         diffContextMode: "everything",
-        uiDensity: "cozy",
+        // "roomy" is invalid, not "cozy": cozy is now one of the four real
+        // presets, so it would no longer exercise the fallback.
+        uiSpacing: "roomy",
         defaultPullMode: "Yolo",
       }),
     );
     const s = store.useSettingsStore.getState();
     expect(s.diffViewMode).toBe("inline");
     expect(s.diffContextMode).toBe("wholeFile");
-    expect(s.uiDensity).toBe("compact");
+    expect(s.uiSpacing).toBe("cozy");
     expect(s.defaultPullMode).toBe("Rebase");
   });
 

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -589,6 +589,19 @@ describe("import validates like load() does", () => {
     expect(s.lastCreateDir).toBe("/Users/someone/dev");
     expect(s.diffViewMode).toBe("split");
   });
+
+  // The uiDensity -> uiSpacing migration's `else` arm used to fire whenever
+  // `uiSpacing` was absent from the payload, with no check for whether the
+  // payload mentioned `uiDensity` either -- so a file that spoke to neither
+  // key still overwrote a Spacious machine's preference with "cozy". This is
+  // the case the review found undercovered: the ternary's own default branch
+  // had no test of its own, and it was the one that was wrong.
+  it("keeps a non-default uiSpacing when the payload mentions neither uiSpacing nor uiDensity", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("uiSpacing", "spacious");
+    store.useSettingsStore.getState().importSettings(payloadOf({ addSignoff: true }));
+    expect(store.useSettingsStore.getState().uiSpacing).toBe("spacious");
+  });
 });
 
 describe("import reports rather than applying silently", () => {

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -13,7 +13,18 @@ async function freshStore() {
 
 beforeEach(() => {
   localStorage.clear();
-  document.documentElement.style.removeProperty("--row-step");
+  const rootStyle = document.documentElement.style;
+  rootStyle.removeProperty("--row-step");
+  rootStyle.removeProperty("--row-scale");
+  // applyTextScale overwrites all ten on every call, so nothing can leak
+  // between tests today — but a future test asserting an UNSET --fs-* var
+  // would otherwise silently inherit whatever ramp the previous test applied.
+  // Literal token list, not FS_TOKENS: this file has no static top-level
+  // import of the store module (see freshStore below), so there is nothing to
+  // import it from.
+  for (const n of [10, 11, 12, 13, 14, 15, 17, 20, 28, 40]) {
+    rootStyle.removeProperty(`--fs-${n}`);
+  }
 });
 
 describe("useSettingsStore persistence", () => {
@@ -622,5 +633,74 @@ describe("recentColors", () => {
     useSettingsStore.getState().pushRecentColor("#ff8800");
     const bag = JSON.parse(useSettingsStore.getState().exportSettings());
     expect(JSON.stringify(bag)).not.toContain("ff8800");
+  });
+});
+
+const fsVar = (n: number) =>
+  document.documentElement.style.getPropertyValue(`--fs-${n}`);
+const rowScale = () =>
+  document.documentElement.style.getPropertyValue("--row-scale");
+
+describe("uiTextScale CSS hook", () => {
+  it("applies the resolved ramp from the persisted scale at load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "larger" }));
+    await freshStore();
+    expect(fsVar(13)).toBe("16.9px");
+    expect(fsVar(40)).toBe("52px");
+    expect(rowScale()).toBe("1.3");
+  });
+
+  it("re-applies the ramp when the setting changes", async () => {
+    // No static top-level import of useSettingsStore exists in this file (see
+    // freshStore above) — a bare `useSettingsStore.getState()` here throws
+    // ReferenceError, so the instance freshStore() just loaded is used instead.
+    const { useSettingsStore } = await freshStore();
+    expect(fsVar(13)).toBe("13px");
+    useSettingsStore.getState().set("uiTextScale", "large");
+    expect(fsVar(13)).toBe("15px");
+    expect(rowScale()).toBe("1.15");
+  });
+
+  // Rounding is what could break this, and a collapsed or reordered pair would
+  // render two different type roles identically with nothing on screen saying
+  // why. Four presets is a finite set, so assert it rather than sample it.
+  it("keeps the ramp strictly ascending at every preset", async () => {
+    const { TEXT_SCALE, FS_TOKENS, applyTextScale } = await freshStore();
+    for (const key of Object.keys(TEXT_SCALE) as (keyof typeof TEXT_SCALE)[]) {
+      applyTextScale(key);
+      const sizes = FS_TOKENS.map((n) => Number.parseFloat(fsVar(n)));
+      for (let i = 1; i < sizes.length; i++) {
+        expect(sizes[i], `${key}: --fs-${FS_TOKENS[i]}`).toBeGreaterThan(sizes[i - 1]);
+      }
+    }
+  });
+
+  // The clipping guard. Rows set `height`, not `min-height`, so a base that
+  // does not grow with the type clips it -- and no test that only reads the
+  // ramp can see that. --fs-13 x --lh-body must fit the SMALLEST row base in
+  // use (22px, PGBranchRow and the Compare header).
+  it("keeps the smallest row base clear of its own line box at every preset", async () => {
+    const { TEXT_SCALE, applyTextScale } = await freshStore();
+    const SMALLEST_ROW_BASE = 22;
+    const LH_BODY = 1.45;
+    for (const key of Object.keys(TEXT_SCALE) as (keyof typeof TEXT_SCALE)[]) {
+      applyTextScale(key);
+      const lineBox = Number.parseFloat(fsVar(13)) * LH_BODY;
+      const rowH = SMALLEST_ROW_BASE * Number.parseFloat(rowScale());
+      expect(rowH, `${key}`).toBeGreaterThanOrEqual(lineBox);
+    }
+  });
+
+  it("falls back to the default for an unknown stored text scale", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "huge" }));
+    await freshStore();
+    expect(fsVar(13)).toBe("13px");
+    expect(rowScale()).toBe("1");
+  });
+
+  it("rejects an inherited Object property as a text scale", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "toString" }));
+    await freshStore();
+    expect(rowScale()).toBe("1");
   });
 });

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -649,6 +649,7 @@ describe("uiTextScale CSS hook", () => {
     expect(fsVar(13)).toBe("16.9px");
     expect(fsVar(40)).toBe("52px");
     expect(rowScale()).toBe("1.3");
+    expect(document.documentElement.dataset.textScale).toBe("larger");
   });
 
   it("re-applies the ramp when the setting changes", async () => {
@@ -660,6 +661,7 @@ describe("uiTextScale CSS hook", () => {
     useSettingsStore.getState().set("uiTextScale", "large");
     expect(fsVar(13)).toBe("15px");
     expect(rowScale()).toBe("1.15");
+    expect(document.documentElement.dataset.textScale).toBe("large");
   });
 
   // Rounding is what could break this, and a collapsed or reordered pair would
@@ -702,6 +704,31 @@ describe("uiTextScale CSS hook", () => {
   it("rejects an inherited Object property as a text scale", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "toString" }));
     await freshStore();
+    expect(rowScale()).toBe("1");
+  });
+});
+
+// The deleted "reset() restores compact density" case was never replaced when
+// the binary density toggle split into these two independent presets, so
+// nothing asserted that reset() re-applies EITHER one to the DOM. reset()
+// writes DEFAULTS to the store either way -- the bug this guards is
+// `applySpacing`/`applyTextScale` not being called alongside it, which would
+// leave every CSS var at whatever the user had picked while the store itself
+// (and any UI reading it) reported the defaults.
+describe("reset() re-applies both UI scales", () => {
+  it("restores --row-step and the text ramp on the DOM, not just the store fields", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("uiSpacing", "spacious");
+    useSettingsStore.getState().set("uiTextScale", "larger");
+    expect(rowStep()).toBe("8px");
+    expect(fsVar(13)).toBe("16.9px");
+
+    useSettingsStore.getState().reset();
+
+    expect(useSettingsStore.getState().uiSpacing).toBe("cozy");
+    expect(useSettingsStore.getState().uiTextScale).toBe("default");
+    expect(rowStep()).toBe("2px");
+    expect(fsVar(13)).toBe("13px");
     expect(rowScale()).toBe("1");
   });
 });

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -389,14 +389,17 @@ describe("uiSpacing CSS hook", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "spacious" }));
     await freshStore();
     expect(rowStep()).toBe("8px");
+    expect(document.documentElement.dataset.spacing).toBe("spacious");
   });
 
   it("re-applies --row-step when the spacing setting changes", async () => {
     const { useSettingsStore } = await freshStore();
     useSettingsStore.getState().set("uiSpacing", "comfortable");
     expect(rowStep()).toBe("4px");
+    expect(document.documentElement.dataset.spacing).toBe("comfortable");
     useSettingsStore.getState().set("uiSpacing", "compact");
     expect(rowStep()).toBe("0px");
+    expect(document.documentElement.dataset.spacing).toBe("compact");
   });
 
   // Compact must stay exactly 0: it is the value that reproduces the

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -1,5 +1,5 @@
 // Store-logic tests for the settings store: persistence shape (including the
-// removal migration for dead settings) and the uiDensity CSS-var hook.
+// removal migration for dead settings) and the uiSpacing CSS-var hook.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const STORAGE_KEY = "pg-settings-v2";
@@ -88,7 +88,7 @@ describe("useSettingsStore persistence", () => {
     expect(raw.diffContextMode).toBe("chunks");
   });
 
-  // Same reasoning as the uiDensity clamp below: load() copies a persisted value
+  // Same reasoning as the uiSpacing clamp below: load() copies a persisted value
   // for a known key without validating it, and an unknown mode reaching the
   // renderer would mean "neither branch" — a blank diff pane.
   it("degrades unrecognized persisted diff modes to the defaults", async () => {
@@ -384,50 +384,79 @@ describe("dateFormat", () => {
   });
 });
 
-describe("uiDensity CSS hook", () => {
-  it("applies --row-step from the persisted density at load", async () => {
+describe("uiSpacing CSS hook", () => {
+  it("applies --row-step from the persisted spacing at load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "spacious" }));
+    await freshStore();
+    expect(rowStep()).toBe("8px");
+  });
+
+  it("re-applies --row-step when the spacing setting changes", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("uiSpacing", "comfortable");
+    expect(rowStep()).toBe("4px");
+    useSettingsStore.getState().set("uiSpacing", "compact");
+    expect(rowStep()).toBe("0px");
+  });
+
+  // Compact must stay exactly 0: it is the value that reproduces the
+  // pre-density layout, so every `calc(Npx + var(--row-step))` collapses to Npx.
+  it("keeps compact at zero and orders the four steps", async () => {
+    const { SPACING_STEP_PX } = await freshStore();
+    expect(SPACING_STEP_PX.compact).toBe(0);
+    expect(Object.values(SPACING_STEP_PX)).toEqual([0, 2, 4, 8]);
+  });
+
+  // An unrecognized value would emit `--row-step: undefinedpx`, and one
+  // invalid substitution makes every `calc(Npx + var(--row-step))` compute to
+  // `auto` — collapsing the height of every row in the app at once.
+  it("falls back to the default for an unknown stored spacing", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "roomy" }));
+    await freshStore();
+    expect(rowStep()).toBe("2px");
+  });
+
+  // `in` walks the prototype chain, so a hand-edited "toString" would pass a
+  // membership check and index the table to a FUNCTION — the same undefinedpx
+  // collapse, reached by a value that looks like it was validated.
+  it("rejects an inherited Object property as a spacing value", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiSpacing: "toString" }));
+    await freshStore();
+    expect(rowStep()).toBe("2px");
+  });
+});
+
+describe("uiDensity migration", () => {
+  it("carries a stored comfortable density over to comfortable spacing", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
-    await freshStore();
-    expect(rowStep()).toBe("4px");
-    expect(document.documentElement.dataset.density).toBe("comfortable");
-  });
-
-  it("re-applies --row-step when the density setting changes", async () => {
     const { useSettingsStore } = await freshStore();
-    expect(rowStep()).toBe("0px");
-    useSettingsStore.getState().set("uiDensity", "comfortable");
+    expect(useSettingsStore.getState().uiSpacing).toBe("comfortable");
     expect(rowStep()).toBe("4px");
-    expect(document.documentElement.dataset.density).toBe("comfortable");
-    useSettingsStore.getState().set("uiDensity", "compact");
-    expect(rowStep()).toBe("0px");
-    expect(document.documentElement.dataset.density).toBe("compact");
   });
 
-  it("reset() restores compact density", async () => {
+  // Deliberate: a stored "compact" cannot be told apart from "never touched
+  // it", and the whole point of the change is that the old default was too
+  // dense. Landing an upgraded install on cozy is the same call the
+  // headIndicator -> headMarks migration made one setting over.
+  it("lands an upgraded compact install on cozy", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "compact" }));
     const { useSettingsStore } = await freshStore();
-    useSettingsStore.getState().set("uiDensity", "comfortable");
-    useSettingsStore.getState().reset();
-    expect(rowStep()).toBe("0px");
-    expect(document.documentElement.dataset.density).toBe("compact");
+    expect(useSettingsStore.getState().uiSpacing).toBe("cozy");
   });
 
-  // Compact must be a no-op delta: the pre-density layout is the compact
-  // layout, so every `calc(Npx + var(--row-step))` has to collapse to Npx.
-  it("keeps compact at a zero step so the default layout is unchanged", async () => {
-    const { DENSITY_STEP_PX } = await freshStore();
-    expect(DENSITY_STEP_PX.compact).toBe(0);
+  it("lets a stored uiSpacing win over a stale uiDensity", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ uiDensity: "comfortable", uiSpacing: "compact" }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().uiSpacing).toBe("compact");
   });
 
-  // load() copies any persisted value for a known key without validating it,
-  // so an unrecognized density must degrade to compact rather than emit
-  // `--row-step: undefinedpx` — an invalid substitution makes every
-  // `calc(Npx + var(--row-step))` compute to `auto`, collapsing the height of
-  // every row in the app at once.
-  it("degrades an unrecognized persisted density to compact", async () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "cozy" }));
-    await freshStore();
-    expect(rowStep()).toBe("0px");
-    expect(document.documentElement.dataset.density).toBe("compact");
+  it("drops the retired key from state", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
+    const { useSettingsStore } = await freshStore();
+    expect("uiDensity" in useSettingsStore.getState()).toBe(false);
   });
 });
 

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -712,7 +712,26 @@ describe("useRowH", () => {
     store.getState().set("uiTextScale", "larger");
     store.getState().set("uiSpacing", "comfortable");
     const { result } = renderHook(() => useRowH(24));
-    // 24 x 1.3 = 31.2, + comfortable step 4
-    expect(result.current).toBeCloseTo(35.2, 5);
+    // 24 x 1.3 = 31.2, + comfortable step 4 = 35.2 exactly, even as a raw
+    // double -- this case alone would pass identically with the rounding
+    // deleted, so it pins the ADD-then-SCALE arithmetic, not the rounding.
+    // The case below is the one that pins rounding specifically.
+    expect(result.current).toBe(35.2);
+  });
+
+  // 26 x 1.3 is where the rounding earns its keep: verified with
+  // `node -e "console.log(26*1.3+0)"`, the raw double is
+  // 33.800000000000004, not 33.8 -- unlike the case above, whose inputs
+  // happen to land on an exact double either way. Deleting Math.round from
+  // useRowH turns this assertion red (confirmed by hand before landing it);
+  // that is what makes it a real pin on the hook's rounding contract rather
+  // than a restatement of whatever the implementation currently emits.
+  it("rounds away the float remainder from a base x scale that lands off-grid", async () => {
+    const { useRowH, useSettingsStore: store } = await freshStore();
+    store.getState().set("uiTextScale", "larger");
+    store.getState().set("uiSpacing", "compact");
+    const { result } = renderHook(() => useRowH(26));
+    // 26 x 1.3 = 33.800000000000004 as a raw double, + compact step 0
+    expect(result.current).toBe(33.8);
   });
 });

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -1,6 +1,7 @@
 // Store-logic tests for the settings store: persistence shape (including the
 // removal migration for dead settings) and the uiSpacing CSS-var hook.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
 
 const STORAGE_KEY = "pg-settings-v2";
 
@@ -702,5 +703,16 @@ describe("uiTextScale CSS hook", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiTextScale: "toString" }));
     await freshStore();
     expect(rowScale()).toBe("1");
+  });
+});
+
+describe("useRowH", () => {
+  it("multiplies the base by the text scale and adds the spacing step", async () => {
+    const { useRowH, useSettingsStore: store } = await freshStore();
+    store.getState().set("uiTextScale", "larger");
+    store.getState().set("uiSpacing", "comfortable");
+    const { result } = renderHook(() => useRowH(24));
+    // 24 x 1.3 = 31.2, + comfortable step 4
+    expect(result.current).toBeCloseTo(35.2, 5);
   });
 });

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -737,6 +737,68 @@ export function applySpacing(spacing: UiSpacing) {
   root.dataset.spacing = s;
 }
 
+/**
+ * Every step of the type ramp, as the NUMBER in its token name.
+ *
+ * `index.css` declares `--fs-10` … `--fs-40` at these exact px values as the
+ * pre-hydration default; `applyTextScale` overwrites all ten from this list,
+ * so the two cannot drift and a new step is added in one place.
+ */
+export const FS_TOKENS = [10, 11, 12, 13, 14, 15, 17, 20, 28, 40] as const;
+
+/**
+ * How far the type ramp moves, per text-size preset.
+ *
+ * Text size is NOT zoom. Zoom scales the whole UI through the webview —
+ * borders, icons, the titlebar, whitespace — and is the answer to "this app is
+ * too small on my display". This scales type, the row bases that have to hold
+ * it, and the column widths that are sized to text; icons and gaps stay put.
+ * The two compose, which is why both exist.
+ */
+export const TEXT_SCALE = {
+  small: 0.92,
+  default: 1,
+  large: 1.15,
+  larger: 1.3,
+} as const;
+
+export type UiTextScale = keyof typeof TEXT_SCALE;
+
+/** Same contract as `normalizeSpacing`, one setting over — see its comment. */
+function normalizeTextScale(scale: unknown): UiTextScale {
+  return typeof scale === "string" && Object.hasOwn(TEXT_SCALE, scale)
+    ? (scale as UiTextScale)
+    : DEFAULTS.uiTextScale;
+}
+
+/**
+ * Apply the text-size preset by writing the RESOLVED ramp to :root.
+ *
+ * Resolved px rather than `--fs-13: calc(13px * var(--ui-text-scale))`, which
+ * reads better but would make `--diff-row-h: calc(var(--fs-12) *
+ * var(--lh-code))` a nested calc() inside an unregistered custom property —
+ * and `readDiffRowHeight` already carries a fallback for the case where that
+ * value does not resolve to px. Writing px keeps `--diff-row-h` a one-level
+ * calc, unchanged, and keeps the question from arising in the webview at all.
+ *
+ * One decimal, not whole pixels: two steps of the ramp are 1px apart at the
+ * small end, and integer rounding can collapse or reorder them.
+ *
+ * `--row-scale` is the same factor, unitless, for the row bases — every row
+ * surface sets `height`, not `min-height`, so a base that does not grow with
+ * the type clips it.
+ */
+export function applyTextScale(scale: UiTextScale) {
+  const root = document.documentElement;
+  const key = normalizeTextScale(scale);
+  const f = TEXT_SCALE[key];
+  for (const base of FS_TOKENS) {
+    root.style.setProperty(`--fs-${base}`, `${Math.round(base * f * 10) / 10}px`);
+  }
+  root.style.setProperty("--row-scale", String(f));
+  root.dataset.textScale = key;
+}
+
 // ─── HEAD ("you are here") indicator ─────────────────────────────────────────
 //
 // The catalog, the weight table and the resolver live in `./headMarks` — pure
@@ -848,6 +910,11 @@ interface PersistedState {
    * binary `uiDensity`; `coerceSettings` migrates the old key.
    */
   uiSpacing: UiSpacing;
+  /**
+   * How large the type is (`--fs-*`) and, with it, the row bases and the
+   * text-sized columns. Independent of `uiZoom`, which scales everything.
+   */
+  uiTextScale: UiTextScale;
   /**
    * How a commit date is written wherever one is shown (#354) — relative
    * ("3w ago"), the absolute stamp, or both. The hover tooltip carries the
@@ -1107,6 +1174,7 @@ const DEFAULTS: PersistedState = {
   themePreference: { ...DEFAULT_THEME_PREFERENCE },
   customThemes: [],
   uiSpacing: "cozy",
+  uiTextScale: "default",
   dateFormat: "relative",
   uiZoom: 1,
   headMarks: ["bar", "tint", "ring"],
@@ -1539,6 +1607,7 @@ function coerceSettings(
           : DEFAULTS.uiSpacing;
   }
   out.uiSpacing = normalizeSpacing(out.uiSpacing);
+  out.uiTextScale = normalizeTextScale(out.uiTextScale);
   // Same failure one column over: the date format picks the Date column's
   // WIDTH as well as its text, so an unknown mode would emit `undefinedpx` in
   // the row grid and collapse the column on every row at once.
@@ -2032,6 +2101,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     // import lands in state and not on screen.
     applyTheme(findTheme(state, state.activeThemeId) ?? BUILTIN_THEMES[0]);
     applySpacing(state.uiSpacing);
+    applyTextScale(state.uiTextScale);
     applyZoom(state.uiZoom);
     return {
       changed,
@@ -2062,6 +2132,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     if (key === "uiSpacing") {
       applySpacing(get().uiSpacing);
     }
+    if (key === "uiTextScale") {
+      applyTextScale(get().uiTextScale);
+    }
     if (key === "uiZoom") {
       applyZoom(get().uiZoom);
     }
@@ -2076,17 +2149,19 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     persist(DEFAULTS);
     applyTheme(BUILTIN_THEMES[0]);
     applySpacing(DEFAULTS.uiSpacing);
+    applyTextScale(DEFAULTS.uiTextScale);
     applyZoom(DEFAULTS.uiZoom);
   },
 }));
 
-// Apply active theme + density on module load so there's no flash before
-// first render.
+// Apply active theme, spacing and text scale on module load so there's no
+// flash before first render.
 {
   const s = useSettingsStore.getState();
   const active = findTheme(s, s.activeThemeId) ?? BUILTIN_THEMES[0];
   applyTheme(active);
   applySpacing(s.uiSpacing);
+  applyTextScale(s.uiTextScale);
   applyZoom(s.uiZoom);
 }
 
@@ -2120,6 +2195,16 @@ export type { Appearance } from "./systemAppearance";
  */
 export function useSpacingStep(): number {
   return SPACING_STEP_PX[normalizeSpacing(useSettingsStore((s) => s.uiSpacing))];
+}
+
+/**
+ * The active text scale as a FACTOR (0.92 … 1.3), for surfaces that multiply a
+ * JS pixel constant by it — windowed row pitches, the SVG graph gutter, and
+ * the commit row's text-sized columns. Everything a `calc()` can reach should
+ * use `var(--row-scale)` instead.
+ */
+export function useTextScale(): number {
+  return TEXT_SCALE[normalizeTextScale(useSettingsStore((s) => s.uiTextScale))];
 }
 
 /**

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { normalizeHex } from "@/lib/color";
 import type { PullMode } from "@/lib/tauri";
 import { type DateFormat, isDateFormat } from "@/lib/commitDate";
-import { DATE_COL_W } from "@/design/graph-geometry";
+import { dateColW } from "@/design/graph-geometry";
 import type { UpdateChannel, UpdateRefsMode } from "@/lib/types";
 import type { SavedIdentity } from "@/features/commits/identity/identityList";
 import {
@@ -2246,12 +2246,13 @@ export function useDateFormat(): DateFormat {
 }
 
 /**
- * Width the Date column needs for the active format.
+ * Width the Date column needs for the active format, at the active text
+ * scale.
  *
  * PGCommitRow and History's column header both call this, then hand the SAME
  * number to `commitRowGrid` — which is what keeps the header aligned with the
- * rows under it when the format changes.
+ * rows under it when the format OR the text size changes.
  */
 export function useDateColumnWidth(): number {
-  return DATE_COL_W[useDateFormat()];
+  return dateColW(useDateFormat(), useTextScale());
 }

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2201,7 +2201,7 @@ export function useSpacingStep(): number {
  * The active text scale as a FACTOR (0.92 … 1.3), for surfaces that multiply a
  * JS pixel constant by it — windowed row pitches, the SVG graph gutter, and
  * the commit row's text-sized columns. Everything a `calc()` can reach should
- * use the `--row-scale` CSS var instead.
+ * use `var(--row-scale)` instead.
  */
 export function useTextScale(): number {
   return TEXT_SCALE[normalizeTextScale(useSettingsStore((s) => s.uiTextScale))];

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -671,7 +671,8 @@ function activationPatch(
  * (`--row-h: calc(24px * var(--row-scale) + var(--row-step))`, …);
  * `applySpacing` overwrites the var from this table, so CSS never hardcodes a
  * step and cannot drift from the JS one. Compact is 0 by definition — it is
- * the value that reproduces the pre-density layout exactly.
+ * the value that reproduces the original fixed layout exactly, from before
+ * either a density toggle or this Spacing preset existed.
  */
 export const SPACING_STEP_PX = {
   compact: 0,
@@ -787,6 +788,11 @@ function normalizeTextScale(scale: unknown): UiTextScale {
  * `--row-scale` is the same factor, unitless, for the row bases — every row
  * surface sets `height`, not `min-height`, so a base that does not grow with
  * the type clips it.
+ *
+ * `data-text-scale` is also set — a reserved hook for any future rule that
+ * isn't a simple ramp substitution, the same reasoning as `applySpacing`'s
+ * `data-spacing` one setting over. Nothing reads it today (it's asserted only
+ * in useSettingsStore.test.ts); drop it if that stays true.
  */
 export function applyTextScale(scale: UiTextScale) {
   const root = document.documentElement;
@@ -1587,10 +1593,18 @@ function coerceSettings(
   // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
   // factor is rejected by the webview and would leave the UI unzoomable.
   out.uiZoom = normalizeZoom(Number(out.uiZoom));
-  // Spacing (#457-era rename). A stored `uiSpacing` wins; otherwise the
-  // pre-rename `uiDensity` is carried over, reading `parsed` rather than `out`
-  // because the old key is gone from the schema and the copy loop above never
-  // picked it up.
+  // Spacing (#457-era rename). A stored `uiSpacing` wins; otherwise, only if
+  // the payload MENTIONS the pre-rename `uiDensity` key at all, that value is
+  // migrated over (reading `parsed` rather than `out` because the old key is
+  // gone from the schema and the copy loop above never picked it up). The
+  // `"uiDensity" in parsed` half of the guard matters as much as the first:
+  // without it, a payload mentioning NEITHER key still fell through to this
+  // branch and replaced `out.uiSpacing` (already `base`'s value, from the copy
+  // loop above) with the migration's fallback — so importing a file as small
+  // as `{"activeThemeId":"dracula"}` silently reset a Spacious user to Cozy.
+  // Same shape as `mentionsMarks` in the headIndicator -> headMarks migration
+  // below: a migration only fires when the payload speaks to the setting it
+  // migrates, never on a payload that is merely silent about it.
   //
   // `compact` deliberately lands on `cozy` rather than on `compact`: a stored
   // "compact" cannot be distinguished from "never touched it" — `load()` fills
@@ -1598,7 +1612,7 @@ function coerceSettings(
   // would ship the roomier default to new installs only. Two pixels per row is
   // mild and one click reversible, and it is the same call the headIndicator
   // migration below makes one setting over.
-  if (!("uiSpacing" in parsed)) {
+  if (!("uiSpacing" in parsed) && "uiDensity" in parsed) {
     out.uiSpacing =
       parsed.uiDensity === "comfortable"
         ? "comfortable"
@@ -2238,7 +2252,7 @@ export function useRowH(basePx: number): number {
  * The user's date format (#354), for the surfaces that render a commit date.
  *
  * A hook rather than a `getState()` read so switching the format in Settings
- * re-renders the log behind it, the same way density does.
+ * re-renders the log behind it, the same way Spacing and Text size do.
  */
 export function useDateFormat(): DateFormat {
   const mode = useSettingsStore((s) => s.dateFormat);

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2201,7 +2201,7 @@ export function useSpacingStep(): number {
  * The active text scale as a FACTOR (0.92 … 1.3), for surfaces that multiply a
  * JS pixel constant by it — windowed row pitches, the SVG graph gutter, and
  * the commit row's text-sized columns. Everything a `calc()` can reach should
- * use `var(--row-scale)` instead.
+ * use the `--row-scale` CSS var instead.
  */
 export function useTextScale(): number {
   return TEXT_SCALE[normalizeTextScale(useSettingsStore((s) => s.uiTextScale))];

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2189,9 +2189,14 @@ export type { Appearance } from "./systemAppearance";
 /**
  * The active spacing preset's pixel step, for surfaces that need the NUMBER
  * rather than the `--row-step` CSS var — i.e. anything doing geometry math in
- * JS. Prefer the CSS token everywhere it works; this exists for SVG user-unit
- * drawing (see `PGGraphRow`) and for windowed lists, neither of which a
- * `calc()` can reach.
+ * JS. Prefer the CSS token everywhere it works.
+ *
+ * `useRowH` is the arithmetic owner for a windowed row's pitch (SVG user-unit
+ * drawing, windowed lists) — do not call this directly for that; it would
+ * recreate the six-copies problem `useRowH` exists to close. This hook's only
+ * two remaining callers are `useRowH` itself (this is half its input) and
+ * `useDiffRowHeight`, which uses it only as a re-read trigger for a value
+ * `--diff-row-h` computes in CSS.
  */
 export function useSpacingStep(): number {
   return SPACING_STEP_PX[normalizeSpacing(useSettingsStore((s) => s.uiSpacing))];
@@ -2199,9 +2204,11 @@ export function useSpacingStep(): number {
 
 /**
  * The active text scale as a FACTOR (0.92 … 1.3), for surfaces that multiply a
- * JS pixel constant by it — windowed row pitches, the SVG graph gutter, and
- * the commit row's text-sized columns. Everything a `calc()` can reach should
- * use `var(--row-scale)` instead.
+ * JS pixel constant by it. Prefer the CSS token (`var(--row-scale)`)
+ * everywhere it works — this hook's own two remaining callers are `useRowH`
+ * (the row-pitch arithmetic owner; do not call this directly to recompute a
+ * row height) and `useDiffRowHeight`, which uses it only as a re-read trigger
+ * for a value `--diff-row-h` computes in CSS.
  */
 export function useTextScale(): number {
   return TEXT_SCALE[normalizeTextScale(useSettingsStore((s) => s.uiTextScale))];

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -664,32 +664,43 @@ function activationPatch(
 }
 
 /**
- * Extra vertical pixels each row-ish surface adds for a given density.
+ * Extra vertical pixels each row-ish surface adds, per spacing preset.
  *
  * THE source of truth for the number. `index.css` declares `--row-step: 0px`
  * as a pre-hydration default and derives every row token from it
- * (`--row-h: calc(24px + var(--row-step))`, …); `applyDensity` overwrites the
- * var from this table, so CSS never hardcodes the comfortable delta and cannot
- * drift from the JS one. Compact is 0 by definition — comfortable is opt-in,
- * and the default layout stays pixel-identical to the pre-density one.
+ * (`--row-h: calc(24px * var(--row-scale) + var(--row-step))`, …);
+ * `applySpacing` overwrites the var from this table, so CSS never hardcodes a
+ * step and cannot drift from the JS one. Compact is 0 by definition — it is
+ * the value that reproduces the pre-density layout exactly.
  */
-export const DENSITY_STEP_PX = { compact: 0, comfortable: 4 } as const;
+export const SPACING_STEP_PX = {
+  compact: 0,
+  cozy: 2,
+  comfortable: 4,
+  spacious: 8,
+} as const;
 
-export type UiDensity = keyof typeof DENSITY_STEP_PX;
+export type UiSpacing = keyof typeof SPACING_STEP_PX;
 
 /**
- * Coerce a persisted density into a known one.
+ * Coerce a persisted spacing into a known one.
  *
- * `load()` copies any JSON value for a known key without validating it, so
- * state can hold a density this build has never heard of — a hand-edited
- * `pg-settings-v2`, or a value written by a newer build the user downgraded
- * from. That must degrade to compact: an unknown key would otherwise emit
- * `--row-step: undefinedpx`, and one invalid substitution makes every
- * `calc(Npx + var(--row-step))` compute to `auto`, collapsing the height of
- * every row in the app at once.
+ * `coerceSettings` copies any JSON value for a known key and only type-guards
+ * it against the TYPE of its default, so state can hold a string this build
+ * has never heard of — a hand-edited `pg-settings-v2`, or a value written by a
+ * newer build the user downgraded from. That must degrade to the default: an
+ * unknown key would emit `--row-step: undefinedpx`, and one invalid
+ * substitution makes every `calc(Npx + var(--row-step))` compute to `auto`,
+ * collapsing the height of every row in the app at once.
+ *
+ * `Object.hasOwn`, not `in`: `in` walks the prototype chain, so "toString"
+ * would pass the check and then index the table to a FUNCTION — the same
+ * collapse, reached by a value that looked validated.
  */
-function normalizeDensity(density: UiDensity): UiDensity {
-  return density in DENSITY_STEP_PX ? density : "compact";
+function normalizeSpacing(spacing: unknown): UiSpacing {
+  return typeof spacing === "string" && Object.hasOwn(SPACING_STEP_PX, spacing)
+    ? (spacing as UiSpacing)
+    : DEFAULTS.uiSpacing;
 }
 
 /**
@@ -713,17 +724,17 @@ export function isValidDiffToolName(name: string): boolean {
 }
 
 /**
- * Apply UI density by writing the row-step slot to CSS vars on :root.
+ * Apply the spacing preset by writing the row-step slot to CSS vars on :root.
  *
- * `data-density` is also set — a reserved hook for any future density rule
- * that isn't a simple pixel delta. Nothing reads it today (it's asserted only
- * in useSettingsStore.test.ts); drop it if that stays true.
+ * `data-spacing` is also set — a reserved hook for any future rule that isn't
+ * a simple pixel delta. Nothing reads it today (it's asserted only in
+ * useSettingsStore.test.ts); drop it if that stays true.
  */
-export function applyDensity(density: UiDensity) {
+export function applySpacing(spacing: UiSpacing) {
   const root = document.documentElement;
-  const d = normalizeDensity(density);
-  root.style.setProperty("--row-step", `${DENSITY_STEP_PX[d]}px`);
-  root.dataset.density = d;
+  const s = normalizeSpacing(spacing);
+  root.style.setProperty("--row-step", `${SPACING_STEP_PX[s]}px`);
+  root.dataset.spacing = s;
 }
 
 // ─── HEAD ("you are here") indicator ─────────────────────────────────────────
@@ -832,7 +843,11 @@ interface PersistedState {
   /** Which theme to apply and on whose say-so (#236). See ThemePreference. */
   themePreference: ThemePreference;
   customThemes: ThemeDef[];
-  uiDensity: "compact" | "comfortable";
+  /**
+   * How much breathing room every list row gets (`--row-step`). Replaces the
+   * binary `uiDensity`; `coerceSettings` migrates the old key.
+   */
+  uiSpacing: UiSpacing;
   /**
    * How a commit date is written wherever one is shown (#354) — relative
    * ("3w ago"), the absolute stamp, or both. The hover tooltip carries the
@@ -1091,7 +1106,7 @@ const DEFAULTS: PersistedState = {
   activeThemeId: "dark-cool",
   themePreference: { ...DEFAULT_THEME_PREFERENCE },
   customThemes: [],
-  uiDensity: "compact",
+  uiSpacing: "cozy",
   dateFormat: "relative",
   uiZoom: 1,
   headMarks: ["bar", "tint", "ring"],
@@ -1452,9 +1467,9 @@ function coerceSettings(
 ): CoercedSettings {
   const known = new Set<string>(Object.keys(DEFAULTS));
   const ignored = Object.keys(parsed).filter(
-    // `headIndicator` left the schema but the migration below still reads it,
-    // so it is honoured rather than ignored.
-    (k) => !known.has(k) && k !== "headIndicator",
+    // `headIndicator` and `uiDensity` left the schema but the migrations below
+    // still read them, so they are honoured rather than ignored.
+    (k) => !known.has(k) && k !== "headIndicator" && k !== "uiDensity",
   );
 
   // Only pick keys that still exist in the schema, so settings removed in
@@ -1504,10 +1519,26 @@ function coerceSettings(
   // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
   // factor is rejected by the webview and would leave the UI unzoomable.
   out.uiZoom = normalizeZoom(Number(out.uiZoom));
-  // An unrecognized density would emit `--row-step: undefinedpx`, and an
-  // invalid substitution makes every `calc(Npx + var(--row-step))` compute to
-  // `auto` — collapsing the height of every row in the app at once.
-  out.uiDensity = normalizeDensity(out.uiDensity);
+  // Spacing (#457-era rename). A stored `uiSpacing` wins; otherwise the
+  // pre-rename `uiDensity` is carried over, reading `parsed` rather than `out`
+  // because the old key is gone from the schema and the copy loop above never
+  // picked it up.
+  //
+  // `compact` deliberately lands on `cozy` rather than on `compact`: a stored
+  // "compact" cannot be distinguished from "never touched it" — `load()` fills
+  // missing keys from DEFAULTS and writes the result back — so preserving it
+  // would ship the roomier default to new installs only. Two pixels per row is
+  // mild and one click reversible, and it is the same call the headIndicator
+  // migration below makes one setting over.
+  if (!("uiSpacing" in parsed)) {
+    out.uiSpacing =
+      parsed.uiDensity === "comfortable"
+        ? "comfortable"
+        : parsed.uiDensity === "compact"
+          ? "cozy"
+          : DEFAULTS.uiSpacing;
+  }
+  out.uiSpacing = normalizeSpacing(out.uiSpacing);
   // Same failure one column over: the date format picks the Date column's
   // WIDTH as well as its text, so an unknown mode would emit `undefinedpx` in
   // the row grid and collapse the column on every row at once.
@@ -2000,7 +2031,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     // Everything with an effect outside the store has to be re-applied, or the
     // import lands in state and not on screen.
     applyTheme(findTheme(state, state.activeThemeId) ?? BUILTIN_THEMES[0]);
-    applyDensity(state.uiDensity);
+    applySpacing(state.uiSpacing);
     applyZoom(state.uiZoom);
     return {
       changed,
@@ -2028,8 +2059,8 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       applyResolved(get());
     }
     persist(snapshot(get()));
-    if (key === "uiDensity") {
-      applyDensity(get().uiDensity);
+    if (key === "uiSpacing") {
+      applySpacing(get().uiSpacing);
     }
     if (key === "uiZoom") {
       applyZoom(get().uiZoom);
@@ -2044,7 +2075,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     set({ ...DEFAULTS });
     persist(DEFAULTS);
     applyTheme(BUILTIN_THEMES[0]);
-    applyDensity(DEFAULTS.uiDensity);
+    applySpacing(DEFAULTS.uiSpacing);
     applyZoom(DEFAULTS.uiZoom);
   },
 }));
@@ -2055,7 +2086,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   const s = useSettingsStore.getState();
   const active = findTheme(s, s.activeThemeId) ?? BUILTIN_THEMES[0];
   applyTheme(active);
-  applyDensity(s.uiDensity);
+  applySpacing(s.uiSpacing);
   applyZoom(s.uiZoom);
 }
 
@@ -2081,13 +2112,14 @@ export function startSystemAppearanceWatch(): () => void {
 export type { Appearance } from "./systemAppearance";
 
 /**
- * The active density's pixel step, for surfaces that need the NUMBER rather
- * than the `--row-step` CSS var — i.e. anything doing geometry math in JS.
- * Prefer the CSS token everywhere it works; this exists for SVG user-unit
- * drawing (see `PGGraphRow`), which a `calc()` cannot reach.
+ * The active spacing preset's pixel step, for surfaces that need the NUMBER
+ * rather than the `--row-step` CSS var — i.e. anything doing geometry math in
+ * JS. Prefer the CSS token everywhere it works; this exists for SVG user-unit
+ * drawing (see `PGGraphRow`) and for windowed lists, neither of which a
+ * `calc()` can reach.
  */
-export function useDensityStep(): number {
-  return DENSITY_STEP_PX[normalizeDensity(useSettingsStore((s) => s.uiDensity))];
+export function useSpacingStep(): number {
+  return SPACING_STEP_PX[normalizeSpacing(useSettingsStore((s) => s.uiSpacing))];
 }
 
 /**

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2208,6 +2208,26 @@ export function useTextScale(): number {
 }
 
 /**
+ * A row's height in px — the JS twin of
+ * `calc(<base>px * var(--row-scale) + var(--row-step))`.
+ *
+ * One owner rather than the expression repeated at each windowed list, because
+ * a window that computes its pitch differently from the rows it measures is
+ * the #70 desync, and six copies is six chances to write it differently. The
+ * base is MULTIPLIED and the step ADDED, for the reason `index.css` gives:
+ * the step is already the user's own number of pixels, the base is what has to
+ * hold the text.
+ *
+ * Rounded to one decimal, matching `applyTextScale`'s own ramp precision:
+ * `basePx * scale` lands on an IEEE754 repeater for ordinary inputs (26 * 1.3
+ * = 33.800000000000004), and an unrounded value would disagree with the CSS
+ * pitch by that same sub-pixel remainder instead of matching it exactly.
+ */
+export function useRowH(basePx: number): number {
+  return Math.round((basePx * useTextScale() + useSpacingStep()) * 10) / 10;
+}
+
+/**
  * The user's date format (#354), for the surfaces that render a commit date.
  *
  * A hook rather than a `getState()` read so switching the format in Settings

--- a/src/index.css
+++ b/src/index.css
@@ -173,8 +173,8 @@
 
   /* ===== DENSITY =====
    * One knob: --row-step, the extra vertical pixels a row spends in
-   * "comfortable" mode. applyDensity() (features/settings/useSettingsStore.ts)
-   * overwrites it on :root from DENSITY_STEP_PX — THE source of truth for the
+   * "comfortable" mode. applySpacing() (features/settings/useSettingsStore.ts)
+   * overwrites it on :root from SPACING_STEP_PX — THE source of truth for the
    * number — so this declaration is only the pre-hydration default.
    *
    * Row surfaces opt in with `calc(<their base>px + var(--row-step))`, or
@@ -190,7 +190,7 @@
    * action strip all read as non-participants.
    *
    * One surface can't use the token: PGGraphRow draws in SVG user units, so
-   * PGCommitRow feeds it the number via useDensityStep(). */
+   * PGCommitRow feeds it the number via useSpacingStep(). */
   --row-step: 0px;
   --row-h: calc(24px + var(--row-step));
 

--- a/src/index.css
+++ b/src/index.css
@@ -171,28 +171,45 @@
 
   --ring: 0 0 0 2px oklch(0.72 0.15 235 / 0.5);
 
-  /* ===== DENSITY =====
-   * One knob: --row-step, the extra vertical pixels a row spends in
-   * "comfortable" mode. applySpacing() (features/settings/useSettingsStore.ts)
-   * overwrites it on :root from SPACING_STEP_PX — THE source of truth for the
-   * number — so this declaration is only the pre-hydration default.
+  /* ===== ROW GEOMETRY: SPACING + TEXT SIZE =====
+   * Two knobs, written from JS (features/settings/useSettingsStore.ts), which
+   * is THE source of truth for both numbers — these declarations are only the
+   * pre-hydration defaults.
    *
-   * Row surfaces opt in with `calc(<their base>px + var(--row-step))`, or
-   * `calc(<base>px + var(--row-step) / 2)` for vertical padding (top+bottom
-   * each take half). Keeping each surface's own base inline means compact
-   * (step 0) renders pixel-identically to the pre-density layout, and
-   * `grep -rn 'var(--row-step)' src/` lists every density-aware surface —
-   * EXCEPT the Settings panel, which takes the step from one shared helper
+   *   --row-step   the user's Spacing preset, in whole extra pixels per row
+   *                (applySpacing, from SPACING_STEP_PX)
+   *   --row-scale  the user's Text size preset, unitless (applyTextScale,
+   *                from TEXT_SCALE) — the same factor the --fs-* ramp took
+   *
+   * Row surfaces opt into BOTH:
+   *
+   *   calc(<base>px * var(--row-scale) + var(--row-step))
+   *   calc(<base>px * var(--row-scale) + var(--row-step) / 2)   for padding,
+   *                                    since top and bottom each take half
+   *
+   * The base is multiplied and the step is added, because the step is already
+   * the user's own number of pixels while the base is what has to HOLD the
+   * text — every row surface sets `height`, not `min-height`, so a base that
+   * did not grow with the type would clip it.
+   *
+   * Keeping each surface's own base inline means compact at x1 renders
+   * pixel-identically to the pre-density layout, and
+   * `grep -rn 'var(--row-step)' src/` lists every participating surface —
+   * EXCEPT the Settings panel, which takes both from one shared helper
    * (`densityPadding()` / `SETTINGS_ROW_PADDING` in features/settings/layout/
    * SettingsCard.tsx) so its row helpers cannot drift apart on height. Add
    * `-e densityPadding -e SETTINGS_ROW_PADDING` to that grep to see them, or
    * the Settings rows, the forge account rows and the Appearance page's theme
    * action strip all read as non-participants.
    *
-   * One surface can't use the token: PGGraphRow draws in SVG user units, so
-   * PGCommitRow feeds it the number via useSpacingStep(). */
+   * `test/uiScale.test.ts` fails the build for a surface that takes one var
+   * without the other.
+   *
+   * One surface can't use either token: PGGraphRow draws in SVG user units, so
+   * PGCommitRow feeds it the numbers via useSpacingStep() + useTextScale(). */
   --row-step: 0px;
-  --row-h: calc(24px + var(--row-step));
+  --row-scale: 1;
+  --row-h: calc(24px * var(--row-scale) + var(--row-step));
 
   /* transitions */
   --t-fast: 80ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -206,7 +206,8 @@
    * without the other.
    *
    * One surface can't use either token: PGGraphRow draws in SVG user units, so
-   * PGCommitRow feeds it the numbers via useSpacingStep() + useTextScale(). */
+   * PGCommitRow feeds it the number from useRowH() — the JS twin of this
+   * calc(), so the two cannot drift apart. */
   --row-step: 0px;
   --row-scale: 1;
   --row-h: calc(24px * var(--row-scale) + var(--row-step));

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -1,7 +1,8 @@
 // Flat row model for a file diff, plus an exact variable-height window.
 //
-// A diff mixes two row heights — a fold separator is density-aware chrome, a code
-// row is --fs-12 * --lh-code — so the fixed-pitch useWindowedList does not fit.
+// A diff mixes two row heights — a fold separator is chrome that follows both
+// UI scales, a code row is --fs-12 * --lh-code — so the fixed-pitch
+// useWindowedList does not fit.
 // Nothing needs measuring though: both heights are KNOWN, so prefix sums give an
 // exact window with no DOM reads and no estimation.
 //
@@ -247,7 +248,7 @@ function gapRows(o: {
 export interface FlattenDiffOptions {
   /** Code-row pitch, from `--diff-row-h`. */
   rowH: number;
-  /** Fold-separator height. Chrome, so density-aware — see the surfaces. */
+  /** Fold-separator height. Chrome, so it follows both UI scales — see the surfaces. */
   foldH: number;
   syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
   /**
@@ -275,10 +276,11 @@ export interface FlattenDiffOptions {
  * anchor index, cached by the hunks ARRAY's identity.
  *
  * None of it depends on syntax, row heights, or gap mode — yet flattenDiffRows
- * is re-run for every one of those (tokens arriving per side, a gap expanded, a
- * density change), and the word diff's LCS is by far the most expensive step of
- * the flatten. One diff object is flattened several times over its life; its
- * hunks array never changes identity, so this computes the invariant part once.
+ * is re-run for every one of those (tokens arriving per side, a gap expanded,
+ * a Spacing or Text size change), and the word diff's LCS is by far the most
+ * expensive step of the flatten. One diff object is flattened several times
+ * over its life; its hunks array never changes identity, so this computes the
+ * invariant part once.
  * Weak, so a superseded diff's lines go with it.
  */
 const baseLinesCache = new WeakMap<

--- a/src/lib/useDiffRowHeight.ts
+++ b/src/lib/useDiffRowHeight.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { useDensityStep } from "@/features/settings/useSettingsStore";
+import { useSpacingStep } from "@/features/settings/useSettingsStore";
 
 /**
  * Used when --diff-row-h cannot be resolved to px — notably jsdom, which does not
@@ -27,7 +27,7 @@ export function readDiffRowHeight(): number {
  * geometry-adjacent tokens.
  */
 export function useDiffRowHeight(): number {
-  const step = useDensityStep();
+  const step = useSpacingStep();
   const [h, setH] = React.useState(() => readDiffRowHeight());
   React.useEffect(() => {
     setH(readDiffRowHeight());

--- a/src/lib/useDiffRowHeight.ts
+++ b/src/lib/useDiffRowHeight.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSpacingStep } from "@/features/settings/useSettingsStore";
+import { useSpacingStep, useTextScale } from "@/features/settings/useSettingsStore";
 
 /**
  * Used when --diff-row-h cannot be resolved to px — notably jsdom, which does not
@@ -23,14 +23,17 @@ export function readDiffRowHeight(): number {
  * literal in TypeScript would already be wrong and would desync the window from
  * the rows it is measuring (the #70 lesson).
  *
- * Re-read when density changes, because that is when the theme layer rewrites
- * geometry-adjacent tokens.
+ * Re-read when either UI scale changes. The TEXT scale is the one that
+ * actually moves this value — `--diff-row-h` is derived from `--fs-12` — and
+ * spacing is kept as a dependency because that is when the theme layer
+ * rewrites geometry-adjacent tokens.
  */
 export function useDiffRowHeight(): number {
   const step = useSpacingStep();
+  const scale = useTextScale();
   const [h, setH] = React.useState(() => readDiffRowHeight());
   React.useEffect(() => {
     setH(readDiffRowHeight());
-  }, [step]);
+  }, [step, scale]);
   return h;
 }

--- a/src/lib/useDiffRowHeight.ts
+++ b/src/lib/useDiffRowHeight.ts
@@ -24,9 +24,13 @@ export function readDiffRowHeight(): number {
  * the rows it is measuring (the #70 lesson).
  *
  * Re-read when either UI scale changes. The TEXT scale is the one that
- * actually moves this value — `--diff-row-h` is derived from `--fs-12` — and
- * spacing is kept as a dependency because that is when the theme layer
- * rewrites geometry-adjacent tokens.
+ * actually moves this value — `--diff-row-h` is derived from `--fs-12` —
+ * spacing never touches it. The spacing dependency is kept anyway as cheap
+ * insurance: re-reading a CSS var costs nothing next to the render it is
+ * already part of, and it means this hook does not need to be revisited if
+ * `--diff-row-h`'s formula ever grows a `--row-step` term. (It is NOT because
+ * `applyTheme` rewrites geometry tokens — it writes colour only, per
+ * `useSettingsStore.ts`'s `applyTheme`.)
  */
 export function useDiffRowHeight(): number {
   const step = useSpacingStep();

--- a/src/lib/useWindowedList.ts
+++ b/src/lib/useWindowedList.ts
@@ -4,8 +4,8 @@
 // the same helper rather than growing a second implementation.
 //
 // Row pitch is always passed in by the caller — History derives it from
-// COMMIT_ROW_BASE_H + useSpacingStep(). A literal here would silently desync
-// the window from the rows at any non-compact density (#70).
+// useRowH(COMMIT_ROW_BASE_H). A literal here would silently desync the window
+// from the rows at any preset but the defaults (#70).
 import React from "react";
 
 export interface WindowRange {

--- a/src/lib/useWindowedList.ts
+++ b/src/lib/useWindowedList.ts
@@ -4,7 +4,7 @@
 // the same helper rather than growing a second implementation.
 //
 // Row pitch is always passed in by the caller — History derives it from
-// COMMIT_ROW_BASE_H + useDensityStep(). A literal here would silently desync
+// COMMIT_ROW_BASE_H + useSpacingStep(). A literal here would silently desync
 // the window from the rows at any non-compact density (#70).
 import React from "react";
 

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -623,7 +623,7 @@ export function BranchesScreen() {
               style={{
                 display: "grid",
                 gridTemplateColumns: gridTemplate,
-                height: "calc(24px + var(--row-step))",
+                height: "calc(24px * var(--row-scale) + var(--row-step))",
                 background: "var(--bg-2)",
                 borderBottom: "1px solid var(--border-0)",
                 alignItems: "center",
@@ -706,7 +706,7 @@ export function BranchesScreen() {
                       display: "grid",
                       gridTemplateColumns: gridTemplate,
                       alignItems: "center",
-                      height: "calc(28px + var(--row-step))",
+                      height: "calc(28px * var(--row-scale) + var(--row-step))",
                       background: selected
                         ? undefined
                         : i % 2
@@ -821,7 +821,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: "calc(28px + var(--row-step))",
+                  height: "calc(28px * var(--row-scale) + var(--row-step))",
                   background:
                     selection?.kind === "branch" && selection.name === b.name
                       ? undefined
@@ -978,7 +978,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: "calc(28px + var(--row-step))",
+                  height: "calc(28px * var(--row-scale) + var(--row-step))",
                   fontFamily: "var(--font-mono)",
                   fontSize: "var(--fs-12)",
                   borderBottom: "1px solid oklch(0.22 0.008 260 / 0.3)",
@@ -1070,7 +1070,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: "calc(28px + var(--row-step))",
+                  height: "calc(28px * var(--row-scale) + var(--row-step))",
                   fontFamily: "var(--font-mono)",
                   fontSize: "var(--fs-12)",
                   borderBottom: "1px solid oklch(0.22 0.008 260 / 0.3)",

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/features/commits/message";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useSpacingStep, useSettingsStore } from "@/features/settings/useSettingsStore";
 import {
   PGPane,
   FocusableScroll,
@@ -640,7 +640,7 @@ export function CommitPanelScreen() {
   // No wrap toggle in this pane, so rows are always fixed-pitch and windowing is
   // always on. Row heights are known, so the window needs no measurement.
   const rowH = useDiffRowHeight();
-  const foldH = 22 + useDensityStep();
+  const foldH = 22 + useSpacingStep();
   // Chunked mode only: which folded runs the reader asked to see. Took the place
   // of the per-hunk `collapsed` set, which #157 retired.
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/features/commits/message";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useSpacingStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useRowH, useSettingsStore } from "@/features/settings/useSettingsStore";
 import {
   PGPane,
   FocusableScroll,
@@ -640,7 +640,7 @@ export function CommitPanelScreen() {
   // No wrap toggle in this pane, so rows are always fixed-pitch and windowing is
   // always on. Row heights are known, so the window needs no measurement.
   const rowH = useDiffRowHeight();
-  const foldH = 22 + useSpacingStep();
+  const foldH = useRowH(22);
   // Chunked mode only: which folded runs the reader asked to see. Took the place
   // of the per-hunk `collapsed` set, which #157 retired.
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -63,7 +63,7 @@ function CompareCommitRow({ commit }: { commit: CommitInfo }) {
         alignItems: "center",
         gap: 8,
         // Density-aware (#70): the Settings toggle must reach this surface.
-        height: "calc(22px + var(--row-step))",
+        height: "calc(22px * var(--row-scale) + var(--row-step))",
         padding: "0 10px",
         fontFamily: "var(--font-mono)",
         fontSize: "var(--fs-12)",

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -62,7 +62,8 @@ function CompareCommitRow({ commit }: { commit: CommitInfo }) {
         display: "flex",
         alignItems: "center",
         gap: 8,
-        // Density-aware (#70): the Settings toggle must reach this surface.
+        // Follows both UI scales (#70): the Settings Spacing and Text size
+        // controls must both reach this surface.
         height: "calc(22px * var(--row-scale) + var(--row-step))",
         padding: "0 10px",
         fontFamily: "var(--font-mono)",

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -60,7 +60,7 @@ import { MinimapGutter } from "@/features/diff/DiffMinimap";
 import { DiffFindBar } from "@/features/diff/DiffFindBar";
 import { useDiffFind } from "@/features/diff/useDiffFind";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
-import { useSpacingStep } from "@/features/settings/useSettingsStore";
+import { useRowH } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
 import {
   PGPane,
@@ -236,7 +236,7 @@ export function DiffViewerScreen() {
 
   // ── Windowed rows ────────────────────────────────────────────────────────
   const rowH = useDiffRowHeight();
-  const foldH = 22 + useSpacingStep();
+  const foldH = useRowH(22);
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(selectedPath);
 
   const { gaps, text: diffText } = useDiffGaps(syntax);

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -60,7 +60,7 @@ import { MinimapGutter } from "@/features/diff/DiffMinimap";
 import { DiffFindBar } from "@/features/diff/DiffFindBar";
 import { useDiffFind } from "@/features/diff/useDiffFind";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
-import { useDensityStep } from "@/features/settings/useSettingsStore";
+import { useSpacingStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
 import {
   PGPane,
@@ -236,7 +236,7 @@ export function DiffViewerScreen() {
 
   // ── Windowed rows ────────────────────────────────────────────────────────
   const rowH = useDiffRowHeight();
-  const foldH = 22 + useDensityStep();
+  const foldH = 22 + useSpacingStep();
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(selectedPath);
 
   const { gaps, text: diffText } = useDiffGaps(syntax);

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -568,7 +568,7 @@ export function DiffViewerScreen() {
                 alignItems: "center",
                 gap: 6,
                 padding: "0 10px",
-                height: "calc(24px + var(--row-step))",
+                height: "calc(24px * var(--row-scale) + var(--row-step))",
                 fontFamily: "var(--font-mono)",
                 fontSize: "var(--fs-12)",
                 cursor: "pointer",

--- a/src/screens/FileHistory.tsx
+++ b/src/screens/FileHistory.tsx
@@ -85,7 +85,7 @@ export function FileHistoryScreen() {
             style={{
               display: "flex",
               gap: 10,
-              padding: "calc(6px + var(--row-step) / 2) 12px",
+              padding: "calc(6px * var(--row-scale) + var(--row-step) / 2) 12px",
               borderBottom: "1px solid var(--border-0)",
               fontFamily: "var(--font-mono)",
               fontSize: "var(--fs-12)",

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -48,7 +48,7 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import {
   useDateColumnWidth,
   useDateFormat,
-  useSpacingStep,
+  useRowH,
   useSettingsStore,
 } from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
@@ -313,9 +313,9 @@ export function HistoryScreen() {
     [visible, rawRows],
   );
 
-  // Row pitch MUST come from the density token, not a literal — PGGraphRow
-  // draws in SVG user units and the window steps by this same number (#70).
-  const rowH = COMMIT_ROW_BASE_H + useSpacingStep();
+  // Row pitch MUST come from useRowH, not a literal — PGGraphRow draws in SVG
+  // user units and the window steps by this same number (#70).
+  const rowH = useRowH(COMMIT_ROW_BASE_H);
   const win = useWindowedList({ count: visible.length, rowHeight: rowH });
 
   // Fetch the next page as the window reaches the end of the loaded list.

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -865,7 +865,7 @@ export function HistoryScreen() {
         style={{
           display: "grid",
           gridTemplateColumns: commitRowGrid(graphW, dateW),
-          height: "calc(24px + var(--row-step))",
+          height: "calc(24px * var(--row-scale) + var(--row-step))",
           background: "var(--bg-2)",
           borderBottom: "1px solid var(--border-0)",
           fontFamily: "var(--font-mono)",

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -48,7 +48,7 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import {
   useDateColumnWidth,
   useDateFormat,
-  useDensityStep,
+  useSpacingStep,
   useSettingsStore,
 } from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
@@ -315,7 +315,7 @@ export function HistoryScreen() {
 
   // Row pitch MUST come from the density token, not a literal — PGGraphRow
   // draws in SVG user units and the window steps by this same number (#70).
-  const rowH = COMMIT_ROW_BASE_H + useDensityStep();
+  const rowH = COMMIT_ROW_BASE_H + useSpacingStep();
   const win = useWindowedList({ count: visible.length, rowHeight: rowH });
 
   // Fetch the next page as the window reaches the end of the loaded list.

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -13,7 +13,8 @@ import {
   PGSkeleton,
   PGToolbar,
   COL_PAD,
-  COMMIT_LIST_MIN_W,
+  colPad,
+  commitListMinW,
   commitMenuItems,
   commitMultiMenuItems,
   COMMIT_ROW_BASE_H,
@@ -50,6 +51,7 @@ import {
   useDateFormat,
   useRowH,
   useSettingsStore,
+  useTextScale,
 } from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
@@ -122,6 +124,13 @@ const DETAIL_DIFF_MIN_W = 320;
  * `SUBJECT_MIN_W`). Clipping alone still let "AUTHOR" run up against "DATE";
  * the padding is what a caption truncates to clear, exactly as a long author
  * name does one row below.
+ *
+ * `paddingRight` here is the ×1 default only — this is a MODULE-LEVEL constant
+ * and cannot call `useTextScale()`, so every usage site below spreads it and
+ * overrides `paddingRight` with `colPad(textScale)`. A spread that skips the
+ * override is how "AUTHORDATE" comes back: the row's own padding scales, the
+ * header's does not, and the caption runs into the one beside it exactly as
+ * before `COL_PAD` existed.
  */
 const HEADER_LABEL: React.CSSProperties = {
   overflow: "hidden",
@@ -131,6 +140,11 @@ const HEADER_LABEL: React.CSSProperties = {
 };
 
 export function HistoryScreen() {
+  // Read once at the top: it feeds both the pane-size floor below
+  // (`commitListMinW`) and the grid template + header padding further down,
+  // and every reader has to agree on the same number or the header drifts
+  // from the rows under it.
+  const textScale = useTextScale();
   const commits = useRepoStore((s) => s.commits);
   const searchResults = useRepoStore((s) => s.searchResults);
   const searching = useRepoStore((s) => s.searching);
@@ -202,7 +216,7 @@ export function HistoryScreen() {
     axis: "width",
     container: layout,
     min: 280,
-    siblingMin: COMMIT_LIST_MIN_W,
+    siblingMin: commitListMinW(textScale),
     storageKey: "pg-history-detail-w",
   });
   const repo = useRepoStore((s) => s.current);
@@ -864,7 +878,7 @@ export function HistoryScreen() {
         data-testid="commit-header"
         style={{
           display: "grid",
-          gridTemplateColumns: commitRowGrid(graphW, dateW),
+          gridTemplateColumns: commitRowGrid(graphW, dateW, textScale),
           height: "calc(24px * var(--row-scale) + var(--row-step))",
           background: "var(--bg-2)",
           borderBottom: "1px solid var(--border-0)",
@@ -880,13 +894,15 @@ export function HistoryScreen() {
             with SHA. The count of lanes that did not fit still belongs here,
             in text: the gutter is a decorative graphic, and Phase 3 (G8)
             marks it aria-hidden, so a fade alone would state this nowhere. */}
-        <span style={{ ...HEADER_LABEL, paddingLeft: 12 }}>
+        <span
+          style={{ ...HEADER_LABEL, paddingLeft: 12, paddingRight: colPad(textScale) }}
+        >
           {hiddenLanes > 0 ? `+${hiddenLanes}` : ""}
         </span>
-        <span style={HEADER_LABEL}>SHA</span>
-        <span style={HEADER_LABEL}>SUBJECT</span>
-        <span style={HEADER_LABEL}>AUTHOR</span>
-        <span style={HEADER_LABEL}>DATE</span>
+        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>SHA</span>
+        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>SUBJECT</span>
+        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>AUTHOR</span>
+        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>DATE</span>
       </div>
       <FocusableScroll
         style={{ flex: 1 }}

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -12,7 +12,6 @@ import {
   PGSelect,
   PGSkeleton,
   PGToolbar,
-  COL_PAD,
   colPad,
   commitListMinW,
   commitMenuItems,
@@ -125,19 +124,22 @@ const DETAIL_DIFF_MIN_W = 320;
  * the padding is what a caption truncates to clear, exactly as a long author
  * name does one row below.
  *
- * `paddingRight` here is the ×1 default only — this is a MODULE-LEVEL constant
- * and cannot call `useTextScale()`, so every usage site below spreads it and
- * overrides `paddingRight` with `colPad(textScale)`. A spread that skips the
- * override is how "AUTHORDATE" comes back: the row's own padding scales, the
- * header's does not, and the caption runs into the one beside it exactly as
- * before `COL_PAD` existed.
+ * A FACTORY, not a module-level constant, and deliberately so: this used to be
+ * a plain object with `paddingRight: COL_PAD` as an unscaled ×1 default, and
+ * every usage site spread it and overrode `paddingRight` with
+ * `colPad(textScale)` by hand — a spread that skipped the override was how
+ * "AUTHORDATE" came back, and nothing caught a call site that forgot it (the
+ * only guard, `History.graph.test.tsx`, asserts the ×1 case, which a forgotten
+ * override also satisfies). Folding the scale into the function makes the
+ * mistake impossible to make instead of merely documented, matching every
+ * other scaled value on this branch (`colPad(scale)`, `commitListMinW(scale)`).
  */
-const HEADER_LABEL: React.CSSProperties = {
+const headerLabel = (scale: number): React.CSSProperties => ({
   overflow: "hidden",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  paddingRight: COL_PAD,
-};
+  paddingRight: colPad(scale),
+});
 
 export function HistoryScreen() {
   // Read once at the top: it feeds both the pane-size floor below
@@ -894,15 +896,13 @@ export function HistoryScreen() {
             with SHA. The count of lanes that did not fit still belongs here,
             in text: the gutter is a decorative graphic, and Phase 3 (G8)
             marks it aria-hidden, so a fade alone would state this nowhere. */}
-        <span
-          style={{ ...HEADER_LABEL, paddingLeft: 12, paddingRight: colPad(textScale) }}
-        >
+        <span style={{ ...headerLabel(textScale), paddingLeft: 12 }}>
           {hiddenLanes > 0 ? `+${hiddenLanes}` : ""}
         </span>
-        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>SHA</span>
-        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>SUBJECT</span>
-        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>AUTHOR</span>
-        <span style={{ ...HEADER_LABEL, paddingRight: colPad(textScale) }}>DATE</span>
+        <span style={headerLabel(textScale)}>SHA</span>
+        <span style={headerLabel(textScale)}>SUBJECT</span>
+        <span style={headerLabel(textScale)}>AUTHOR</span>
+        <span style={headerLabel(textScale)}>DATE</span>
       </div>
       <FocusableScroll
         style={{ flex: 1 }}

--- a/src/screens/History.virtual.test.tsx
+++ b/src/screens/History.virtual.test.tsx
@@ -8,6 +8,7 @@ import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { COMMIT_ROW_BASE_H } from "@/design";
 import type { CommitInfo } from "@/lib/types";
 
@@ -26,6 +27,11 @@ const BIG: CommitInfo[] = Array.from({ length: 300 }, (_, i) => ({
 }));
 
 beforeEach(() => {
+  // Pin the axis this file's math assumes: the default preset moved off
+  // compact (#457-era spacing rename), and this suite would otherwise measure
+  // whatever DEFAULTS.uiSpacing happens to be rather than the step-0 case it
+  // documents.
+  useSettingsStore.getState().set("uiSpacing", "compact");
   useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
   useKeymapStore.getState().setPreset("rider");
   useFocusStore.setState({

--- a/src/screens/History.virtual.test.tsx
+++ b/src/screens/History.virtual.test.tsx
@@ -27,11 +27,15 @@ const BIG: CommitInfo[] = Array.from({ length: 300 }, (_, i) => ({
 }));
 
 beforeEach(() => {
-  // Pin the axis this file's math assumes: the default preset moved off
-  // compact (#457-era spacing rename), and this suite would otherwise measure
-  // whatever DEFAULTS.uiSpacing happens to be rather than the step-0 case it
-  // documents.
+  // Pin BOTH scale axes this file's math assumes: the default spacing preset
+  // moved off compact (#457-era spacing rename), and this suite would
+  // otherwise measure whatever DEFAULTS.uiSpacing happens to be rather than
+  // the step-0 case it documents. Text scale gets the same pin, one axis
+  // over — the same fragility the spacing pin was added to close, and a
+  // DEFAULTS.uiTextScale change would silently move this suite's row-height
+  // math otherwise.
   useSettingsStore.getState().set("uiSpacing", "compact");
+  useSettingsStore.getState().set("uiTextScale", "default");
   useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
   useKeymapStore.getState().setPreset("rider");
   useFocusStore.setState({

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -32,7 +32,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import {
   useDateFormat,
-  useSpacingStep,
+  useRowH,
   useSettingsStore,
 } from "@/features/settings/useSettingsStore";
 import { useWindowedList } from "@/lib/useWindowedList";
@@ -363,7 +363,7 @@ export function RepoBrowserScreen() {
   // mounted (#61 A8). This screen owns the window because it already owns both
   // the scroll element and the flattened row order `usePaneList` indexes.
   const treeScrollRef = React.useRef<HTMLDivElement>(null);
-  const treeRowH = FILE_TREE_ROW_BASE_H + useSpacingStep();
+  const treeRowH = useRowH(FILE_TREE_ROW_BASE_H);
   const treeWin = useWindowedList({
     count: flatRows.length,
     rowHeight: treeRowH,
@@ -715,7 +715,7 @@ export function RepoBrowserScreen() {
     new: { kind: "worktree" },
   });
   const diffRowH = useDiffRowHeight();
-  const diffFoldH = 22 + useSpacingStep();
+  const diffFoldH = useRowH(22);
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(
     selectedFile?.path ?? null,
   );

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -32,7 +32,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import {
   useDateFormat,
-  useDensityStep,
+  useSpacingStep,
   useSettingsStore,
 } from "@/features/settings/useSettingsStore";
 import { useWindowedList } from "@/lib/useWindowedList";
@@ -363,7 +363,7 @@ export function RepoBrowserScreen() {
   // mounted (#61 A8). This screen owns the window because it already owns both
   // the scroll element and the flattened row order `usePaneList` indexes.
   const treeScrollRef = React.useRef<HTMLDivElement>(null);
-  const treeRowH = FILE_TREE_ROW_BASE_H + useDensityStep();
+  const treeRowH = FILE_TREE_ROW_BASE_H + useSpacingStep();
   const treeWin = useWindowedList({
     count: flatRows.length,
     rowHeight: treeRowH,
@@ -715,7 +715,7 @@ export function RepoBrowserScreen() {
     new: { kind: "worktree" },
   });
   const diffRowH = useDiffRowHeight();
-  const diffFoldH = 22 + useDensityStep();
+  const diffFoldH = 22 + useSpacingStep();
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(
     selectedFile?.path ?? null,
   );

--- a/src/screens/RepoBrowser.virtual.test.tsx
+++ b/src/screens/RepoBrowser.virtual.test.tsx
@@ -7,6 +7,7 @@ import { render, waitFor } from "@testing-library/react";
 import { RepoBrowserScreen } from "./RepoBrowser";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { mockInvoke } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { FILE_TREE_ROW_BASE_H } from "@/design";
 import type { FileStatus, RepoHandle } from "@/lib/types";
 
@@ -27,6 +28,11 @@ const MANY: FileStatus[] = Array.from({ length: 300 }, (_, i) => ({
 }));
 
 beforeEach(() => {
+  // Pin the axis this file's math assumes: the default preset moved off
+  // compact (#457-era spacing rename), and this suite would otherwise measure
+  // whatever DEFAULTS.uiSpacing happens to be rather than the step-0 case it
+  // documents.
+  useSettingsStore.getState().set("uiSpacing", "compact");
   mockInvoke("list_all_files", () => MANY);
   mockInvoke("get_diff", (args) => ({
     path: args.path as string,

--- a/src/screens/RepoBrowser.virtual.test.tsx
+++ b/src/screens/RepoBrowser.virtual.test.tsx
@@ -28,11 +28,15 @@ const MANY: FileStatus[] = Array.from({ length: 300 }, (_, i) => ({
 }));
 
 beforeEach(() => {
-  // Pin the axis this file's math assumes: the default preset moved off
-  // compact (#457-era spacing rename), and this suite would otherwise measure
-  // whatever DEFAULTS.uiSpacing happens to be rather than the step-0 case it
-  // documents.
+  // Pin BOTH scale axes this file's math assumes: the default spacing preset
+  // moved off compact (#457-era spacing rename), and this suite would
+  // otherwise measure whatever DEFAULTS.uiSpacing happens to be rather than
+  // the step-0 case it documents. Text scale gets the same pin, one axis
+  // over — the same fragility the spacing pin was added to close, and a
+  // DEFAULTS.uiTextScale change would silently move this suite's row-height
+  // math otherwise.
   useSettingsStore.getState().set("uiSpacing", "compact");
+  useSettingsStore.getState().set("uiTextScale", "default");
   mockInvoke("list_all_files", () => MANY);
   mockInvoke("get_diff", (args) => ({
     path: args.path as string,

--- a/src/screens/Settings.appearance.test.tsx
+++ b/src/screens/Settings.appearance.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { WithDialogs, resetDialogs } from "@/test/dialog";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
-import { AppearancePage } from "@/features/settings/pages/appearance";
+import { AppearancePage, meta } from "@/features/settings/pages/appearance";
 import { densityPadding } from "@/features/settings/layout/SettingsCard";
 
 /**
@@ -111,5 +111,34 @@ describe("the Appearance control", () => {
     useSettingsStore.getState().setThemeFollowMode("system");
     renderSettings();
     expect(screen.getByText(/Follows the OS — currently dark/)).toBeInTheDocument();
+  });
+});
+
+// Settings is a registry: a row absent from `meta` is a setting the search
+// cannot find, and hints are ReactNode and are NOT indexed -- which is why the
+// words a user would actually type live in `keywords`.
+describe("Appearance size controls", () => {
+  it("indexes both new size rows, and no longer the retired density row", () => {
+    const rows = meta.cards.flatMap((c) => c.rows);
+    const ids = rows.map((r) => r.id);
+    expect(ids).toContain("appearance.textSize");
+    expect(ids).toContain("appearance.spacing");
+    expect(ids).not.toContain("appearance.density");
+  });
+
+  // The vocabulary this build no longer displays still has to find its
+  // replacement: someone who learned the word "density" must land on Spacing.
+  it("keeps the retired vocabulary searchable on the spacing row", () => {
+    const row = meta.cards.flatMap((c) => c.rows).find((r) => r.id === "appearance.spacing")!;
+    for (const word of ["density", "compact", "comfortable"]) {
+      expect(row.keywords).toContain(word);
+    }
+  });
+
+  it("keeps font-size vocabulary searchable on the text row", () => {
+    const row = meta.cards.flatMap((c) => c.rows).find((r) => r.id === "appearance.textSize")!;
+    for (const word of ["font", "text", "larger"]) {
+      expect(row.keywords).toContain(word);
+    }
   });
 });

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -159,7 +159,7 @@ export function WelcomeScreen() {
                       display: "flex",
                       alignItems: "center",
                       gap: 8,
-                      padding: "calc(6px + var(--row-step) / 2) 8px",
+                      padding: "calc(6px * var(--row-scale) + var(--row-step) / 2) 8px",
                       borderRadius: "var(--r-3)",
                       cursor: loading ? "default" : "pointer",
                       fontSize: "var(--fs-12)",

--- a/test/uiScale.test.ts
+++ b/test/uiScale.test.ts
@@ -1,0 +1,55 @@
+// A row surface that opts into spacing must opt into text size too.
+//
+// Every one of these sets `height`, not `min-height`, so a base that does not
+// grow with the type CLIPS it: at the largest preset --fs-13's line box is
+// 24.5px, taller than the 22px and 24px bases in use. The two vars are one
+// decision — `--row-step` is the user's spacing preset, `--row-scale` the
+// text one — and a surface that takes the first without the second is a row
+// that gets roomier but still cuts its own text in half.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+
+function sourceFiles(): string[] {
+  return globSync("src/**/*.{ts,tsx,css}", { cwd: ROOT })
+    .filter((f) => !f.includes(".test."))
+    .map((f) => join(ROOT, f));
+}
+
+describe("--row-step and --row-scale travel together", () => {
+  it("has no row surface that scales with spacing but not with text", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        // `calc(<n>px + var(--row-step)` — a base that never grows with type.
+        if (/calc\(\s*\d+px\s*\+\s*var\(--row-step\)/.test(line)) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // The other half: a base multiplied by --row-scale but never given the
+  // user's spacing step is a row that ignores the Spacing setting entirely.
+  it("has no row surface that scales with text but not with spacing", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        if (
+          /var\(--row-scale\)/.test(line) &&
+          !/var\(--row-step\)/.test(line) &&
+          !/--row-scale:/.test(line)
+        ) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/uiScale.test.ts
+++ b/test/uiScale.test.ts
@@ -6,6 +6,19 @@
 // decision — `--row-step` is the user's spacing preset, `--row-scale` the
 // text one — and a surface that takes the first without the second is a row
 // that gets roomier but still cuts its own text in half.
+//
+// Comment lines are excluded before any regex below runs (see isCommentLine):
+// no real `calc()` call site lives inside a comment, so skipping them costs
+// zero protection, and it is what lets a docstring say `--row-scale` alone —
+// genuinely true for a text-only helper like `useTextScale()`, which never
+// touches row height — without this test reading that prose as a call site.
+//
+// One blind spot none of these regexes can see: `densityPadding()` in
+// `features/settings/layout/SettingsCard.tsx` builds its string from a
+// template literal (`` `${basePx}px` ``), so the literal `\d+px` these
+// patterns look for never appears in its source text. Its only safety net is
+// the `-e densityPadding -e SETTINGS_ROW_PADDING` grep addendum named in the
+// `index.css` row-geometry comment — this file is not exhaustive on its own.
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { globSync } from "node:fs";
@@ -19,12 +32,26 @@ function sourceFiles(): string[] {
     .map((f) => join(ROOT, f));
 }
 
+/**
+ * True for a comment-continuation line in either style this codebase uses —
+ * a `//` line comment, or a block comment's ` * ` continuation line. A prose
+ * mention of `--row-scale` or `--row-step` in a docstring is not a
+ * row-geometry call site, and matching it anyway is exactly what forced a
+ * docstring reword the first time this test existed — the fix belongs here,
+ * not in the prose.
+ */
+function isCommentLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("//") || t.startsWith("*");
+}
+
 describe("--row-step and --row-scale travel together", () => {
   it("has no row surface that scales with spacing but not with text", () => {
     const offenders: string[] = [];
     for (const file of sourceFiles()) {
       const text = readFileSync(file, "utf8");
       text.split("\n").forEach((line, i) => {
+        if (isCommentLine(line)) return;
         // `calc(<n>px + var(--row-step)` — a base that never grows with type.
         if (/calc\(\s*\d+px\s*\+\s*var\(--row-step\)/.test(line)) {
           offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
@@ -41,11 +68,35 @@ describe("--row-step and --row-scale travel together", () => {
     for (const file of sourceFiles()) {
       const text = readFileSync(file, "utf8");
       text.split("\n").forEach((line, i) => {
+        if (isCommentLine(line)) return;
         if (
           /var\(--row-scale\)/.test(line) &&
           !/var\(--row-step\)/.test(line) &&
           !/--row-scale:/.test(line)
         ) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // A third failure mode the two assertions above cannot see between them: a
+  // line multiplied TWICE (`* var(--row-scale) * var(--row-scale)`), from
+  // sweeping an already-swept call site or copy-pasting one that was already
+  // fixed. The first assertion only fires when the base is immediately
+  // followed by `+`, which a doubled multiply never is; the second only fires
+  // when `var(--row-step)` is ABSENT, and a doubled line still has it. Only
+  // counting occurrences catches a row that would grow twice as fast as every
+  // other row under the same Text size setting.
+  it("has no row surface that multiplies by --row-scale more than once", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        if (isCommentLine(line)) return;
+        const hits = line.match(/var\(--row-scale\)/g);
+        if (hits && hits.length > 1) {
           offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`);
         }
       });


### PR DESCRIPTION
Replaces the binary **UI density** setting (`compact` | `comfortable`, a 4px row-step toggle) with **two independent presets**, so a user can loosen the layout, enlarge the type, or both:

| Control | Values | Effect |
|---|---|---|
| **Text size** | Small · Default · Large · Larger | ×0.92 · ×1 · ×1.15 · ×1.3 on the whole type ramp |
| **Spacing** | Compact · Cozy · Comfortable · Spacious | +0 · +2 · +4 · +8 px per row |

The existing whole-UI **Zoom** control is untouched and stays as the third knob. The division is deliberate: Zoom scales *everything* including chrome, icons and borders; Text size scales type, the row bases that must hold it, and text-derived column widths; Spacing scales row breathing room only. Each answers a question the other two cannot, which is why all three exist.

## ⚠️ This changes the default for existing installs

**An install on `compact` migrates to `cozy` (+2px per row).** This is the one user-visible behaviour change and it is deliberate: a stored `compact` cannot be distinguished from "never touched it" — `load()` fills missing keys from `DEFAULTS` and writes the result back — so grandfathering it would ship the roomier default to new installs only, i.e. to nobody who already formed the opinion that prompted this. Two pixels per row, one click reversible. Same call the `headIndicator` → `headMarks` migration made.

`comfortable` stays `comfortable`. `uiTextScale` defaults to `default` (×1) everywhere — nobody's type changes size without asking.

**For whoever cuts the next release:** this needs a changelog line. Per `docs/dev/releasing.md` entries are written at cut time from `git log <tag>..main`, so none is added here.

## How it works

- `applySpacing` writes `--row-step`; `applyTextScale` writes all ten `--fs-*` tokens as **resolved px computed in JS** (one decimal) plus a unitless `--row-scale`. JS owns the numbers; `index.css` declares only pre-hydration defaults. Resolved px rather than `calc(13px * var(--scale))` because the latter would make `--diff-row-h` a nested `calc()` inside an unregistered custom property — exactly the case `readDiffRowHeight` already carries a fallback for.
- 26 CSS row call sites read `calc(<base>px * var(--row-scale) + var(--row-step))` — **base multiplied, step added**. The step is already the user's own pixel count and must not scale; the base is what has to hold the text. Row surfaces keep `height`, not `min-height`: several are windowed, and a row whose height the window cannot predict desyncs it (#70).
- `useRowH(base)` is the JS twin, collapsing six hand-written copies of that arithmetic into one owner.
- The commit row's text-sized columns became functions of the scale — `SHA_COL_W` is literally "seven hex digits of monospace", and truncating a sha destroys its meaning rather than shortening it. `commitListMinW` scales with the columns it is the sum of, so the Date column cannot fall off the right edge at Large.
- Migration lives in `coerceSettings`, the one function both `load()` and `importSettings` pass through.

## Guards added

`test/uiScale.test.ts` fails the build for a row surface that takes one scale var without the other, or double-multiplies. Plus: the type ramp stays strictly ascending at every preset; the smallest row base clears its own line box at every preset (the clipping guard); the column minimums still fit the narrowest pane at every preset, re-derived from `commitRowGrid`'s own emitted template rather than from the formula it checks; and both normalizers reject an inherited `Object` property, which `in` would have waved through into an `undefinedpx` collapse of every row in the app.

## Testing

- **3880 unit** tests across 377 files, **257 docs** tests, `tsc --noEmit` clean — run at the branch head after the final commit.
- **e2e `settings.e2e.ts` 15/15** in Docker, including a new case that observes the scaled ramp and a scaled row box together. jsdom cannot resolve `calc()`, so that pair is only observable in a real webview — and it is exactly what breaks if type grows while its container does not.

Running e2e also caught a real bug: both spacing cases measured their "compact" baseline off a freshly-opened repo, which stopped being true when the default moved to `cozy`. They now select Compact explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
